### PR TITLE
[26.1] Carry the landing-request destination through OIDC login

### DIFF
--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -10,7 +10,7 @@ import AdminRoutes from "@/entry/analysis/routes/admin-routes";
 import LibraryRoutes from "@/entry/analysis/routes/library-routes";
 import StorageRoutes from "@/entry/analysis/routes/storage-routes";
 import { getAppRoot } from "@/onload/loadConfig";
-import { requireAuth, requireAuthForUploadMethod } from "@/router/guards";
+import { redirectLoggedIn, requireAuth, requireAuthForUploadMethod } from "@/router/guards";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -145,14 +145,6 @@ function redirectAnon(redirect = "") {
     }
 }
 
-// redirect logged in users
-function redirectLoggedIn() {
-    const Galaxy = getGalaxyInstance();
-    if (Galaxy.user.id) {
-        return "/";
-    }
-}
-
 function redirectIf(condition, path) {
     if (condition) {
         return path;
@@ -169,13 +161,13 @@ export function getRouter(Galaxy) {
             {
                 path: "/login/start",
                 component: Login,
-                redirect: redirectLoggedIn(),
+                beforeEnter: redirectLoggedIn,
             },
             /** Registration entry route */
             {
                 path: "/register/start",
                 component: Register,
-                redirect: redirectLoggedIn(),
+                beforeEnter: redirectLoggedIn,
             },
             /** Workflow editor */
             {

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -8,9 +8,10 @@ import { ExternalIdentities } from "@/components/User/ExternalIdentities";
 import { hasSingleOidcProfile } from "@/components/User/ExternalIdentities/ExternalIDHelper";
 import AdminRoutes from "@/entry/analysis/routes/admin-routes";
 import LibraryRoutes from "@/entry/analysis/routes/library-routes";
+import LoginRoutes from "@/entry/analysis/routes/login-routes";
 import StorageRoutes from "@/entry/analysis/routes/storage-routes";
 import { getAppRoot } from "@/onload/loadConfig";
-import { redirectLoggedIn, requireAuth, requireAuthForUploadMethod } from "@/router/guards";
+import { requireAuth, requireAuthForUploadMethod } from "@/router/guards";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -109,8 +110,6 @@ import WorkflowImport from "@/components/Workflow/WorkflowImport.vue";
 import WorkflowInvocationState from "@/components/WorkflowInvocationState/WorkflowInvocationState.vue";
 import Analysis from "@/entry/analysis/modules/Analysis.vue";
 import Home from "@/entry/analysis/modules/Home.vue";
-import Login from "@/entry/analysis/modules/Login.vue";
-import Register from "@/entry/analysis/modules/Register.vue";
 import WorkflowEditorModule from "@/entry/analysis/modules/WorkflowEditor.vue";
 
 Vue.use(VueRouter);
@@ -157,18 +156,8 @@ export function getRouter(Galaxy) {
         base: getAppRoot(),
         mode: "history",
         routes: [
-            /** Login entry route */
-            {
-                path: "/login/start",
-                component: Login,
-                beforeEnter: redirectLoggedIn,
-            },
-            /** Registration entry route */
-            {
-                path: "/register/start",
-                component: Register,
-                beforeEnter: redirectLoggedIn,
-            },
+            /** Login and registration entry routes */
+            ...LoginRoutes,
             /** Workflow editor */
             {
                 path: "/workflows/edit",

--- a/client/src/entry/analysis/routes/login-routes.test.ts
+++ b/client/src/entry/analysis/routes/login-routes.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Vue from "vue";
+import VueRouter from "vue-router";
+
+import { getGalaxyInstance } from "@/app";
+
+import LoginRoutes from "./login-routes";
+
+vi.mock("@/app");
+
+Vue.use(VueRouter);
+
+const LANDING_PATH = "/tool_landings/1234-5678?public=true";
+
+function setUser(id: string | null) {
+    vi.mocked(getGalaxyInstance).mockReturnValue({ user: { id } } as ReturnType<typeof getGalaxyInstance>);
+}
+
+/** Drive the real router, so this covers the route wiring and not just the guard. */
+async function navigateTo(path: string) {
+    const router = new VueRouter({ mode: "abstract", routes: LoginRoutes });
+    // vue-router rejects the push promise when a guard redirects; currentRoute still
+    // settles on wherever the guard sent us, which is what we are asserting on.
+    await router.push(path).catch(() => undefined);
+    return router;
+}
+
+describe("login entry routes", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("renders the login page for anonymous users", async () => {
+        setUser(null);
+        const router = await navigateTo("/login/start");
+        expect(router.currentRoute.path).toEqual("/login/start");
+        // A route-level `redirect` function returning undefined would match nothing here,
+        // leaving anonymous users with a blank page instead of the login form.
+        expect(router.currentRoute.matched).toHaveLength(1);
+        expect(router.currentRoute.matched[0]?.components?.default).toBeTruthy();
+    });
+
+    it("keeps the pending destination on the route for the login form to use", async () => {
+        setUser(null);
+        const router = await navigateTo(`/login/start?redirect=${encodeURIComponent(LANDING_PATH)}`);
+        expect(router.currentRoute.path).toEqual("/login/start");
+        expect(router.currentRoute.query.redirect).toEqual(LANDING_PATH);
+    });
+
+    it("sends a logged-in user straight to the pending destination", async () => {
+        setUser("f2db41e1fa331b3e");
+        const router = await navigateTo(`/login/start?redirect=${encodeURIComponent(LANDING_PATH)}`);
+        expect(router.currentRoute.fullPath).toEqual(LANDING_PATH);
+    });
+
+    it("sends a logged-in user home when nothing is pending", async () => {
+        setUser("f2db41e1fa331b3e");
+        const router = await navigateTo("/login/start");
+        expect(router.currentRoute.path).toEqual("/");
+    });
+
+    it("refuses to bounce a logged-in user off this Galaxy", async () => {
+        setUser("f2db41e1fa331b3e");
+        const router = await navigateTo("/login/start?redirect=https%3A%2F%2Fevil.example.com%2F");
+        expect(router.currentRoute.path).toEqual("/");
+    });
+
+    it("applies the same treatment to the registration entry route", async () => {
+        setUser("f2db41e1fa331b3e");
+        const router = await navigateTo(`/register/start?redirect=${encodeURIComponent(LANDING_PATH)}`);
+        expect(router.currentRoute.fullPath).toEqual(LANDING_PATH);
+    });
+
+    it("renders the registration page for anonymous users", async () => {
+        setUser(null);
+        const router = await navigateTo("/register/start");
+        expect(router.currentRoute.path).toEqual("/register/start");
+        expect(router.currentRoute.matched).toHaveLength(1);
+    });
+});

--- a/client/src/entry/analysis/routes/login-routes.test.ts
+++ b/client/src/entry/analysis/routes/login-routes.test.ts
@@ -72,6 +72,8 @@ describe("login entry routes", () => {
     });
 
     it("renders the registration page for anonymous users", async () => {
+        // Only reachable this way when require_login is off -- with it on, the server
+        // gate redirects first, because /register/start is not in its allowed paths.
         setUser(null);
         const router = await navigateTo("/register/start");
         expect(router.currentRoute.path).toEqual("/register/start");

--- a/client/src/entry/analysis/routes/login-routes.ts
+++ b/client/src/entry/analysis/routes/login-routes.ts
@@ -1,0 +1,24 @@
+import { redirectLoggedIn } from "@/router/guards";
+
+import Login from "@/entry/analysis/modules/Login.vue";
+import Register from "@/entry/analysis/modules/Register.vue";
+
+/**
+ * Entry routes for logging in and registering.
+ *
+ * These use a `beforeEnter` guard rather than a route-level `redirect`, so that a
+ * pending `redirect` query param is honored instead of dropped -- see the guard for why
+ * a `redirect` function would not work here.
+ */
+export default [
+    {
+        path: "/login/start",
+        component: Login,
+        beforeEnter: redirectLoggedIn,
+    },
+    {
+        path: "/register/start",
+        component: Register,
+        beforeEnter: redirectLoggedIn,
+    },
+];

--- a/client/src/router/guards.test.ts
+++ b/client/src/router/guards.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigationGuardNext, Route } from "vue-router";
+
+import { getGalaxyInstance } from "@/app";
+
+import { redirectLoggedIn } from "./guards";
+
+vi.mock("@/app");
+
+const LANDING_PATH = "/tool_landings/1234-5678?public=true";
+
+function runGuard(query: Route["query"] = {}) {
+    const next = vi.fn();
+    redirectLoggedIn({ query } as Route, {} as Route, next as unknown as NavigationGuardNext);
+    return next;
+}
+
+function setUser(id: string | null) {
+    vi.mocked(getGalaxyInstance).mockReturnValue({ user: { id } } as ReturnType<typeof getGalaxyInstance>);
+}
+
+describe("redirectLoggedIn", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("renders the login form for anonymous users", () => {
+        setUser(null);
+        expect(runGuard()).toHaveBeenCalledWith();
+    });
+
+    it("renders the login form when there is no Galaxy user at all", () => {
+        vi.mocked(getGalaxyInstance).mockReturnValue({} as ReturnType<typeof getGalaxyInstance>);
+        expect(runGuard()).toHaveBeenCalledWith();
+    });
+
+    it("sends logged-in users home when no destination is pending", () => {
+        setUser("f2db41e1fa331b3e");
+        expect(runGuard()).toHaveBeenCalledWith("/");
+    });
+
+    it("sends logged-in users to the pending destination, query string intact", () => {
+        setUser("f2db41e1fa331b3e");
+        expect(runGuard({ redirect: LANDING_PATH })).toHaveBeenCalledWith(LANDING_PATH);
+    });
+
+    it("refuses to bounce logged-in users off this Galaxy", () => {
+        setUser("f2db41e1fa331b3e");
+        expect(runGuard({ redirect: "https://evil.example.com/" })).toHaveBeenCalledWith("/");
+        expect(runGuard({ redirect: "//evil.example.com/" })).toHaveBeenCalledWith("/");
+    });
+
+    it("does not bounce a logged-in user back to the login route", () => {
+        setUser("f2db41e1fa331b3e");
+        expect(runGuard({ redirect: "/login/start" })).toHaveBeenCalledWith("/");
+    });
+});

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -13,7 +13,9 @@ const LOGIN_ENTRY_ROUTES = ["/login/start", "/register/start"];
  * Keeps logged-in users off the login and registration entry routes.
  *
  * A pending `redirect` is honored rather than dropped, so a deep link survives the round
- * trip through login even when the user turns out to be signed in already.
+ * trip through login even when the user turns out to be signed in already. It has to be
+ * root-relative: the router applies `base` itself, so a destination that already carries
+ * the app root would end up with it twice.
  *
  * This is a navigation guard rather than a route-level `redirect`, because vue-router
  * treats a `redirect` function returning undefined as "no match" and renders nothing --

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -1,8 +1,33 @@
 import type { NavigationGuardNext, Route } from "vue-router";
 
+import { getGalaxyInstance } from "@/app";
 import type { UploadMethod } from "@/components/Panels/Upload/types";
 import { getUploadMethod } from "@/components/Panels/Upload/uploadMethodRegistry";
 import { useUserStore } from "@/stores/userStore";
+import { safeRedirectPath } from "@/utils/redirect";
+
+// Entry routes that exist to get you logged in -- never a destination to come back to.
+const LOGIN_ENTRY_ROUTES = ["/login/start", "/register/start"];
+
+/**
+ * Keeps logged-in users off the login and registration entry routes.
+ *
+ * A pending `redirect` is honored rather than dropped, so a deep link survives the round
+ * trip through login even when the user turns out to be signed in already.
+ *
+ * This is a navigation guard rather than a route-level `redirect`, because vue-router
+ * treats a `redirect` function returning undefined as "no match" and renders nothing --
+ * which would leave anonymous users staring at a blank login page.
+ */
+export function redirectLoggedIn(to: Route, _from: Route, next: NavigationGuardNext) {
+    const Galaxy = getGalaxyInstance();
+    if (!Galaxy?.user?.id) {
+        next();
+        return;
+    }
+    const redirect = safeRedirectPath(to.query.redirect);
+    next(redirect && !LOGIN_ENTRY_ROUTES.includes(redirect) ? redirect : "/");
+}
 
 async function redirectIfAnonymous(to: Route, next: NavigationGuardNext) {
     const userStore = useUserStore();

--- a/client/src/utils/redirect.test.ts
+++ b/client/src/utils/redirect.test.ts
@@ -39,6 +39,17 @@ describe("safeRedirectPath", () => {
         // browsers strip tabs and newlines, so this reaches the network as "//evil.example.com"
         expect(safeRedirectPath("/\t/evil.example.com")).toBeUndefined();
         expect(safeRedirectPath("/\n/evil.example.com")).toBeUndefined();
+        expect(safeRedirectPath(" //evil.example.com")).toBeUndefined();
+    });
+
+    it("refuses control characters outright", () => {
+        // Accepting these would hand on a value whose meaning changes when it is resolved.
+        expect(safeRedirectPath("/foo\tbar")).toBeUndefined();
+        expect(safeRedirectPath("/foo\nbar")).toBeUndefined();
+        expect(safeRedirectPath("/foo\u0000bar")).toBeUndefined();
+        expect(safeRedirectPath("/foo\u007fbar")).toBeUndefined();
+        expect(safeRedirectPath(" /histories/list")).toBeUndefined();
+        expect(safeRedirectPath("/histories/list ")).toBeUndefined();
     });
 
     it("rejects non-paths and empty values", () => {

--- a/client/src/utils/redirect.test.ts
+++ b/client/src/utils/redirect.test.ts
@@ -1,8 +1,8 @@
-import { expect, test, vi } from "vitest";
+import { describe, expect, it, test, vi } from "vitest";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
-import { withPrefix } from "./redirect";
+import { safeRedirectPath, withPrefix } from "./redirect";
 
 vi.mock("@/onload/loadConfig");
 
@@ -19,4 +19,34 @@ test("route prefix changes", async () => {
     // ensure that it can only be called once
     expect(withPrefix(withPrefix("/home"))).toEqual("/prefix/prefix/home");
     // This doesn't do what it looks like it should do?
+});
+
+describe("safeRedirectPath", () => {
+    it("accepts relative paths, query string and all", () => {
+        expect(safeRedirectPath("/")).toEqual("/");
+        expect(safeRedirectPath("/tool_landings/1234-5678?public=true")).toEqual(
+            "/tool_landings/1234-5678?public=true",
+        );
+        expect(safeRedirectPath("/histories/list#anchor")).toEqual("/histories/list#anchor");
+    });
+
+    it("rejects anything pointing off this Galaxy", () => {
+        expect(safeRedirectPath("https://evil.example.com/")).toBeUndefined();
+        expect(safeRedirectPath("http://evil.example.com/")).toBeUndefined();
+        // protocol-relative -- the browser reads these as another origin
+        expect(safeRedirectPath("//evil.example.com/")).toBeUndefined();
+        expect(safeRedirectPath("/\\evil.example.com/")).toBeUndefined();
+        // browsers strip tabs and newlines, so this reaches the network as "//evil.example.com"
+        expect(safeRedirectPath("/\t/evil.example.com")).toBeUndefined();
+        expect(safeRedirectPath("/\n/evil.example.com")).toBeUndefined();
+    });
+
+    it("rejects non-paths and empty values", () => {
+        expect(safeRedirectPath(undefined)).toBeUndefined();
+        expect(safeRedirectPath(null)).toBeUndefined();
+        expect(safeRedirectPath("")).toBeUndefined();
+        expect(safeRedirectPath("histories/list")).toBeUndefined();
+        // vue-router hands back an array when a param is repeated
+        expect(safeRedirectPath(["/histories/list"])).toBeUndefined();
+    });
 });

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -54,3 +54,27 @@ export function withPrefix(path: string) {
 function hasRoot(path: string) {
     return path.startsWith(getAppRoot());
 }
+
+// Browsers drop tabs and newlines from a URL before resolving it, so "/<TAB>/host"
+// reaches the network as the protocol-relative "//host".
+const strippedByBrowsers = /[\t\r\n]/g;
+
+/**
+ * Guards a post-login redirect target, which arrives from the query string and is
+ * therefore attacker-supplied. Anything a browser could resolve to a different origin --
+ * an absolute URL, a protocol-relative `//host`, or the backslash spelling browsers
+ * normalize to it -- is refused.
+ * @param path
+ * @returns The path if it is a relative URL that stays on this Galaxy, otherwise undefined.
+ */
+export function safeRedirectPath(path: unknown): string | undefined {
+    if (typeof path !== "string" || !path) {
+        return undefined;
+    }
+    // Validate what the browser will actually see, not what we were handed.
+    const candidate = path.replace(strippedByBrowsers, "").trim();
+    if (!candidate.startsWith("/") || candidate[1] === "/" || candidate[1] === "\\") {
+        return undefined;
+    }
+    return path;
+}

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -55,9 +55,8 @@ function hasRoot(path: string) {
     return path.startsWith(getAppRoot());
 }
 
-// Browsers drop tabs and newlines from a URL before resolving it, so "/<TAB>/host"
-// reaches the network as the protocol-relative "//host".
-const strippedByBrowsers = /[\t\r\n]/g;
+// eslint-disable-next-line no-control-regex
+const controlCharacters = /[\u0000-\u001f\u007f]/;
 
 /**
  * Guards a post-login redirect target, which arrives from the query string and is
@@ -71,9 +70,14 @@ export function safeRedirectPath(path: unknown): string | undefined {
     if (typeof path !== "string" || !path) {
         return undefined;
     }
-    // Validate what the browser will actually see, not what we were handed.
-    const candidate = path.replace(strippedByBrowsers, "").trim();
-    if (!candidate.startsWith("/") || candidate[1] === "/" || candidate[1] === "\\") {
+    // A browser drops tabs and newlines before resolving a URL, so "/<TAB>/host" would
+    // reach the network as the protocol-relative "//host". Refuse control characters
+    // outright rather than accepting a value whose meaning changes later; surrounding
+    // whitespace gets trimmed the same way.
+    if (path !== path.trim() || controlCharacters.test(path)) {
+        return undefined;
+    }
+    if (!path.startsWith("/") || path[1] === "/" || path[1] === "\\") {
         return undefined;
     }
     return path;

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1374,9 +1374,7 @@ def compare_urls(url1, url2, compare_scheme=True, compare_hostname=True, compare
     return True
 
 
-# Browsers drop tabs and newlines from a URL before resolving it, so "/<TAB>/host"
-# reaches the network as the protocol-relative "//host".
-STRIPPED_BY_BROWSERS = re.compile(r"[\t\r\n]")
+CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def is_safe_local_redirect(path: Any) -> bool:
@@ -1389,11 +1387,15 @@ def is_safe_local_redirect(path: Any) -> bool:
     """
     if not isinstance(path, str) or not path:
         return False
-    # Validate what the browser will actually see, not what we were handed.
-    candidate = STRIPPED_BY_BROWSERS.sub("", path).strip()
-    if not candidate.startswith("/"):
+    # A browser drops tabs and newlines before resolving a URL, so "/<TAB>/host" would
+    # reach the network as the protocol-relative "//host". Refuse control characters
+    # outright rather than accepting a value whose meaning changes later; surrounding
+    # whitespace gets trimmed the same way.
+    if path != path.strip() or CONTROL_CHARACTERS.search(path):
         return False
-    return candidate[1:2] not in ("/", "\\")
+    if not path.startswith("/"):
+        return False
+    return path[1:2] not in ("/", "\\")
 
 
 def read_build_sites(filename, check_builds=True):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1374,6 +1374,28 @@ def compare_urls(url1, url2, compare_scheme=True, compare_hostname=True, compare
     return True
 
 
+# Browsers drop tabs and newlines from a URL before resolving it, so "/<TAB>/host"
+# reaches the network as the protocol-relative "//host".
+STRIPPED_BY_BROWSERS = re.compile(r"[\t\r\n]")
+
+
+def is_safe_local_redirect(path: Any) -> bool:
+    """Is ``path`` a relative URL that cannot leave this server?
+
+    Post-login redirect targets arrive from the query string, so they are attacker
+    supplied. Anything a browser could resolve to a different origin -- an absolute
+    URL, a protocol-relative ``//host``, or the backslash spelling browsers normalize
+    to it -- has to be refused.
+    """
+    if not isinstance(path, str) or not path:
+        return False
+    # Validate what the browser will actually see, not what we were handed.
+    candidate = STRIPPED_BY_BROWSERS.sub("", path).strip()
+    if not candidate.startswith("/"):
+        return False
+    return candidate[1:2] not in ("/", "\\")
+
+
 def read_build_sites(filename, check_builds=True):
     """read db names to ucsc mappings from file, this file should probably be merged with the one above"""
     build_sites = []

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -14,7 +14,10 @@ from typing import (
     Any,
     Optional,
 )
-from urllib.parse import urlparse
+from urllib.parse import (
+    quote,
+    urlparse,
+)
 
 import mako.lookup
 import mako.runtime
@@ -755,9 +758,16 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 return
             # redirect to root if the path is not in the list above
             if self.request.path not in allowed_paths:
-                # path_qs, not path -- the query string is part of where the user was
-                # headed (landing requests carry "?public=true", for instance).
-                login_url = url_for("/login", redirect=self.request.path_qs)
+                # Everything downstream re-applies the app root -- url_for on the way
+                # back out of the OIDC callback, withPrefix and the client router on the
+                # way through the login page -- so hand on a root-relative destination
+                # (path_info) or a prefixed deployment ends up with the prefix twice.
+                # The query string is part of where the user was headed; landing
+                # requests carry "?public=true".
+                destination = quote(self.request.path_info)
+                if self.request.query_string:
+                    destination = f"{destination}?{self.request.query_string}"
+                login_url = url_for("/login", redirect=destination)
                 self.response.send_redirect(login_url)
 
     def __create_new_session(self, prev_galaxy_session=None, user_for_new_session=None):

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -755,7 +755,9 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 return
             # redirect to root if the path is not in the list above
             if self.request.path not in allowed_paths:
-                login_url = url_for("/login", redirect=self.request.path)
+                # path_qs, not path -- the query string is part of where the user was
+                # headed (landing requests carry "?public=true", for instance).
+                login_url = url_for("/login", redirect=self.request.path_qs)
                 self.response.send_redirect(login_url)
 
     def __create_new_session(self, prev_galaxy_session=None, user_for_new_session=None):

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -13,7 +13,10 @@ from galaxy import (
     exceptions,
     web,
 )
-from galaxy.util import url_get
+from galaxy.util import (
+    is_safe_local_redirect,
+    url_get,
+)
 from galaxy.web import url_for
 from galaxy.webapps.base.controller import BaseUIController
 
@@ -104,11 +107,14 @@ class OIDC(BaseUIController):
     def callback(self, trans, provider, idphint=None, **kwargs):
         user = trans.user.username if trans.user is not None else "anonymous"
         login_next_cookie = trans.get_cookie(name=LOGIN_NEXT_COOKIE_NAME)
-        if login_next_cookie and login_next_cookie != "None":
+        if login_next_cookie and login_next_cookie != "None" and is_safe_local_redirect(login_next_cookie):
             # This cookie can sometimes be set to a literal string 'None', which we don't want to use as a redirect.
             login_next = url_for(login_next_cookie)
         else:
-            # Fallback to default redirect if no login_next cookie is found.
+            # Fallback to default redirect if no login_next cookie is found, or if it points
+            # somewhere we refuse to send the user -- this value reaches us from the client.
+            if login_next_cookie and login_next_cookie != "None":
+                log.warning("Ignoring post-login redirect target outside of Galaxy: %s", login_next_cookie)
             login_next = url_for("/")
         if not bool(kwargs):
             log.warning(f"OIDC callback received no data for provider `{provider}` and user `{user}`")

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -14,8 +14,10 @@ from galaxy.managers.histories import HistoryManager
 from galaxy.model import HistoryDatasetAssociation
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.structured_app import StructuredApp
+from galaxy.util import is_safe_local_redirect
 from galaxy.webapps.base import controller
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
+from .authnz import LOGIN_NEXT_COOKIE_NAME
 from ..api import depends
 
 log = logging.getLogger(__name__)
@@ -64,6 +66,13 @@ class RootController(controller.BaseUIController, UsesAnnotations):
             and is_logout_redirect is False
         ):
             provider = next(iter(trans.app.config.oidc.keys()))
+            # Stash where the user was headed before handing them to the provider --
+            # the OIDC callback has no other way to recover it. Matches what the authnz
+            # controller does for the multi-provider case.
+            login_next = redirect if is_safe_local_redirect(redirect) else "/"
+            if redirect and login_next != redirect:
+                log.warning("Ignoring redirect target outside of Galaxy: %s", redirect)
+            trans.set_cookie(value=login_next, name=LOGIN_NEXT_COOKIE_NAME, age=1)
             success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
             if success:
                 return trans.response.send_redirect(redirect_uri)

--- a/test/unit/util/test_safe_local_redirect.py
+++ b/test/unit/util/test_safe_local_redirect.py
@@ -1,0 +1,59 @@
+"""Tests for ``is_safe_local_redirect``, which guards post-login redirect targets.
+
+These values reach Galaxy from a query string or a cookie, so the interesting cases are
+all the spellings of "another origin" that a browser will happily resolve.
+"""
+
+import pytest
+
+from galaxy.util import is_safe_local_redirect
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/tool_landings/1234-5678?public=true",
+        "/histories/list#anchor",
+        "/workflows/edit?id=abc&version=2",
+        # a path that merely mentions a URL in its query string is still local
+        "/authnz/cilogon/login?idphint=https://test.com",
+    ],
+)
+def test_relative_paths_are_safe(path):
+    assert is_safe_local_redirect(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "https://evil.example.com/",
+        "http://evil.example.com/",
+        "//evil.example.com/",
+        "/\\evil.example.com/",
+        "/\\\\evil.example.com/",
+        # browsers strip tabs and newlines, turning these into "//evil.example.com"
+        "/\t/evil.example.com",
+        "/\n/evil.example.com",
+        "/\r/evil.example.com",
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        # scheme-relative with leading whitespace a browser would trim
+        " //evil.example.com",
+        " /histories/list",
+        "/histories/list ",
+    ],
+)
+def test_anything_leaving_this_server_is_refused(path):
+    assert is_safe_local_redirect(path) is False
+
+
+@pytest.mark.parametrize("path", ["/foo\tbar", "/foo\nbar", "/foo\rbar", "/foo\x00bar", "/foo\x7fbar"])
+def test_control_characters_are_refused_outright(path):
+    """Accepting these would store a value that only fails later, when it is redirected to."""
+    assert is_safe_local_redirect(path) is False
+
+
+@pytest.mark.parametrize("path", [None, "", "histories/list", 42, ["/histories/list"], b"/histories/list"])
+def test_empty_and_non_string_values_are_refused(path):
+    assert is_safe_local_redirect(path) is False

--- a/test/unit/webapps/test_authnz_login_next.py
+++ b/test/unit/webapps/test_authnz_login_next.py
@@ -1,0 +1,75 @@
+"""Tests for how the OIDC callback consumes the login-next cookie.
+
+This is the point where an attacker-supplied value becomes a redirect, so it is where
+the destination has to be validated -- doing it here covers every writer of the cookie,
+including the ``next`` parameter accepted by ``OIDC.login``.
+"""
+
+from typing import Optional
+
+import pytest
+
+from galaxy.util.bunch import Bunch
+from galaxy.webapps.galaxy.controllers import authnz as authnz_module
+from galaxy.webapps.galaxy.controllers.authnz import (
+    LOGIN_NEXT_COOKIE_NAME,
+    OIDC,
+)
+
+LANDING_PATH = "/tool_landings/1234-5678?public=true"
+
+
+class StubTrans:
+    """The slice of the transaction interface ``OIDC.callback`` touches before it stops."""
+
+    def __init__(self, login_next_cookie: Optional[str]):
+        self.user = None
+        self._cookies = {LOGIN_NEXT_COOKIE_NAME: login_next_cookie}
+        self.login_redirect_url: Optional[str] = None
+        self.app = Bunch(authnz_manager=Bunch(callback=self._callback))
+
+    def get_cookie(self, name):
+        return self._cookies.get(name)
+
+    def _callback(self, provider, state, code, trans, login_redirect_url=None, idphint=None):
+        # Record what the controller decided, then stop the flow.
+        self.login_redirect_url = login_redirect_url
+        return False, "halt", (None, None)
+
+    def show_error_message(self, message):
+        return message
+
+
+@pytest.fixture(autouse=True)
+def passthrough_url_for(monkeypatch):
+    # url_for needs a live routes config; the decision under test is which value it gets.
+    monkeypatch.setattr(authnz_module, "url_for", lambda path: path)
+
+
+def chosen_redirect_for(cookie_value):
+    trans = StubTrans(cookie_value)
+    OIDC.callback(None, trans, "keycloak", code="auth-code", state="state-token")
+    return trans.login_redirect_url
+
+
+def test_callback_honors_a_relative_destination():
+    assert chosen_redirect_for(LANDING_PATH) == LANDING_PATH
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "https://evil.example.com/",
+        "//evil.example.com/",
+        "/\\evil.example.com/",
+        "/\t/evil.example.com",
+        "not-a-path",
+    ],
+)
+def test_callback_refuses_to_send_the_user_off_site(hostile):
+    assert chosen_redirect_for(hostile) == "/"
+
+
+@pytest.mark.parametrize("empty", [None, "", "None"])
+def test_callback_falls_back_to_root_without_a_destination(empty):
+    assert chosen_redirect_for(empty) == "/"

--- a/test/unit/webapps/test_require_login_redirect.py
+++ b/test/unit/webapps/test_require_login_redirect.py
@@ -100,8 +100,13 @@ def test_login_redirect_targets_the_login_entry_point():
     assert urlparse(location).path == "/login"
 
 
-def test_login_route_itself_is_not_gated():
-    """Otherwise require_login would bounce the login page to itself."""
-    trans = _trans_for("/login", "redirect=%2Ftool_landings%2Fabc")
+@pytest.mark.parametrize("path", ["/login", "/login/start"])
+def test_login_routes_are_not_themselves_gated(path):
+    """The whole chain lands on one of these, so gating either one is an infinite loop.
+
+    /login redirects to /login/start, and both have to pass through the require_login
+    check or an anonymous user can never reach a login form at all.
+    """
+    trans = _trans_for(path, "redirect=%2Ftool_landings%2Fabc")
     # No HTTPFound raised means the request was allowed through.
     trans._ensure_logged_in_user("galaxysession")

--- a/test/unit/webapps/test_require_login_redirect.py
+++ b/test/unit/webapps/test_require_login_redirect.py
@@ -1,0 +1,107 @@
+"""Tests for the ``require_login`` redirect built by ``GalaxyWebTransaction``.
+
+A deep link into Galaxy has to survive the round trip through the login flow, query
+string and all. Landing requests are the motivating case: the destination that matters
+is ``/tool_landings/<uuid>?public=true``, and dropping the query string silently
+orphans the landing request once the user finally logs in.
+
+This is a unit test rather than an integration test because the integration harness
+polls ``/`` for a 200 to decide the server is up, which never happens once
+``require_login`` is on.
+"""
+
+from typing import cast
+from urllib.parse import (
+    parse_qs,
+    urlparse,
+)
+
+import pytest
+import webob.exc
+from routes import request_config
+
+from galaxy.app_unittest_utils import galaxy_mock
+from galaxy.structured_app import BasicSharedApp
+from galaxy.util.bunch import Bunch
+from galaxy.webapps.base.webapp import (
+    GalaxyWebTransaction,
+    WebApplication,
+)
+
+LANDING_PATH = "/tool_landings/8a7f3c1e-0000-4000-8000-abcdef123456"
+LANDING_QUERY = "public=true"
+
+
+class StubGalaxyWebTransaction(GalaxyWebTransaction):
+    def _ensure_valid_session(self, session_cookie: str, create: bool = True) -> None:
+        pass
+
+
+class RoutedWebApplication(WebApplication):
+    def _instantiate_controller(self, type, app):
+        # Only the route map matters here, so skip building real controllers.
+        return object()
+
+
+def _trans_for(path: str, query_string: str = "") -> StubGalaxyWebTransaction:
+    app = cast(BasicSharedApp, galaxy_mock.MockApp())
+    app.config.require_login = True
+    app.config.show_welcome_with_login = False
+    app.config.template_cache_path = "/tmp"
+    # The login gate consults these while deciding what bypasses require_login.
+    app.datatypes_registry = Bunch(get_display_sites=lambda name: [], display_applications={})
+
+    webapp = RoutedWebApplication(cast(WebApplication, app))
+    # The two generic routes url_for resolves against -- see buildapp.app_pair.
+    webapp.add_route("/{controller}/{action}", action="index")
+    webapp.add_route("/{action}", controller="root", action="index")
+
+    routes_config = request_config()
+    routes_config.mapper = webapp.mapper
+    routes_config.host = "galaxy.example.org"
+    routes_config.protocol = "https"
+
+    environ = galaxy_mock.buildMockEnviron(PATH_INFO=path, QUERY_STRING=query_string)
+    trans = StubGalaxyWebTransaction(environ, app, cast(WebApplication, webapp), "galaxysession")
+    trans.galaxy_session = Bunch(user=None)
+    return trans
+
+
+def _login_redirect_for(path: str, query_string: str = "") -> str:
+    """Run the require_login gate and return where it sent the browser."""
+    trans = _trans_for(path, query_string)
+    with pytest.raises(webob.exc.HTTPFound) as caught:
+        trans._ensure_logged_in_user("galaxysession")
+    return caught.value.location
+
+
+def _redirect_param(location: str) -> str:
+    redirect = parse_qs(urlparse(location).query).get("redirect")
+    assert redirect, f"no redirect param carried on login redirect: {location}"
+    return redirect[0]
+
+
+def test_login_redirect_preserves_the_query_string():
+    location = _login_redirect_for(LANDING_PATH, LANDING_QUERY)
+    redirect = _redirect_param(location)
+    assert redirect.startswith(LANDING_PATH)
+    # The bug: only request.path was forwarded, so "?public=true" never made it here
+    # and the landing request was orphaned once the user came back from logging in.
+    assert LANDING_QUERY in redirect, f"query string dropped from login redirect: {redirect}"
+
+
+def test_login_redirect_without_a_query_string_is_unchanged():
+    redirect = _redirect_param(_login_redirect_for(LANDING_PATH))
+    assert redirect == LANDING_PATH
+
+
+def test_login_redirect_targets_the_login_entry_point():
+    location = _login_redirect_for(LANDING_PATH, LANDING_QUERY)
+    assert urlparse(location).path == "/login"
+
+
+def test_login_route_itself_is_not_gated():
+    """Otherwise require_login would bounce the login page to itself."""
+    trans = _trans_for("/login", "redirect=%2Ftool_landings%2Fabc")
+    # No HTTPFound raised means the request was allowed through.
+    trans._ensure_logged_in_user("galaxysession")

--- a/test/unit/webapps/test_require_login_redirect.py
+++ b/test/unit/webapps/test_require_login_redirect.py
@@ -43,7 +43,7 @@ class RoutedWebApplication(WebApplication):
         return object()
 
 
-def _trans_for(path: str, query_string: str = "") -> StubGalaxyWebTransaction:
+def _trans_for(path: str, query_string: str = "", script_name: str = "") -> StubGalaxyWebTransaction:
     app = cast(BasicSharedApp, galaxy_mock.MockApp())
     app.config.require_login = True
     app.config.show_welcome_with_login = False
@@ -61,15 +61,15 @@ def _trans_for(path: str, query_string: str = "") -> StubGalaxyWebTransaction:
     routes_config.host = "galaxy.example.org"
     routes_config.protocol = "https"
 
-    environ = galaxy_mock.buildMockEnviron(PATH_INFO=path, QUERY_STRING=query_string)
+    environ = galaxy_mock.buildMockEnviron(PATH_INFO=path, QUERY_STRING=query_string, SCRIPT_NAME=script_name)
     trans = StubGalaxyWebTransaction(environ, app, cast(WebApplication, webapp), "galaxysession")
     trans.galaxy_session = Bunch(user=None)
     return trans
 
 
-def _login_redirect_for(path: str, query_string: str = "") -> str:
+def _login_redirect_for(path: str, query_string: str = "", script_name: str = "") -> str:
     """Run the require_login gate and return where it sent the browser."""
-    trans = _trans_for(path, query_string)
+    trans = _trans_for(path, query_string, script_name)
     with pytest.raises(webob.exc.HTTPFound) as caught:
         trans._ensure_logged_in_user("galaxysession")
     return caught.value.location
@@ -93,6 +93,19 @@ def test_login_redirect_preserves_the_query_string():
 def test_login_redirect_without_a_query_string_is_unchanged():
     redirect = _redirect_param(_login_redirect_for(LANDING_PATH))
     assert redirect == LANDING_PATH
+
+
+def test_login_redirect_is_root_relative_under_a_prefix():
+    """Every consumer re-applies the app root, so it must not be in here already.
+
+    url_for on the way out of the OIDC callback, withPrefix on the local login path, and
+    the client router's `base` all prepend it -- a prefixed destination becomes
+    /galaxy/galaxy/... and 404s.
+    """
+    location = _login_redirect_for(LANDING_PATH, LANDING_QUERY, script_name="/galaxy")
+    redirect = _redirect_param(location)
+    assert redirect == f"{LANDING_PATH}?{LANDING_QUERY}"
+    assert not redirect.startswith("/galaxy"), f"app root leaked into the destination: {redirect}"
 
 
 def test_login_redirect_targets_the_login_entry_point():

--- a/test/unit/webapps/test_require_login_redirect.py
+++ b/test/unit/webapps/test_require_login_redirect.py
@@ -10,7 +10,10 @@ polls ``/`` for a 200 to decide the server is up, which never happens once
 ``require_login`` is on.
 """
 
-from typing import cast
+from typing import (
+    Any,
+    cast,
+)
 from urllib.parse import (
     parse_qs,
     urlparse,
@@ -21,7 +24,7 @@ import webob.exc
 from routes import request_config
 
 from galaxy.app_unittest_utils import galaxy_mock
-from galaxy.structured_app import BasicSharedApp
+from galaxy.model import GalaxySession
 from galaxy.util.bunch import Bunch
 from galaxy.webapps.base.webapp import (
     GalaxyWebTransaction,
@@ -44,14 +47,14 @@ class RoutedWebApplication(WebApplication):
 
 
 def _trans_for(path: str, query_string: str = "", script_name: str = "") -> StubGalaxyWebTransaction:
-    app = cast(BasicSharedApp, galaxy_mock.MockApp())
+    app: Any = galaxy_mock.MockApp()
     app.config.require_login = True
     app.config.show_welcome_with_login = False
     app.config.template_cache_path = "/tmp"
     # The login gate consults these while deciding what bypasses require_login.
     app.datatypes_registry = Bunch(get_display_sites=lambda name: [], display_applications={})
 
-    webapp = RoutedWebApplication(cast(WebApplication, app))
+    webapp = RoutedWebApplication(app)
     # The two generic routes url_for resolves against -- see buildapp.app_pair.
     webapp.add_route("/{controller}/{action}", action="index")
     webapp.add_route("/{action}", controller="root", action="index")
@@ -62,8 +65,8 @@ def _trans_for(path: str, query_string: str = "", script_name: str = "") -> Stub
     routes_config.protocol = "https"
 
     environ = galaxy_mock.buildMockEnviron(PATH_INFO=path, QUERY_STRING=query_string, SCRIPT_NAME=script_name)
-    trans = StubGalaxyWebTransaction(environ, app, cast(WebApplication, webapp), "galaxysession")
-    trans.galaxy_session = Bunch(user=None)
+    trans = StubGalaxyWebTransaction(environ, app, webapp, "galaxysession")
+    trans.galaxy_session = cast(GalaxySession, Bunch(user=None))
     return trans
 
 

--- a/test/unit/webapps/test_root_login.py
+++ b/test/unit/webapps/test_root_login.py
@@ -1,0 +1,85 @@
+"""Unit tests for the ``root`` controller's ``/login`` entry point.
+
+When a Galaxy instance delegates authentication to a single OIDC provider, ``/login``
+bounces the browser straight at that provider. Where the user was originally headed has
+to be stashed in the login-next cookie *before* that bounce, because the OIDC callback
+has no other way to recover it -- see ``OIDC.callback`` in the ``authnz`` controller.
+"""
+
+from typing import Optional
+
+import pytest
+
+from galaxy.util.bunch import Bunch
+from galaxy.webapps.galaxy.controllers.authnz import LOGIN_NEXT_COOKIE_NAME
+from galaxy.webapps.galaxy.controllers.root import RootController
+
+IDP_URL = "https://idp.example.org/authorize?client_id=galaxy"
+LANDING_PATH = "/tool_landings/1234-5678?public=true"
+
+
+class StubTrans:
+    """The slice of the transaction interface ``RootController.login`` actually touches."""
+
+    def __init__(self, authenticators=(), oidc_providers=("tapis",)):
+        self.cookies: dict[str, str] = {}
+        self.redirected_to: Optional[str] = None
+        self.app = Bunch(
+            config=Bunch(enable_oidc=True, oidc={name: {} for name in oidc_providers}),
+            auth_manager=Bunch(authenticators=list(authenticators)),
+            authnz_manager=Bunch(authenticate=lambda provider, trans: (True, "", IDP_URL)),
+        )
+        self.response = Bunch(send_redirect=self._send_redirect)
+
+    def _send_redirect(self, url):
+        self.redirected_to = url
+        return url
+
+    def set_cookie(self, value, name="galaxysession", **kwd):
+        self.cookies[name] = value
+
+
+def login(trans, **kwd):
+    # ``login`` never touches ``self``, so there is no controller to build here.
+    return RootController.login(None, trans, **kwd)
+
+
+def test_single_provider_login_stashes_destination_before_bouncing_to_idp():
+    trans = StubTrans()
+    login(trans, redirect=LANDING_PATH)
+    assert trans.redirected_to == IDP_URL
+    assert trans.cookies[LOGIN_NEXT_COOKIE_NAME] == LANDING_PATH
+
+
+def test_single_provider_login_without_destination_defaults_to_root():
+    trans = StubTrans()
+    login(trans)
+    assert trans.redirected_to == IDP_URL
+    assert trans.cookies[LOGIN_NEXT_COOKIE_NAME] == "/"
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "https://evil.example.com/",
+        "//evil.example.com/",
+        "/\\evil.example.com/",
+        "/\t/evil.example.com",
+        "not-a-path",
+    ],
+)
+def test_single_provider_login_refuses_offsite_destination(hostile):
+    trans = StubTrans()
+    login(trans, redirect=hostile)
+    assert trans.cookies[LOGIN_NEXT_COOKIE_NAME] == "/"
+
+
+def test_multiple_providers_fall_through_to_the_login_page(monkeypatch):
+    # More than one provider means Galaxy has to ask which one, so no cookie is set here;
+    # the client passes the destination along when the user picks a provider.
+    monkeypatch.setattr("galaxy.web.url_for", lambda **kwd: f"/login/start?redirect={kwd.get('redirect')}")
+    trans = StubTrans(oidc_providers=("tapis", "keycloak"))
+    login(trans, redirect=LANDING_PATH)
+    assert trans.redirected_to is not None
+    assert "login/start" in trans.redirected_to
+    assert LOGIN_NEXT_COOKIE_NAME not in trans.cookies


### PR DESCRIPTION
## Summary

A landing request deep link loses its destination on the way through login, so the user
authenticates and ends up on the Galaxy home page instead of the fetch review grid. The
landing request is silently orphaned -- no error, the import just never happens.

This shows up on any instance with `require_login: true` plus OIDC. I hit it wiring up
the CFDE Data Resource Center's "Export to Cloud Workspace" button, which anonymously
POSTs to `/api/data_landings` and then sends the user to
`/tool_landings/<uuid>?public=true`.

Three things drop the destination, and you need all three fixed before the flow works.

**The one that actually causes the reported bug** is in `RootController.login`. When a
single OIDC provider is configured and there are no local authenticators, `/login` hands
the browser straight to the provider -- and it was doing that without ever setting the
`galaxy-oidc-login-next` cookie. `OIDC.callback` then has nothing to come back to and
falls through to `url_for("/")`. That's why the symptom is the home page rather than a
partially-mangled redirect. `OIDC.login` already sets this cookie for the multi-provider
case; the single-provider shortcut just never did.

**The require_login gate** in `_ensure_logged_in_user` was forwarding `self.request.path`,
so `?public=true` was gone before login even started.

**On the client**, a logged-in user hitting `/login/start?redirect=...` got sent to `/`
with the redirect discarded, because `redirectLoggedIn()` returned `"/"` unconditionally.
That's now a `beforeEnter` guard rather than a route-level `redirect`, which matters more
than it looks: vue-router treats a `redirect` function returning `undefined` as "no match"
and renders nothing, so the obvious fix would have left anonymous users on a blank login
page. The login and register entry routes moved into `routes/login-routes.ts` alongside
the admin, library and storage route modules so the wiring is testable.

## Open redirect

Worth a close look since these values arrive from a query string. There was no existing
validation on this path -- `OIDC.login` accepted an arbitrary `next` and stored it
verbatim. I added `is_safe_local_redirect` (server) and `safeRedirectPath` (client), and
applied the server one where the cookie is *consumed* in `OIDC.callback`, which closes the
hole for the pre-existing `next` parameter too. Both refuse absolute URLs,
protocol-relative `//host`, the `/\host` spelling browsers normalize to it, control
characters, and surrounding whitespace.

That last bit is slightly beyond the reported bug, so it's easy to drop if you'd rather
keep the release-branch diff narrower -- it's self-contained.

## Prefixed deployments

`request.path_qs` includes `SCRIPT_NAME`, and everything downstream re-applies the app
root on its own -- `url_for` coming back out of the callback, `withPrefix` on the local
login path, and the client router's own `base`. Under a `/galaxy` prefix the destination
became `/galaxy/galaxy/tool_landings/...` and 404'd. Sending `path_info` instead fixes
that, and incidentally fixes the local login path, which has had the same double-prefix
through `withPrefix` all along.

## Not included

`redirectToSingleProvider` in `ExternalIDHelper.ts` calls `submitOIDCLogon(idp, "")` with
a hardcoded empty `next` -- same class of bug, but it's gated on `disable_local_accounts`
so it isn't what's biting here. `submitCILogon` takes no redirect parameter at all, so
fixing only the non-cilogon half would be a half-fix. Left alone deliberately; happy to do
it separately.

## Test plan

- [x] `test/unit/webapps/test_root_login.py` -- the single-provider branch stashes the
      destination before bouncing to the IdP, and refuses off-site targets
- [x] `test/unit/webapps/test_authnz_login_next.py` -- the callback honors a relative
      destination and falls back to `/` for anything else
- [x] `test/unit/webapps/test_require_login_redirect.py` -- the gate preserves the query
      string, stays root-relative under a prefix, and doesn't gate `/login` or
      `/login/start` (either would be an infinite loop)
- [x] `test/unit/util/test_safe_local_redirect.py` -- the validator itself
- [x] `client/src/entry/analysis/routes/login-routes.test.ts` -- drives a real vue-router,
      so it covers the wiring and not just the guard, and pins that an anonymous user ends
      up on a route that actually has a component to render
- [x] `client/src/router/guards.test.ts`, `client/src/utils/redirect.test.ts`
- [x] `make client-format`, `pnpm build`, `mypy`

Each fix was checked by reverting it and confirming a test fails.

Worth noting for anyone who goes looking: `require_login` can't be integration-tested
today. `wait_for_http_server` polls `/` for a 200, which `require_login` turns into a
permanent 302, so the driver never considers the server up. That's why this is covered by
unit tests against `_ensure_logged_in_user` instead, and why there's no existing
`require_login` coverage in the repo.

Manual verification, which is the real proof, is the curl-then-browser round trip: create
a data landing anonymously, open `/tool_landings/<uuid>?public=true` in a fresh session,
and confirm `galaxy-oidc-login-next` is set to the full landing path *before* the bounce
to the IdP.
