### PR TITLE
[26.1] Name DRS-fetched datasets from DRS metadata instead of the URI basename

### DIFF
--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -16,6 +16,7 @@ from pydantic import (
     ConfigDict,
     Field,
 )
+from typing_extensions import TypedDict
 
 from galaxy.files.sources._defaults import (
     DEFAULT_SCHEME,
@@ -454,10 +455,19 @@ def resolve_file_source_template(
     return resolved_config_class(**expanded_dict)
 
 
-class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
-    """Context for file source operations, providing user data and resolved configuration."""
+class RealizedSourceMetadata(TypedDict, total=False):
+    """What a file source learned while realizing a source - every key optional."""
 
-    def __init__(self, user_data: UserData, config: TResolvedConfig, metadata_out: Optional[dict] = None):
+    name: str
+
+
+class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
+    """Context for file source operations: user data, resolved configuration, and an
+    optional channel for a source to report metadata back to the caller."""
+
+    def __init__(
+        self, user_data: UserData, config: TResolvedConfig, metadata_out: Optional[RealizedSourceMetadata] = None
+    ):
         self._user_data = user_data
         self._config = config
         self._metadata_out = metadata_out
@@ -473,7 +483,7 @@ class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
         return self._config
 
     @property
-    def metadata_out(self) -> Optional[dict]:
+    def metadata_out(self) -> Optional[RealizedSourceMetadata]:
         """Caller-supplied dict a file source may populate with metadata about the realized source.
 
         This is how a file source reports back things it learns while realizing a

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -457,9 +457,10 @@ def resolve_file_source_template(
 class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
     """Context for file source operations, providing user data and resolved configuration."""
 
-    def __init__(self, user_data: UserData, config: TResolvedConfig):
+    def __init__(self, user_data: UserData, config: TResolvedConfig, metadata_out: Optional[dict] = None):
         self._user_data = user_data
         self._config = config
+        self._metadata_out = metadata_out
 
     @property
     def user_data(self) -> UserData:
@@ -470,3 +471,14 @@ class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
     def config(self) -> TResolvedConfig:
         """Resolved configuration for the file source with all templates expanded."""
         return self._config
+
+    @property
+    def metadata_out(self) -> Optional[dict]:
+        """Caller-supplied dict a file source may populate with metadata about the realized source.
+
+        This is how a file source reports back things it learns while realizing a
+        source that the caller cannot derive from the URI alone -- currently only the
+        DRS file source uses it, to report the object's ``name``. ``None`` when the
+        caller isn't interested.
+        """
+        return self._metadata_out

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -31,6 +31,7 @@ from galaxy.files.models import (
     FilesSourceProperties,
     FilesSourceRuntimeContext,
     FilesSourceTemplateContext,
+    RealizedSourceMetadata,
     resolve_file_source_template,
     TResolvedConfig,
     TTemplateConfig,
@@ -114,7 +115,7 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ):
         """Realize source path (relative to uri root) to local file system path.
 
@@ -129,7 +130,7 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         :param metadata_out: An optional dict the file source may populate with metadata about the
             realized source that isn't derivable from the URI - currently only a ``name`` key
             reported by the DRS file source. Filesource specific, defaults to None
-        :type metadata_out: Optional[dict], optional
+        :type metadata_out: Optional[RealizedSourceMetadata], optional
         """
 
     @abc.abstractmethod
@@ -468,7 +469,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         self,
         opts: Optional[FilesSourceOptions] = None,
         user_context: "OptionalUserContext" = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ) -> FilesSourceRuntimeContext:
         """
         Get the runtime context for this file source, resolving the template configuration
@@ -603,7 +604,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ):
         self._check_user_access(user_context)
         self._check_credentials_fresh()

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -114,6 +114,7 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
+        metadata_out: Optional[dict] = None,
     ):
         """Realize source path (relative to uri root) to local file system path.
 
@@ -125,6 +126,10 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         :type user_context: OptionalUserContext, optional
         :param opts: A set of options to exercise additional control over the realize_to method. Filesource specific, defaults to None
         :type opts: Optional[FilesSourceOptions], optional
+        :param metadata_out: An optional dict the file source may populate with metadata about the
+            realized source that isn't derivable from the URI - currently only a ``name`` key
+            reported by the DRS file source. Filesource specific, defaults to None
+        :type metadata_out: Optional[dict], optional
         """
 
     @abc.abstractmethod
@@ -463,6 +468,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         self,
         opts: Optional[FilesSourceOptions] = None,
         user_context: "OptionalUserContext" = None,
+        metadata_out: Optional[dict] = None,
     ) -> FilesSourceRuntimeContext:
         """
         Get the runtime context for this file source, resolving the template configuration
@@ -480,7 +486,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
             updated_headers = self._inject_oidc_bearer_token(dict(resolved_config.http_headers or {}), user_context)
             if updated_headers is not None:
                 resolved_config = resolved_config.model_copy(update={"http_headers": updated_headers})
-        return FilesSourceRuntimeContext(user_data=user_data, config=resolved_config)
+        return FilesSourceRuntimeContext(user_data=user_data, config=resolved_config, metadata_out=metadata_out)
 
     def _apply_defaults_to_template(
         self, defaults: dict[str, Any], template_config: TTemplateConfig
@@ -597,10 +603,11 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
+        metadata_out: Optional[dict] = None,
     ):
         self._check_user_access(user_context)
         self._check_credentials_fresh()
-        resolved_config = self._get_runtime_context(opts, user_context)
+        resolved_config = self._get_runtime_context(opts, user_context, metadata_out=metadata_out)
         self._realize_to(source_path, native_path, resolved_config)
 
     @abc.abstractmethod

--- a/lib/galaxy/files/sources/drs.py
+++ b/lib/galaxy/files/sources/drs.py
@@ -66,6 +66,7 @@ class DRSFilesSource(BaseFilesSource[DRSFileSourceTemplateConfiguration, DRSFile
             fetch_url_allowlist=self._allowlist,
             headers=headers or None,
             force_http=config.force_http,
+            metadata_out=context.metadata_out,
         )
 
     def _write_from(

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -2,6 +2,7 @@ import json
 import logging
 import time
 from typing import (
+    Any,
     Optional,
 )
 from urllib.parse import quote
@@ -27,6 +28,42 @@ log = logging.getLogger(__name__)
 
 # Constants
 CHUNK_SIZE = 8192
+
+# POSIX NAME_MAX is 255 *bytes*, and dataset names are stored as TrimmedString(255)
+# characters, so a 255-byte cap satisfies both limits at once.
+MAX_DRS_NAME_BYTES = 255
+
+
+def sanitize_drs_name(name: Any) -> Optional[str]:
+    """Reduce an untrusted DRS object ``name`` to something safe to use as a dataset name.
+
+    A DRS server can put anything in this field, and it ends up both as a dataset name and
+    as an input to downstream filename construction, so strip it down to a single path
+    component with no control characters. Returns None if nothing usable is left.
+    """
+    if not isinstance(name, str):
+        return None
+    # Keep only the last path component so a name like "../../etc/passwd" cannot steer
+    # anything downstream out of its intended directory.
+    candidate = name.replace("\\", "/").split("/")[-1]
+    candidate = "".join(c for c in candidate if c.isprintable()).strip()
+    candidate = _truncate_to_bytes(candidate, MAX_DRS_NAME_BYTES).strip()
+    if candidate in ("", ".", ".."):
+        return None
+    return candidate
+
+
+def _truncate_to_bytes(value: str, max_bytes: int) -> str:
+    """Trim ``value`` to at most ``max_bytes`` UTF-8 bytes without splitting a character.
+
+    Counting characters isn't enough: 255 emoji are 255 characters but 1020 bytes, which
+    overruns NAME_MAX the moment the name is used to build a path.
+    """
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    # errors="ignore" drops the partial character the byte-wise cut may have left behind.
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
 
 def _not_implemented(drs_uri: str, desc: str) -> NotImplementedError:
@@ -324,8 +361,16 @@ def fetch_drs_to_file(
     retry_options: Optional[RetryOptions] = None,
     headers: Optional[dict] = None,
     fetch_url_allowlist: Optional[list[IpAllowedListEntryT]] = None,
+    metadata_out: Optional[dict] = None,
 ):
-    """Fetch contents of drs:// URI to a target path."""
+    """Fetch contents of drs:// URI to a target path.
+
+    If ``metadata_out`` is supplied and the DRS object declares a usable ``name``, it is
+    reported back under the ``name`` key so callers can name the dataset something better
+    than the opaque identifier in the URI. It is populated on a best-effort basis and is
+    never cleared, so callers should pass a dict scoped to a single fetch rather than
+    reusing one and assuming a missing key means this call reported nothing.
+    """
     if not drs_uri.startswith("drs://"):
         raise ValueError(f"Unknown scheme for drs_uri {drs_uri}")
 
@@ -361,6 +406,11 @@ def fetch_drs_to_file(
     access_methods = response_object.get("access_methods", [])
     if len(access_methods) == 0:
         raise ValueError(f"No access methods found in DRS response for {drs_uri}")
+
+    if metadata_out is not None:
+        drs_name = sanitize_drs_name(response_object.get("name"))
+        if drs_name:
+            metadata_out["name"] = drs_name
 
     downloaded = False
     for access_method in access_methods:

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -15,6 +15,7 @@ from galaxy.files import (
 from galaxy.files.models import (
     FilesSourceOptions,
     PartialFilesSourceProperties,
+    RealizedSourceMetadata,
 )
 from galaxy.files.uris import stream_url_to_file
 from galaxy.util import (
@@ -40,6 +41,9 @@ def sanitize_drs_name(name: Any) -> Optional[str]:
     A DRS server can put anything in this field, and it ends up both as a dataset name and
     as an input to downstream filename construction, so strip it down to a single path
     component with no control characters. Returns None if nothing usable is left.
+
+    Not :func:`galaxy.util.sanitize_for_filename` - that mangles legitimate Unicode and
+    substitutes a random id rather than reporting failure.
     """
     if not isinstance(name, str):
         return None
@@ -361,7 +365,7 @@ def fetch_drs_to_file(
     retry_options: Optional[RetryOptions] = None,
     headers: Optional[dict] = None,
     fetch_url_allowlist: Optional[list[IpAllowedListEntryT]] = None,
-    metadata_out: Optional[dict] = None,
+    metadata_out: Optional[RealizedSourceMetadata] = None,
 ):
     """Fetch contents of drs:// URI to a target path.
 

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -15,7 +15,10 @@ from galaxy.files import (
     ConfiguredFileSources,
     NoMatchingFileSource,
 )
-from galaxy.files.models import FilesSourceOptions
+from galaxy.files.models import (
+    FilesSourceOptions,
+    RealizedSourceMetadata,
+)
 from galaxy.util import (
     stream_to_open_named_file,
     unicodify,
@@ -44,7 +47,7 @@ def stream_url_to_file(
     user_context=None,
     target_path: Optional[str] = None,
     file_source_opts: Optional[FilesSourceOptions] = None,
-    metadata_out: Optional[dict] = None,
+    metadata_out: Optional[RealizedSourceMetadata] = None,
 ) -> str:
     """Stream ``url`` to a local path and return that path.
 

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -44,14 +44,23 @@ def stream_url_to_file(
     user_context=None,
     target_path: Optional[str] = None,
     file_source_opts: Optional[FilesSourceOptions] = None,
+    metadata_out: Optional[dict] = None,
 ) -> str:
+    """Stream ``url`` to a local path and return that path.
+
+    ``metadata_out``, if supplied, is populated by file sources that can report metadata
+    about the source they realized. Only the DRS file source does so today, setting a
+    ``name`` key from the DRS object's own name.
+    """
     file_sources = ensure_file_sources(file_sources)
     file_source, rel_path = file_sources.get_file_source_path(url)
     if file_source:
         if not target_path:
             with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
                 target_path = temp.name
-        file_source.realize_to(rel_path, target_path, user_context=user_context, opts=file_source_opts)
+        file_source.realize_to(
+            rel_path, target_path, user_context=user_context, opts=file_source_opts, metadata_out=metadata_out
+        )
         return target_path
     else:
         raise NoMatchingFileSource(f"Could not find a matching handler for: {url}")

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -564,12 +564,16 @@ def _has_src_to_path(
             extra_props = PartialFilesSourceProperties(**{"http_headers": headers})
             file_source_options = FilesSourceOptions(extra_props=extra_props)
 
+        # Populated by file sources that can report a better name than the URI offers -
+        # a DRS URI's last path segment is typically an opaque identifier.
+        source_metadata: dict[str, Any] = {}
         try:
             path = stream_url_to_file(
                 url,
                 file_sources=upload_config.file_sources,
                 dir=upload_config.working_directory,
                 file_source_opts=file_source_options,
+                metadata_out=source_metadata,
             )
         except Exception as e:
             raise Exception(f"Failed to fetch url {url}. {str(e)}")
@@ -582,7 +586,7 @@ def _has_src_to_path(
                 if hash_value:
                     _handle_hash_validation(hash_function, hash_value, path)
         if name is None:
-            name = url.split("/")[-1]
+            name = source_metadata.get("name") or url.split("/")[-1]
     elif src == "pasted":
         path = stream_to_file(StringIO(item["paste_content"]), dir=upload_config.working_directory)
         if name is None:

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -518,7 +518,9 @@ def _directory_to_items(directory):
 
 def _has_src_to_name(item) -> Optional[str]:
     # Logic should broadly match logic of _has_src_to_path but not resolve the item
-    # into a path.
+    # into a path. Deliberately does not consult file source metadata the way
+    # _has_src_to_path does - a DRS name would require the very fetch deferral avoids,
+    # so deferred DRS datasets keep the URI basename.
     name = item.get("name")
     src = item.get("src")
     if src == "url":

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -22,6 +22,7 @@ from galaxy.datatypes.upload_util import (
 from galaxy.files.models import (
     FilesSourceOptions,
     PartialFilesSourceProperties,
+    RealizedSourceMetadata,
 )
 from galaxy.files.uris import (
     ensure_file_sources,
@@ -566,7 +567,7 @@ def _has_src_to_path(
 
         # Populated by file sources that can report a better name than the URI offers -
         # a DRS URI's last path segment is typically an opaque identifier.
-        source_metadata: dict[str, Any] = {}
+        source_metadata: RealizedSourceMetadata = {}
         try:
             path = stream_url_to_file(
                 url,

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -5,14 +5,22 @@ from base64 import b64encode
 from contextlib import contextmanager
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+)
 
 import pytest
+import responses
 
 from galaxy.tools.data_fetch import main
 
 B64_FOR_1_2_3 = b64encode(b"1 2 3").decode("utf-8")
 URI_FOR_1_2_3 = f"base64://{B64_FOR_1_2_3}"
+
+DRS_OBJECT_ID = "000009a0-5b22-5be5-9217-a26b5c0b03c2"
+DRS_URI = f"drs://drs.example.org/{DRS_OBJECT_ID}"
+DRS_OBJECT_URL = f"https://drs.example.org/ga4gh/drs/v1/objects/{DRS_OBJECT_ID}"
 
 
 @pytest.mark.parametrize(
@@ -88,6 +96,109 @@ def test_simple_uri_get(mock_http_server):
         hda_result = output["elements"][0]
         assert hda_result["state"] == "ok"
         assert hda_result["ext"] == "bed"
+        assert hda_result["name"] == "1.bed"
+
+
+@responses.activate
+def test_drs_uri_named_from_drs_metadata(mock_http_server):
+    _mock_drs_object(_bed_content_url(mock_http_server), name="sample.bed")
+    hda_result = _fetch_drs_element()
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == "sample.bed"
+
+
+@responses.activate
+def test_drs_uri_named_from_drs_metadata_via_access_id(mock_http_server):
+    _mock_drs_object(_bed_content_url(mock_http_server), name="sample.bed", access_id="https")
+    hda_result = _fetch_drs_element()
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == "sample.bed"
+
+
+@responses.activate
+def test_drs_uri_explicit_name_wins(mock_http_server):
+    _mock_drs_object(_bed_content_url(mock_http_server), name="sample.bed")
+    hda_result = _fetch_drs_element(name="user supplied name")
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == "user supplied name"
+
+
+@responses.activate
+def test_drs_uri_without_name_falls_back_to_uri_basename(mock_http_server):
+    _mock_drs_object(_bed_content_url(mock_http_server))
+    hda_result = _fetch_drs_element()
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == DRS_OBJECT_ID
+
+
+@pytest.mark.parametrize(
+    "drs_name, expected_name",
+    [
+        ("../../../etc/passwd", "passwd"),
+        ("/etc/passwd", "passwd"),
+        ("..\\..\\windows\\system32", "system32"),
+        ("sample\r\n.bed", "sample.bed"),
+        ("..", DRS_OBJECT_ID),
+        (".", DRS_OBJECT_ID),
+        ("", DRS_OBJECT_ID),
+        ("   ", DRS_OBJECT_ID),
+        ("etc/", DRS_OBJECT_ID),
+        (12345, DRS_OBJECT_ID),
+        ({"value": "sample.bed"}, DRS_OBJECT_ID),
+    ],
+)
+@responses.activate
+def test_drs_uri_name_is_sanitized(mock_http_server, drs_name, expected_name):
+    _mock_drs_object(_bed_content_url(mock_http_server), name=drs_name)
+    hda_result = _fetch_drs_element()
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == expected_name
+
+
+@responses.activate
+def test_drs_uri_overlong_name_is_truncated(mock_http_server):
+    _mock_drs_object(_bed_content_url(mock_http_server), name="a" * 300)
+    hda_result = _fetch_drs_element()
+    assert hda_result["state"] == "ok"
+    assert hda_result["name"] == "a" * 255
+
+
+def _bed_content_url(mock_http_server) -> str:
+    return mock_http_server.get_url(
+        remote_url="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed",
+        file_path="test-data/1.bed",
+    )
+
+
+def _mock_drs_object(content_url: str, name: Any = None, access_id: Optional[str] = None) -> None:
+    """Register mock responses for a DRS object resolving to ``content_url``."""
+    access_method: dict[str, Any] = {"type": "https"}
+    if access_id is not None:
+        access_method["access_id"] = access_id
+        responses.add(responses.GET, f"{DRS_OBJECT_URL}/access/{access_id}", json={"url": content_url})
+    else:
+        access_method["access_url"] = {"url": content_url}
+    drs_object: dict[str, Any] = {"id": DRS_OBJECT_ID, "access_methods": [access_method]}
+    if name is not None:
+        drs_object["name"] = name
+    responses.add(responses.GET, DRS_OBJECT_URL, json=drs_object)
+
+
+def _fetch_drs_element(name: Optional[str] = None) -> dict[str, Any]:
+    element: dict[str, Any] = {"src": "url", "url": DRS_URI}
+    if name is not None:
+        element["name"] = name
+    with _execute_context(allow_localhost=True) as execute_context:
+        request = {
+            "targets": [
+                {
+                    "destination": {"type": "hdas"},
+                    "elements": [element],
+                }
+            ]
+        }
+        execute_context.execute_request(request)
+        return _unnamed_output(execute_context)["elements"][0]
 
 
 def test_correct_md5():
@@ -420,6 +531,7 @@ def _execute_context(allow_localhost=False):
                         "file_sources": [
                             {"type": "http", "id": "stock_http"},
                             {"type": "base64", "id": "stock_base64"},
+                            {"type": "drs", "id": "stock_drs"},
                         ],
                         "config": {
                             "symlink_allowlist": [],

--- a/test/unit/files/test_drs.py
+++ b/test/unit/files/test_drs.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import tempfile
 import urllib
 from typing import Any
 from unittest import mock
@@ -12,6 +13,7 @@ from galaxy.files import (
     DictFileSourcesUserContext,
     ProvidesFileSourcesUserContext,
 )
+from galaxy.files.sources.util import sanitize_drs_name
 from ._util import (
     assert_realizes_as,
     assert_realizes_contains,
@@ -161,6 +163,105 @@ def test_file_source_drs_http():
         assert file_source_pair.file_source.id == "test1"
 
         assert_realizes_as(file_sources, test_url, "hello drs world", user_context=user_context)
+
+        # The DRS object's own name is reported back through metadata_out so callers can
+        # name the dataset something better than the identifier in the URI.
+        metadata_out: dict[str, Any] = {}
+        with tempfile.NamedTemporaryFile(mode="r") as temp:
+            file_source_pair.file_source.realize_to(
+                file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out
+            )
+        assert metadata_out["name"] == "hello-314159"
+
+
+@responses.activate
+def test_file_source_drs_omits_unusable_name_from_metadata():
+    """A DRS object with no usable name leaves metadata_out empty so callers keep their own fallback."""
+
+    def drs_repo_handler(request):
+        data = {
+            "id": "271828",
+            "access_methods": [{"type": "https", "access_url": {"url": "https://my.respository.org/myfile.txt"}}],
+        }
+        return (200, {}, json.dumps(data))
+
+    responses.add_callback(
+        responses.GET,
+        "https://drs.example.org/ga4gh/drs/v1/objects/271828",
+        callback=drs_repo_handler,
+        content_type="application/json",
+    )
+
+    test_url = "drs://drs.example.org/271828"
+
+    def download(request, **kwargs):
+        response: Any = io.StringIO("hello drs world")
+        response.headers = {}
+        response.geturl = lambda: test_url
+        return response
+
+    with mock.patch.object(urllib.request, "urlopen", new=download):
+        user_context = user_context_fixture()
+        file_sources = configured_file_sources(FILE_SOURCES_CONF)
+        file_source_pair = file_sources.get_file_source_path(test_url)
+        metadata_out: dict[str, Any] = {}
+        with tempfile.NamedTemporaryFile(mode="r") as temp:
+            file_source_pair.file_source.realize_to(
+                file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out
+            )
+        assert metadata_out == {}
+
+
+@pytest.mark.parametrize(
+    "raw_name, expected",
+    [
+        ("sample.bed", "sample.bed"),
+        ("L1000_LINCS_DCIC_PBIOA020_HCC515_24H_G06.tsv.gz", "L1000_LINCS_DCIC_PBIOA020_HCC515_24H_G06.tsv.gz"),
+        ("  padded.txt  ", "padded.txt"),
+        ("ünïcödé.txt", "ünïcödé.txt"),
+        ("../../../etc/passwd", "passwd"),
+        ("/etc/passwd", "passwd"),
+        ("..\\..\\windows\\system32\\cmd.exe", "cmd.exe"),
+        ("sample\t\r\n.bed", "sample.bed"),
+        ("sample\x00.bed", "sample.bed"),
+        # Bidi overrides and zero-width characters are how a name gets to look like
+        # something it isn't, so they go too.
+        ("‮gnp.exe", "gnp.exe"),
+        ("file​name.txt", "filename.txt"),
+        ("a" * 300, "a" * 255),
+        ("", None),
+        ("   ", None),
+        (".", None),
+        ("..", None),
+        ("some/dir/", None),
+        ("\x00\x01", None),
+        (None, None),
+        (12345, None),
+        (["sample.bed"], None),
+        ({"value": "sample.bed"}, None),
+    ],
+)
+def test_sanitize_drs_name(raw_name, expected):
+    assert sanitize_drs_name(raw_name) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_name",
+    [
+        "a" * 300,
+        "\U0001f600" * 255,  # 255 characters, 1020 UTF-8 bytes
+        "ü" * 200,
+        "🎉ünïcödé" * 40,
+    ],
+)
+def test_sanitize_drs_name_caps_encoded_bytes(raw_name):
+    """The cap has to be on bytes -- POSIX NAME_MAX is a byte limit, so 255 emoji would overrun it."""
+    sanitized = sanitize_drs_name(raw_name)
+    assert sanitized
+    assert len(sanitized.encode("utf-8")) <= 255
+    # Truncation keeps a prefix and never leaves a mangled partial character behind.
+    assert raw_name.startswith(sanitized)
+    assert sanitized.encode("utf-8").decode("utf-8") == sanitized
 
 
 @responses.activate

--- a/test/unit/files/test_drs.py
+++ b/test/unit/files/test_drs.py
@@ -13,6 +13,7 @@ from galaxy.files import (
     DictFileSourcesUserContext,
     ProvidesFileSourcesUserContext,
 )
+from galaxy.files.models import RealizedSourceMetadata
 from galaxy.files.sources.util import sanitize_drs_name
 from ._util import (
     assert_realizes_as,
@@ -166,7 +167,7 @@ def test_file_source_drs_http():
 
         # The DRS object's own name is reported back through metadata_out so callers can
         # name the dataset something better than the identifier in the URI.
-        metadata_out: dict[str, Any] = {}
+        metadata_out: RealizedSourceMetadata = {}
         with tempfile.NamedTemporaryFile(mode="r") as temp:
             file_source_pair.file_source.realize_to(
                 file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out
@@ -204,7 +205,7 @@ def test_file_source_drs_omits_unusable_name_from_metadata():
         user_context = user_context_fixture()
         file_sources = configured_file_sources(FILE_SOURCES_CONF)
         file_source_pair = file_sources.get_file_source_path(test_url)
-        metadata_out: dict[str, Any] = {}
+        metadata_out: RealizedSourceMetadata = {}
         with tempfile.NamedTemporaryFile(mode="r") as temp:
             file_source_pair.file_source.realize_to(
                 file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out


### PR DESCRIPTION
Fetching a `drs://` URI names the resulting dataset after the last path segment of the
URI, and on most DRS servers that segment is an opaque identifier. So this:

```
drs://cfde.cloud/000009a0-5b22-5be5-9217-a26b5c0b03c2
```

lands in the history as a dataset named `000009a0-5b22-5be5-9217-a26b5c0b03c2`, while the
DRS object Galaxy already fetched to resolve that URI has the answer sitting right there:

```json
{
  "id": "2bb4c866b94c36831e2e4e33031e5ef6",
  "name": "L1000_LINCS_DCIC_PBIOA020_HCC515_24H_G06_BRD-K21448636_0.04uM.tsv.gz",
  "size": 296040,
  "checksums": [{"type": "md5", "checksum": "2bb4c866b94c36831e2e4e33031e5ef6"}],
  "access_methods": [{"type": "https", "access_id": "https", "access_url": {"url": "https://lincs-dcic.s3.amazonaws.com/..."}}]
}
```

`fetch_drs_to_file()` reads `access_methods` off that response and drops `name` on the
floor. This is about to start mattering -- CFDE is beginning to hand users off to
`galaxy.cfdeworkspace.org` with lists of DRS URIs, and every dataset would arrive as a
bare UUID.

### The plumbing

The name is known down in `galaxy.files.sources.util.fetch_drs_to_file()` and the naming
decision happens up in `data_fetch._has_src_to_path()`, with nothing connecting them --
`stream_url_to_file()` hands back a bare `str`:

```
data_fetch._has_src_to_path
  -> files.uris.stream_url_to_file -> str
    -> DRSFilesSource.realize_to
      -> fetch_drs_to_file            # knows the name, returns None
```

So file sources need some way to report a suggested name back up. I went with an optional
`metadata_out: Optional[dict]` out-parameter rather than giving `stream_url_to_file()` a
richer return type. There are eight call sites for it -- `data_fetch`,
`unpack_tar_gz_archive`, `sniff`, `tool_data`, `model/deferred`, `model/store`, plus
`uris` and `sources/util` themselves -- and on a release branch I'd rather be additive
than clean.

The one bit I'd point out to a reviewer: `metadata_out` rides on
`FilesSourceRuntimeContext` instead of being threaded through `_realize_to()`. That leaves
all 15 file source plugins alone -- only `realize_to()` (the ABC declaration plus the
single concrete `BaseFilesSource` implementation) and `_get_runtime_context()` grew a
parameter, and DRS is the only plugin that reads it.

An explicit `name` in the fetch request still wins over everything. A DRS object with no
usable name falls back to the URI basename exactly like before, and non-DRS URLs never
touch any of this -- `metadata_out` just stays empty.

### One side effect worth knowing about

The name isn't purely cosmetic. `upload_util.handle_upload()` does
`os.path.splitext(name)[1]` in its unsniffable-binary branch, so for content Galaxy can't
sniff, the extension on the DRS name now picks the datatype -- where a UUID, having no
extension at all, previously left it as generic `binary` with a "format cannot be
determined" warning. `is_extension_unsniffable_binary()` bounds that to datatypes already
registered as unsniffable binaries, so a remote name can't invent one, and it's the same
thing a plain `https://` upload has always done with its basename. I think it's the
behavior you'd want, but it's a real change beyond the name string, so I'd rather call it
out than have it turn up as a surprise. (The other `name` consumer in that function,
`uploaded_file_ext`, is dead -- `handle_uploaded_dataset_file_internal()` accepts it and
never reads it, so it isn't a second path here.)

### Deferred datasets are deliberately not covered

`_has_src_to_name()` handles deferred datasets and by design never resolves anything, so a
deferred DRS dataset still gets the UUID. Fixing that means a metadata-only DRS lookup
(a second HTTP request), a new method on the file source, and wiring file sources into a
function that currently only takes the item -- more than I want to put on `release_26.1`.
Happy to do it separately against `dev` if folks want it.

### Sanitizing the name

This is the part I'd most like eyes on. The name comes from a remote server and ends up
both as a dataset name and as an input to downstream filename construction, so
`sanitize_drs_name()` rejects anything that isn't a `str`, normalizes `\` to `/` and keeps
only the last path component (`../../etc/passwd` becomes `passwd`), drops non-printable
characters, strips whitespace, rejects `""` / `"."` / `".."`, and caps the result at 255
UTF-8 *bytes*. Anything rejected falls back to the URI basename.

The cap is on bytes rather than characters on purpose -- POSIX `NAME_MAX` is a byte limit,
so 255 emoji are a legal 255-character name that still overruns it the moment the name is
used to build a path. Worth saying that the path this replaces, `url.split("/")[-1]`, has
none of these protections: it happily yields `..` for a URL ending in `/..` and has no
length bound at all, so DRS naming ends up better defended than the URL naming sitting
next to it.

`str.isprintable()` is false for Unicode category `Cf`, so that filter also takes out bidi
overrides and zero-width characters -- the classic right-to-left-override `‮gnp.exe` trick
doesn't survive it. There are tests for both.

The non-`str` rejection isn't paranoia for its own sake -- nothing obliges a DRS server to
put a string in that field, and CFDE's metadata is already loose enough elsewhere that I
didn't want to assume field shapes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure a `drs` file source, then fetch `drs://cfde.cloud/000009a0-5b22-5be5-9217-a26b5c0b03c2`. Before this change the dataset is named `000009a0-5b22-5be5-9217-a26b5c0b03c2`; after, it's `L1000_LINCS_DCIC_PBIOA020_HCC515_24H_G06_BRD-K21448636_0.04uM.tsv.gz` (296040 bytes).
  2. Fetch `drs://cfde.cloud/1839b464-ea47-5aa5-8244-22b93c0d6206`, which resolves through a different DRS server and has only an `access_id` with no inline `access_url` fallback. Should be named `submission.zip` (548527 bytes).
  3. Fetch either URI with an explicit `name` in the request and confirm the request wins.

Both are public and unauthenticated. Note that `_get_access_info()` prefers `access_id`
over an inline `access_url`, so both of these go through the two-step
`/access/{access_id}` resolution in practice -- the inline-`access_url` branch is covered
by the unit tests rather than by either of these objects.

The first commit is the failing tests on their own, so it's easy to see the UUID naming
before the fix. Automated coverage is in `test/unit/app/tools/test_data_fetch.py` (both
access-method shapes, the precedence rules, sanitization, and the URI-basename fallback)
and `test/unit/files/test_drs.py` (the `metadata_out` channel and `sanitize_drs_name()`
directly). Everything is mocked -- no live hosts.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
