### PR TITLE
Add Crypt4GH End-to-End Support for Galaxy

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faBug, faChartBar, faInfoCircle, faKey, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import type { HDADetailed } from "@/api";
+import { useCrypt4ghRecrypt } from "@/composables/useCrypt4ghRecrypt";
 import { copy as sendToClipboard } from "@/utils/clipboard";
 import localize from "@/utils/localization";
 import { absPath, prependPath } from "@/utils/redirect";
@@ -45,6 +46,22 @@ const showVisualizations = computed(() => {
 const showRerun = computed(() => {
     return props.item.accessible && props.item.rerunnable && props.item.creating_job && props.item.state != "upload";
 });
+
+const isCrypt4gh = computed(() => {
+    const ext = props.item.extension;
+    return ext === "c4gh" || (ext != null && ext.endsWith(".c4gh"));
+});
+
+const showRecrypt = computed(() => {
+    return (
+        props.writable &&
+        isCrypt4gh.value &&
+        !props.item.purged &&
+        !["error", "failed_metadata", "upload", "noPermission"].includes(props.item.state)
+    );
+});
+
+const { recrypting, recrypt } = useCrypt4ghRecrypt();
 const reportErrorUrl = computed(() => {
     return prependPath(props.itemUrls.reportError!);
 });
@@ -88,6 +105,10 @@ function onVisualize() {
 
 function onRerun() {
     router.push(`/?job_id=${props.item.creating_job}`);
+}
+
+function onRecrypt() {
+    recrypt(props.item);
 }
 </script>
 
@@ -165,6 +186,18 @@ function onRerun() {
                     :href="rerunUrl"
                     @click.prevent.stop="onRerun">
                     <FontAwesomeIcon :icon="faRedo" />
+                </BButton>
+
+                <BButton
+                    v-if="showRecrypt"
+                    v-g-tooltip.hover
+                    class="recrypt-btn px-1"
+                    :title="recrypting ? 'Recrypting...' : 'Recrypt Crypt4GH-encrypted dataset for compute'"
+                    size="sm"
+                    variant="link"
+                    :disabled="recrypting"
+                    @click.prevent.stop="onRecrypt">
+                    <FontAwesomeIcon :icon="faKey" />
                 </BButton>
             </div>
         </div>

--- a/client/src/composables/useCrypt4ghRecrypt.ts
+++ b/client/src/composables/useCrypt4ghRecrypt.ts
@@ -1,0 +1,126 @@
+import axios from "axios";
+import { ref } from "vue";
+
+import type { HDADetailed } from "@/api";
+import { setAttributes } from "@/components/DatasetInformation/services";
+import { Toast } from "@/composables/toast";
+import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+/** Keys that the recryptor service returns in its response. */
+interface RecryptServiceResponse {
+    crypt4gh_header: string;
+    crypt4gh_compute_keypair_id: string;
+    crypt4gh_compute_keypair_expiration_date: string;
+}
+
+/** Fields sent to `setAttributes` to persist compute re-encryption metadata. */
+type Crypt4ghComputeAttributes = {
+    crypt4gh_compute_header: string;
+    crypt4gh_compute_keypair_id: string;
+    crypt4gh_compute_keypair_expiration_date: string;
+};
+
+/**
+ * Extracts the `metadata_crypt4gh_header` field from a dataset.
+ */
+function getCrypt4ghHeader(item: HDADetailed): string | undefined {
+    return (item as unknown as Record<string, unknown>)["metadata_crypt4gh_header"] as string | undefined;
+}
+
+/**
+ * Extracts the Crypt4GH recrypt service URL from the user's extra preferences.
+ *
+ * The port is stored under the `crypt4gh_recrypt_service|port` key inside the
+ * `extra_user_preferences` JSON string in the user store.
+ */
+function getRecryptServiceUrl(): string {
+    const userStore = useUserStore();
+    const prefs = userStore.currentPreferences as Record<string, unknown> | null;
+    const extraPrefsRaw = prefs?.["extra_user_preferences"];
+
+    if (!extraPrefsRaw || typeof extraPrefsRaw !== "string") {
+        throw new Error("No Crypt4GH recrypt service configured. Set the port in your user preferences.");
+    }
+
+    const extraPrefs = JSON.parse(extraPrefsRaw) as Record<string, string>;
+    const port = extraPrefs["crypt4gh_recrypt_service|port"];
+
+    if (!port) {
+        throw new Error("No Crypt4GH recrypt service port configured. Set the port in your user preferences.");
+    }
+
+    return `https://localhost:${port}/recrypt_header`;
+}
+
+/**
+ * Calls the external recryptor service to re-encrypt a Crypt4GH header for
+ * compute use. Returns the compute header and keypair metadata.
+ */
+async function fetchRecryptedHeader(crypt4ghHeader: string): Promise<Crypt4ghComputeAttributes> {
+    const serviceUrl = getRecryptServiceUrl();
+    const { data } = await axios.post<RecryptServiceResponse>(serviceUrl, {
+        crypt4gh_header: crypt4ghHeader,
+    });
+
+    return {
+        crypt4gh_compute_header: data.crypt4gh_header,
+        crypt4gh_compute_keypair_id: data.crypt4gh_compute_keypair_id,
+        crypt4gh_compute_keypair_expiration_date: data.crypt4gh_compute_keypair_expiration_date,
+    };
+}
+
+/**
+ * Composable that provides Crypt4GH recrypt functionality for a dataset.
+ *
+ * Encapsulates the full recrypt flow:
+ * 1. Read the stored Crypt4GH header from dataset metadata.
+ * 2. Call the external recryptor service to produce a compute header.
+ * 3. Persist the compute metadata via `setAttributes`.
+ * 4. Reload the current history so the UI reflects the new state.
+ *
+ * Exposes a `recrypting` ref for loading-state binding and a `recrypt` method
+ * that performs the operation with built-in error handling and toast feedback.
+ */
+export function useCrypt4ghRecrypt() {
+    const recrypting = ref(false);
+
+    async function recrypt(item: HDADetailed) {
+        if (recrypting.value) {
+            return;
+        }
+
+        const crypt4ghHeader = getCrypt4ghHeader(item);
+        if (!crypt4ghHeader) {
+            Toast.error("Dataset does not have a stored Crypt4GH header.", "Recrypt failed");
+            return;
+        }
+
+        recrypting.value = true;
+        try {
+            const computeAttributes = await fetchRecryptedHeader(crypt4ghHeader);
+
+            await setAttributes(
+                item.id,
+                {
+                    name: item.name,
+                    info: item.misc_info ?? "",
+                    ...computeAttributes,
+                },
+                "attributes",
+            );
+
+            const historyStore = useHistoryStore();
+            await historyStore.loadCurrentHistory();
+
+            Toast.success("Crypt4GH header re-encrypted for compute.");
+        } catch (err) {
+            Toast.error(errorMessageAsString(err, "Crypt4GH recrypt failed."), "Recrypt failed");
+        } finally {
+            recrypting.value = false;
+        }
+    }
+
+    return { recrypting, recrypt };
+}

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1254,6 +1254,19 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``crypt4gh_cleanup_failure_is_job_failure``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    When true, Crypt4GH plaintext cleanup failures on the compute side
+    are treated as job failures, preventing successful job completion
+    if plaintext staging artifacts cannot be removed.  Recommended for
+    sensitive deployments.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``datatypes_disable_auto``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -477,9 +477,14 @@
     process composes its named store with the default
     (``tool_source_database_connection``) store at runtime, with reads
     tried in declared order and writes always landing on the default.
-    Each entry takes a SQLAlchemy ``url`` and an optional ``read_only:
-    true`` flag. For SQLite connection-level read-only, use a SQLite
-    URI with ``mode=ro&uri=true``.
+    Each entry takes either a normal SQLAlchemy ``url`` or an
+    ``external_store_directory`` containing versioned publisher
+    bundles. Galaxy never consults manifests for a normal URL. For an
+    external directory it reads the sidecars and automatically selects
+    the newest cohort compatible with its store/source/index formats
+    and index schema. External stores are always read-only.
+    For SQLite connection-level read-only, use a SQLite URI with
+    ``mode=ro&uri=true``.
     For details see
     https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
 :Default: ``None``
@@ -1218,6 +1223,35 @@
     compressed datatypes will be unpacked before sniffing.
 :Default: ``true``
 :Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_crypt4gh_transparent_staging``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enable transparent datatype matching for Crypt4GH-wrapped
+    datasets. When enabled, wrapped datatypes (for example
+    ``fastqsanger.c4gh``) can match tool input formats that accept
+    their inner datatype, assuming Crypt4GH staging/decryption support
+    is configured for job execution.
+:Default: ``false``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``crypt4gh_reencryption_service_url``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Base URL of the runner-side Crypt4GH re-encryption service.  When
+    ``enable_crypt4gh_transparent_staging`` is true this service is
+    called during job pre/post-processing to decrypt inputs and
+    encrypt outputs.  The service is responsible for all private-key
+    operations; Galaxy never handles private keys or plaintext payload
+    bytes. Example: ``http://127.0.0.1:47419``
+:Default: ``None``
+:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -93,6 +93,7 @@ from galaxy.util import (
     galaxy_directory,
     now,
 )
+from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
 from galaxy.util.custom_logging import get_logger
 from galaxy.workflow.completion_hooks import WorkflowCompletionHookRegistry
 
@@ -264,6 +265,11 @@ def change_datatype(
     if datatype == "auto":
         path = dataset_instance.dataset.get_file_name()
         datatype = sniff.guess_ext(path, datatypes_registry.sniff_order)
+        datatype = preserve_crypt4gh_inner_file_ext(
+            datatype,
+            current_ext=dataset_instance.extension,
+            metadata_inner_ext=getattr(dataset_instance.metadata, "crypt4gh_inner_ext", None),
+        )
     datatypes_registry.change_datatype(dataset_instance, datatype)
     sa_session.commit()
     set_metadata(hda_manager, ldda_manager, sa_session, dataset_id, model_class)

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -97,6 +97,7 @@ class GalaxyAppConfigurationAttributes:
     sniff_compressed_dynamic_datatypes_default: bool
     enable_crypt4gh_transparent_staging: bool
     crypt4gh_reencryption_service_url: str | None
+    crypt4gh_cleanup_failure_is_job_failure: bool
     datatypes_disable_auto: bool
     visualization_plugins_directory: str
     tour_config_dir: str

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -95,6 +95,8 @@ class GalaxyAppConfigurationAttributes:
     len_file_path: str
     datatypes_config_file: str
     sniff_compressed_dynamic_datatypes_default: bool
+    enable_crypt4gh_transparent_staging: bool
+    crypt4gh_reencryption_service_url: str | None
     datatypes_disable_auto: bool
     visualization_plugins_directory: str
     tour_config_dir: str

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -620,11 +620,13 @@ galaxy:
   # (``tool_source_database_connection``) store at runtime, with reads
   # tried in declared order and writes always landing on the default.
   # Each entry takes either a normal SQLAlchemy ``url`` or an
-  # ``external_store_directory`` of versioned publisher bundles. Manifests
-  # are ignored for normal URL stores. Galaxy automatically selects the
-  # newest manifest-compatible bundle from an external directory, which is
-  # always read-only. For an explicit SQLite URL, use ``mode=ro&uri=true``
-  # when connection-level read-only behavior is wanted.
+  # ``external_store_directory`` containing versioned publisher bundles.
+  # Galaxy never consults manifests for a normal URL. For an external
+  # directory it reads the sidecars and automatically selects the newest
+  # cohort compatible with its store/source/index formats and index
+  # schema. External stores are always read-only.
+  # For SQLite connection-level read-only, use a SQLite URI with
+  # ``mode=ro&uri=true``.
   # For details see
   # https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
   #tool_source_stores: null
@@ -980,6 +982,21 @@ galaxy:
   # datatypes_conf.xml file. With this option set to false the
   # compressed datatypes will be unpacked before sniffing.
   #sniff_compressed_dynamic_datatypes_default: true
+
+  # Enable transparent datatype matching for Crypt4GH-wrapped datasets.
+  # When enabled, wrapped datatypes (for example ``fastqsanger.c4gh``)
+  # can match tool input formats that accept their inner datatype,
+  # assuming Crypt4GH staging/decryption support is configured for job
+  # execution.
+  #enable_crypt4gh_transparent_staging: false
+
+  # Base URL of the runner-side Crypt4GH re-encryption service.  When
+  # ``enable_crypt4gh_transparent_staging`` is true this service is
+  # called during job pre/post-processing to decrypt inputs and encrypt
+  # outputs.  The service is responsible for all private-key operations;
+  # Galaxy never handles private keys or plaintext payload bytes.
+  # Example: ``http://127.0.0.1:47419``
+  #crypt4gh_reencryption_service_url: null
 
   # Disable the 'Auto-detect' option for file uploads
   #datatypes_disable_auto: false
@@ -3434,3 +3451,4 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
+

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -998,6 +998,12 @@ galaxy:
   # Example: ``http://127.0.0.1:47419``
   #crypt4gh_reencryption_service_url: null
 
+  # When true, Crypt4GH plaintext cleanup failures on the compute side
+  # are treated as job failures, preventing successful job completion if
+  # plaintext staging artifacts cannot be removed.  Recommended for
+  # sensitive deployments.
+  #crypt4gh_cleanup_failure_is_job_failure: false
+
   # Disable the 'Auto-detect' option for file uploads
   #datatypes_disable_auto: false
 

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -179,6 +179,15 @@ preferences:
               required: False
               value: False
 
+    crypt4gh_recrypt_service:
+        description: Crypt4GH recryption service running on your machine
+        inputs:
+            - name: port
+              label: Port number of your local Service instance
+              type: text
+              required: False
+              value: "61357"
+
     # Used in file_sources_conf.yml
     elabftw:
         description: Your eLabFTW Integration Settings

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -897,6 +897,28 @@ mapping:
           With this option set to false the compressed datatypes will be unpacked
           before sniffing.
 
+      enable_crypt4gh_transparent_staging:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable transparent datatype matching for Crypt4GH-wrapped datasets.
+          When enabled, wrapped datatypes (for example ``fastqsanger.c4gh``)
+          can match tool input formats that accept their inner datatype, assuming
+          Crypt4GH staging/decryption support is configured for job execution.
+
+      crypt4gh_reencryption_service_url:
+        type: str
+        default: null
+        required: false
+        desc: |
+          Base URL of the runner-side Crypt4GH re-encryption service.  When
+          ``enable_crypt4gh_transparent_staging`` is true this service is
+          called during job pre/post-processing to decrypt inputs and encrypt
+          outputs.  The service is responsible for all private-key operations;
+          Galaxy never handles private keys or plaintext payload bytes.
+          Example: ``http://127.0.0.1:47419``
+
       datatypes_disable_auto:
         type: bool
         default: false

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -919,6 +919,16 @@ mapping:
           Galaxy never handles private keys or plaintext payload bytes.
           Example: ``http://127.0.0.1:47419``
 
+      crypt4gh_cleanup_failure_is_job_failure:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          When true, Crypt4GH plaintext cleanup failures on the compute side
+          are treated as job failures, preventing successful job completion
+          if plaintext staging artifacts cannot be removed.  Recommended for
+          sensitive deployments.
+
       datatypes_disable_auto:
         type: bool
         default: false

--- a/lib/galaxy/datatypes/crypt4gh.py
+++ b/lib/galaxy/datatypes/crypt4gh.py
@@ -100,7 +100,7 @@ class Crypt4GH(Binary):
         "node, in ISO 8601 format (retained for both analysis input and output "
         "datasets).",
         readonly=False,
-        visible=False,
+        visible=True,
         optional=True,
         no_value="",
     )
@@ -172,9 +172,7 @@ class Crypt4GH(Binary):
         known, the wrapper can match tool inputs that accept the inner
         format.  Otherwise, only direct type matches are considered.
         """
-        datatype_classes = tuple(
-            datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes
-        )
+        datatype_classes = tuple(datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes)
         if datatype_classes and isinstance(self, datatype_classes):
             return True
         inner_datatype = self.crypt4gh_inner_datatype

--- a/lib/galaxy/datatypes/crypt4gh.py
+++ b/lib/galaxy/datatypes/crypt4gh.py
@@ -213,7 +213,6 @@ class Crypt4GH(Binary):
         headers["Content-Length"] = str(file_size)
         headers["content-type"] = "application/octet-stream"
         headers["Content-Disposition"] = self.download_content_disposition(data, to_ext, **kwd)
-        
 
         return open(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb"), headers
 

--- a/lib/galaxy/datatypes/crypt4gh.py
+++ b/lib/galaxy/datatypes/crypt4gh.py
@@ -15,6 +15,7 @@ Design principles
 """
 
 import base64
+import logging
 import os
 from datetime import datetime
 from inspect import isclass
@@ -23,6 +24,7 @@ from typing import Any
 from galaxy.datatypes.binary import Binary
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.protocols import DatasetProtocol
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util.crypt4gh import (
     check_crypt4gh,
     CRYPT4GH_FILE_EXT,
@@ -31,6 +33,8 @@ from galaxy.util.crypt4gh import (
     unwrap_crypt4gh_file_ext,
     wrap_crypt4gh_file_ext,
 )
+
+log = logging.getLogger(__name__)
 
 
 class Crypt4GH(Binary):
@@ -180,10 +184,70 @@ class Crypt4GH(Binary):
             return inner_datatype.matches_any(target_datatypes)
         return False
 
+    # --- Download / archive -------------------------------------------------
+
+    def is_archive_download(self, datatypes_registry, extension) -> bool:
+        """Return ``True`` for Crypt4GH datasets so downloads are streamed.
+
+        Crypt4GH datasets may have encrypted extra files that must be
+        included in a zip archive.  Since :meth:`is_archive_download`
+        cannot inspect the dataset instance, we return ``True`` for all
+        Crypt4GH extensions and let :meth:`_serve_file_download` decide
+        whether to zip (extra files present) or serve the primary file
+        directly.
+        """
+        if is_crypt4gh_file_ext(extension):
+            return True
+        return super().is_archive_download(datatypes_registry, extension)
+
+    def _serve_file_download(self, headers, data, trans, to_ext, file_size, **kwd):
+        """Serve a Crypt4GH dataset download.
+
+        If the dataset has extra files, produce a zip archive containing
+        the primary encrypted file and all encrypted extra files.
+        Otherwise, serve the primary file directly as a regular download.
+        """
+        if self._has_extra_files(data):
+            return self._archive_composite_dataset(trans, data, headers, do_action=kwd.get("do_action", "zip"))
+        # No extra files — serve the primary file directly.
+        headers["Content-Length"] = str(file_size)
+        headers["content-type"] = "application/octet-stream"
+        headers["Content-Disposition"] = self.download_content_disposition(data, to_ext, **kwd)
+        
+
+        return open(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb"), headers
+
+    def _archive_main_file(self, archive, display_name: str, data_filename: str) -> tuple[bool, str, str]:
+        """Add the primary Crypt4GH file to the download archive.
+
+        Unlike the default implementation which writes the file as
+        ``{display_name}.html``, this writes it with its actual encrypted
+        extension (e.g. ``fastqsanger.c4gh``).
+        """
+        error, msg, messagetype = False, "", ""
+        archname = f"{display_name}.{self.file_ext}"
+        try:
+            archive.write(data_filename, archname)
+        except OSError:
+            error = True
+            log.exception("Unable to add Crypt4GH primary file %s to download archive", data_filename)
+            msg = "Unable to create archive for download, please report this error"
+            messagetype = "error"
+        return error, msg, messagetype
+
+    def _has_extra_files(self, dataset) -> bool:
+        """Check if *dataset* has a non-empty extra files directory."""
+        extra_files_path = getattr(dataset, "extra_files_path", None)
+        if not extra_files_path or not os.path.isdir(extra_files_path):
+            return False
+        for _root, _dirs, files in os.walk(extra_files_path):
+            if files:
+                return True
+        return False
+
     # --- Internal helpers ---------------------------------------------------
 
     def _infer_inner_ext(self, dataset: DatasetProtocol) -> str:
-        """Determine the inner extension from the datatype, dataset, or filename."""
         # 1. Typed wrapper extension (e.g. fastqsanger.c4gh -> fastqsanger)
         dataset_ext = unwrap_crypt4gh_file_ext(self.file_ext)
         if dataset_ext is not None:

--- a/lib/galaxy/datatypes/crypt4gh.py
+++ b/lib/galaxy/datatypes/crypt4gh.py
@@ -1,0 +1,235 @@
+"""Crypt4GH wrapper datatype for Galaxy.
+
+This module defines the :class:`Crypt4GH` datatype and the
+:func:`build_crypt4gh_datatype` factory used by the registry to
+dynamically create ``inner_ext.c4gh`` wrapper datatypes.
+
+Design principles
+-----------------
+* The datatype **never** decrypts or inspects plaintext payload data.
+* ``set_meta`` reads only the public Crypt4GH header and stores it
+  Base64-encoded, along with the inferred inner extension.
+* ``matches_any`` resolves against the inner datatype when transparent
+  staging is enabled, allowing Crypt4GH-wrapped inputs to match tools
+  that accept the inner format.
+"""
+
+import base64
+import os
+from datetime import datetime
+from inspect import isclass
+from typing import Any
+
+from galaxy.datatypes.binary import Binary
+from galaxy.datatypes.metadata import MetadataElement
+from galaxy.datatypes.protocols import DatasetProtocol
+from galaxy.util.crypt4gh import (
+    check_crypt4gh,
+    CRYPT4GH_FILE_EXT,
+    is_crypt4gh_file_ext,
+    read_crypt4gh_header,
+    unwrap_crypt4gh_file_ext,
+    wrap_crypt4gh_file_ext,
+)
+
+
+class Crypt4GH(Binary):
+    """Generic Crypt4GH wrapper datatype (``c4gh`` extension).
+
+    Typed wrappers (e.g. ``fastqsanger.c4gh``) are created dynamically
+    by :func:`build_crypt4gh_datatype` and carry a reference to their
+    inner datatype instance for transparent matching.
+    """
+
+    file_ext = CRYPT4GH_FILE_EXT
+    display_behavior = "download"
+
+    # Set by the registry on all Crypt4GH datatypes (generic and typed).
+    transparent_staging_enabled: bool = False
+
+    # Set only on typed wrappers created by build_crypt4gh_datatype.
+    crypt4gh_inner_datatype: Any | None = None
+
+    # --- Metadata elements --------------------------------------------------
+
+    MetadataElement(
+        name="crypt4gh_header",
+        default="",
+        desc="Crypt4GH header (Base64-encoded)",
+        readonly=True,
+        visible=True,
+        optional=False,
+        no_value="",
+    )
+
+    MetadataElement(
+        name="crypt4gh_compute_header",
+        default="",
+        desc="Crypt4GH header (Base64-encoded) for the compute node, if available.  This is used to re-encrypt the dataset for the compute node.",
+        readonly=False,
+        visible=True,
+        optional=True,
+        no_value="",
+    )
+
+    MetadataElement(
+        name="crypt4gh_inner_ext",
+        default="data",
+        desc="Wrapped datatype extension",
+        readonly=True,
+        visible=True,
+        optional=True,
+        no_value="data",
+    )
+
+    MetadataElement(
+        name="crypt4gh_compute_keypair_id",
+        default="",
+        desc="Unique identifier of the corresponding keypair at the compute node "
+        "(retained for both analysis input and output datasets).",
+        readonly=False,
+        visible=False,
+        optional=True,
+        no_value="",
+    )
+
+    MetadataElement(
+        name="crypt4gh_compute_keypair_expiration_date",
+        default="",
+        desc="Date and time of expiration of the corresponding keypair at the compute "
+        "node, in ISO 8601 format (retained for both analysis input and output "
+        "datasets).",
+        readonly=False,
+        visible=False,
+        optional=True,
+        no_value="",
+    )
+
+    # --- Sniffing -----------------------------------------------------------
+
+    def sniff(self, filename: str) -> bool:
+        """Return True if *filename* is a Crypt4GH file belonging to this datatype.
+
+        For the generic ``c4gh`` wrapper, the magic-byte header check is
+        sufficient.  For typed wrappers (e.g. ``fastqsanger.c4gh``), the
+        original filename must also end with the expected inner extension
+        so that a generic file is not mis-attributed to a specific type.
+        """
+        if not check_crypt4gh(filename):
+            return False
+        if self.file_ext == CRYPT4GH_FILE_EXT:
+            return True
+        basename = os.path.basename(filename)
+        unwrapped_name = unwrap_crypt4gh_file_ext(basename)
+        if unwrapped_name is None:
+            return False
+        inner_ext = unwrap_crypt4gh_file_ext(self.file_ext)
+        return inner_ext is not None and unwrapped_name.endswith(f".{inner_ext}")
+
+    # --- Metadata -----------------------------------------------------------
+
+    def set_meta(
+        self,
+        dataset: DatasetProtocol,
+        overwrite: bool = True,
+        crypt4gh_compute_keypair_id: str | None = None,
+        crypt4gh_compute_keypair_expiration_date: datetime | None = None,
+        **kwd,
+    ) -> None:
+        """Read the public Crypt4GH header and store metadata.
+
+        This method **never** reads or decrypts payload data.  It only
+        parses the header portion of the file.
+        """
+        header = read_crypt4gh_header(dataset.get_file_name())
+        if overwrite or not dataset.metadata.element_is_set("crypt4gh_header"):
+            dataset.metadata.crypt4gh_header = base64.b64encode(header).decode("ascii")
+        dataset.metadata.crypt4gh_inner_ext = self._infer_inner_ext(dataset)
+        if crypt4gh_compute_keypair_id is not None:
+            dataset.metadata.crypt4gh_compute_keypair_id = crypt4gh_compute_keypair_id
+        if crypt4gh_compute_keypair_expiration_date is not None:
+            dataset.metadata.crypt4gh_compute_keypair_expiration_date = (
+                crypt4gh_compute_keypair_expiration_date.isoformat()
+            )
+
+    def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
+        if not dataset.dataset.purged:
+            dataset.peek = f"Encrypted Crypt4GH dataset wrapping '{self._infer_inner_ext(dataset)}'"
+            dataset.blurb = "encrypted"
+        else:
+            dataset.peek = "file does not exist"
+            dataset.blurb = "file purged from disk"
+
+    def display_peek(self, dataset: DatasetProtocol) -> str:
+        return dataset.peek or "Encrypted Crypt4GH dataset"
+
+    # --- Matching -----------------------------------------------------------
+
+    def matches_any(self, target_datatypes: list[Any]) -> bool:
+        """Check if this datatype matches any of *target_datatypes*.
+
+        When transparent staging is enabled and an inner datatype is
+        known, the wrapper can match tool inputs that accept the inner
+        format.  Otherwise, only direct type matches are considered.
+        """
+        datatype_classes = tuple(
+            datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes
+        )
+        if datatype_classes and isinstance(self, datatype_classes):
+            return True
+        inner_datatype = self.crypt4gh_inner_datatype
+        if self.transparent_staging_enabled and inner_datatype is not None:
+            return inner_datatype.matches_any(target_datatypes)
+        return False
+
+    # --- Internal helpers ---------------------------------------------------
+
+    def _infer_inner_ext(self, dataset: DatasetProtocol) -> str:
+        """Determine the inner extension from the datatype, dataset, or filename."""
+        # 1. Typed wrapper extension (e.g. fastqsanger.c4gh -> fastqsanger)
+        dataset_ext = unwrap_crypt4gh_file_ext(self.file_ext)
+        if dataset_ext is not None:
+            return dataset_ext
+        # 2. Dataset's own extension
+        dataset_ext = unwrap_crypt4gh_file_ext(dataset.extension)
+        if dataset_ext is not None:
+            return dataset_ext
+        # 3. Original upload filename
+        created_from_basename = getattr(dataset.dataset, "created_from_basename", None)
+        if created_from_basename:
+            unwrapped_name = unwrap_crypt4gh_file_ext(created_from_basename)
+            if unwrapped_name is not None:
+                return unwrapped_name.rsplit(".", 1)[-1]
+        return "data"
+
+
+def build_crypt4gh_datatype(inner_datatype, transparent_staging_enabled: bool):
+    """Create a typed Crypt4GH wrapper datatype instance for *inner_datatype*.
+
+    The resulting class inherits from :class:`Crypt4GH` and carries the
+    inner datatype instance as ``crypt4gh_inner_datatype`` so that
+    ``matches_any`` can delegate to it when transparent staging is
+    enabled.
+    """
+    datatype_class = type(
+        f"{inner_datatype.__class__.__name__}Crypt4gh",
+        (Crypt4GH,),
+        {
+            "file_ext": f"{inner_datatype.file_ext}.{CRYPT4GH_FILE_EXT}",
+            "crypt4gh_inner_datatype": inner_datatype,
+            "transparent_staging_enabled": transparent_staging_enabled,
+            "edam_format": getattr(inner_datatype, "edam_format", Crypt4GH.edam_format),
+            "edam_data": getattr(inner_datatype, "edam_data", Crypt4GH.edam_data),
+        },
+    )
+    return datatype_class()
+
+
+__all__ = (
+    "CRYPT4GH_FILE_EXT",
+    "Crypt4GH",
+    "build_crypt4gh_datatype",
+    "is_crypt4gh_file_ext",
+    "unwrap_crypt4gh_file_ext",
+    "wrap_crypt4gh_file_ext",
+)

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -504,17 +504,10 @@ class Registry:
         """
         transparent_staging_enabled = self.enable_crypt4gh_transparent_staging
         existing_datatypes = list(self.datatypes_by_extension.items())
-        for extension, datatype in existing_datatypes:
+        for extension, _datatype in existing_datatypes:
             if extension == CRYPT4GH_FILE_EXT or is_crypt4gh_file_ext(extension):
                 continue
-            wrapped_extension = wrap_crypt4gh_file_ext(extension)
-            if wrapped_extension in self.datatypes_by_extension:
-                continue
-            wrapped_datatype = build_crypt4gh_datatype(datatype, transparent_staging_enabled)
-            self.datatypes_by_extension[wrapped_extension] = wrapped_datatype
-            self.datatypes_by_suffix_inferences[wrapped_extension] = wrapped_datatype
-            self.mimetypes_by_extension[wrapped_extension] = wrapped_datatype.get_mime()
-            self.log.debug("Dynamically registered crypt4gh datatype: %s", wrapped_extension)
+            self.get_or_create_crypt4gh_datatype(extension, transparent_staging_enabled=transparent_staging_enabled)
 
         if CRYPT4GH_FILE_EXT not in self.datatypes_by_extension:
             generic_crypt4gh_datatype = Crypt4GH()
@@ -523,6 +516,30 @@ class Registry:
             self.datatypes_by_suffix_inferences[CRYPT4GH_FILE_EXT] = generic_crypt4gh_datatype
             self.mimetypes_by_extension[CRYPT4GH_FILE_EXT] = generic_crypt4gh_datatype.get_mime()
             self.log.debug("Dynamically registered crypt4gh datatype: %s", CRYPT4GH_FILE_EXT)
+
+    def get_or_create_crypt4gh_datatype(
+        self, base_ext: str, *, transparent_staging_enabled: bool | None = None
+    ) -> Any | None:
+        """Create and register a Crypt4GH wrapper datatype for *base_ext* if needed."""
+        if transparent_staging_enabled is None:
+            transparent_staging_enabled = self.enable_crypt4gh_transparent_staging
+        transparent_staging_enabled = bool(transparent_staging_enabled)
+
+        wrapped_extension = wrap_crypt4gh_file_ext(base_ext)
+        existing_datatype = self.datatypes_by_extension.get(wrapped_extension)
+        if existing_datatype is not None:
+            return existing_datatype
+
+        inner_datatype = self.get_datatype_by_extension(base_ext)
+        if inner_datatype is None:
+            return None
+
+        wrapped_datatype = build_crypt4gh_datatype(inner_datatype, transparent_staging_enabled)
+        self.datatypes_by_extension[wrapped_extension] = wrapped_datatype
+        self.datatypes_by_suffix_inferences[wrapped_extension] = wrapped_datatype
+        self.mimetypes_by_extension[wrapped_extension] = wrapped_datatype.get_mime()
+        self.log.debug("Dynamically registered crypt4gh datatype: %s", wrapped_extension)
+        return wrapped_datatype
 
     def _load_build_sites(self, root):
         def load_build_site(build_site_config):

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -44,6 +44,14 @@ from . import (
     tracks,
     xml,
 )
+from .crypt4gh import (
+    build_crypt4gh_datatype,
+    Crypt4GH,
+    CRYPT4GH_FILE_EXT,
+    is_crypt4gh_file_ext,
+    unwrap_crypt4gh_file_ext,
+    wrap_crypt4gh_file_ext,
+)
 from .display_applications.application import DisplayApplication
 
 if TYPE_CHECKING:
@@ -126,6 +134,9 @@ class Registry:
         self.build_sites = {}
         self.display_sites = {}
         self.legacy_build_sites = {}
+        self.enable_crypt4gh_transparent_staging = (
+            getattr(config, "enable_crypt4gh_transparent_staging", False) if config is not None else False
+        )
 
     def load_datatypes(
         self,
@@ -163,6 +174,9 @@ class Registry:
                 root = config
             registration = root.find("registration")
             assert registration is not None
+            transparent_staging_attr = registration.get("crypt4gh_transparent_staging")
+            if transparent_staging_attr is not None:
+                self.enable_crypt4gh_transparent_staging = galaxy.util.string_as_bool(transparent_staging_attr)
             # Set default paths defined in local datatypes_conf.xml.
             if use_converters:
                 if not self.converters_path:
@@ -461,6 +475,7 @@ class Registry:
                 self._load_build_sites(root)
 
         self.set_default_values()
+        self._register_crypt4gh_datatypes()
 
         def append_to_sniff_order() -> None:
             sniff_order_classes = {type(_) for _ in self.sniff_order}
@@ -478,6 +493,36 @@ class Registry:
                     self.sniff_order.append(datatype)
 
         append_to_sniff_order()
+
+    def _register_crypt4gh_datatypes(self) -> None:
+        """Dynamically register ``inner_ext.c4gh`` wrapper datatypes.
+
+        For every datatype already in the registry (except existing
+        Crypt4GH wrappers), create a typed wrapper via
+        :func:`build_crypt4gh_datatype`.  Also ensure the generic
+        ``c4gh`` datatype is always available.
+        """
+        transparent_staging_enabled = self.enable_crypt4gh_transparent_staging
+        existing_datatypes = list(self.datatypes_by_extension.items())
+        for extension, datatype in existing_datatypes:
+            if extension == CRYPT4GH_FILE_EXT or is_crypt4gh_file_ext(extension):
+                continue
+            wrapped_extension = wrap_crypt4gh_file_ext(extension)
+            if wrapped_extension in self.datatypes_by_extension:
+                continue
+            wrapped_datatype = build_crypt4gh_datatype(datatype, transparent_staging_enabled)
+            self.datatypes_by_extension[wrapped_extension] = wrapped_datatype
+            self.datatypes_by_suffix_inferences[wrapped_extension] = wrapped_datatype
+            self.mimetypes_by_extension[wrapped_extension] = wrapped_datatype.get_mime()
+            self.log.debug("Dynamically registered crypt4gh datatype: %s", wrapped_extension)
+
+        if CRYPT4GH_FILE_EXT not in self.datatypes_by_extension:
+            generic_crypt4gh_datatype = Crypt4GH()
+            generic_crypt4gh_datatype.transparent_staging_enabled = transparent_staging_enabled
+            self.datatypes_by_extension[CRYPT4GH_FILE_EXT] = generic_crypt4gh_datatype
+            self.datatypes_by_suffix_inferences[CRYPT4GH_FILE_EXT] = generic_crypt4gh_datatype
+            self.mimetypes_by_extension[CRYPT4GH_FILE_EXT] = generic_crypt4gh_datatype.get_mime()
+            self.log.debug("Dynamically registered crypt4gh datatype: %s", CRYPT4GH_FILE_EXT)
 
     def _load_build_sites(self, root):
         def load_build_site(build_site_config):
@@ -607,8 +652,19 @@ class Registry:
                                     self.sniffer_elems.append(elem)
 
     def get_datatype_from_filename(self, name):
-        max_extension_parts = 3
         generic_datatype_instance = self.get_datatype_by_extension("data")
+        # Check for Crypt4GH wrapper suffix first (e.g. "reads.fastq.c4gh").
+        if (inner_name := unwrap_crypt4gh_file_ext(name)) is not None:
+            if "." not in inner_name:
+                return self.get_datatype_by_extension(CRYPT4GH_FILE_EXT) or generic_datatype_instance
+            inner_datatype = self.get_datatype_from_filename(inner_name)
+            wrapped_extension = wrap_crypt4gh_file_ext(inner_datatype.file_ext)
+            return self.datatypes_by_extension.get(
+                wrapped_extension,
+                self.get_datatype_by_extension(CRYPT4GH_FILE_EXT) or generic_datatype_instance,
+            )
+
+        max_extension_parts = 3
         if "." not in name:
             return generic_datatype_instance
         extension_parts = name.rsplit(".", max_extension_parts)[1:]
@@ -1040,7 +1096,7 @@ class Registry:
         if not self._registry_xml_string:
             registry_string_template = Template("""<?xml version="1.0"?>
             <datatypes>
-              <registration converters_path="$converters_path" display_path="$display_path">
+              <registration converters_path="$converters_path" display_path="$display_path" crypt4gh_transparent_staging="$crypt4gh_transparent_staging">
                 $datatype_elems
               </registration>
               <sniffers>
@@ -1055,6 +1111,7 @@ class Registry:
             self._registry_xml_string = registry_string_template.substitute(
                 converters_path=converters_path,
                 display_path=display_path,
+                crypt4gh_transparent_staging=str(self.enable_crypt4gh_transparent_staging).lower(),
                 datatype_elems=datatype_elems,
                 sniffer_elems=sniffer_elems,
             )
@@ -1103,10 +1160,16 @@ def upload_warning(template: Template | None, auto_compressed_type: str | None =
     return template.safe_substitute(template_args)
 
 
-def example_datatype_registry_for_sample(sniff_compressed_dynamic_datatypes_default=True):
+def example_datatype_registry_for_sample(
+    sniff_compressed_dynamic_datatypes_default=True,
+    enable_crypt4gh_transparent_staging=False,
+):
     galaxy_dir = galaxy.util.galaxy_directory()
     sample_conf = os.path.join(galaxy_dir, "lib", "galaxy", "config", "sample", "datatypes_conf.xml.sample")
-    config = Bunch(sniff_compressed_dynamic_datatypes_default=sniff_compressed_dynamic_datatypes_default)
+    config = Bunch(
+        sniff_compressed_dynamic_datatypes_default=sniff_compressed_dynamic_datatypes_default,
+        enable_crypt4gh_transparent_staging=enable_crypt4gh_transparent_staging,
+    )
     datatypes_registry = Registry(config)
     datatypes_registry.load_datatypes(root_dir=galaxy_dir, config=sample_conf)
     return datatypes_registry

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -979,10 +979,20 @@ class Registry:
         if ext not in self._converters_by_datatype:
             converters = {}
             source_datatype = type(self.get_datatype_by_extension(ext))
+            inner_ext = unwrap_crypt4gh_file_ext(ext)
             for ext2, converters_dict in self.datatype_converters.items():
                 converter_datatype = type(self.get_datatype_by_extension(ext2))
                 if issubclass(source_datatype, converter_datatype):
                     converters.update({k: v for k, v in converters_dict.items() if k != ext})
+                elif inner_ext is not None and ext2 == inner_ext:
+                    # A converter registered for the inner datatype (e.g. sam -> bam)
+                    # also serves the Crypt4GH-wrapped variant (sam.c4gh -> bam.c4gh).
+                    for target_ext, converter in converters_dict.items():
+                        if target_ext == ext:
+                            continue
+                        wrapped_target = wrap_crypt4gh_file_ext(target_ext)
+                        if wrapped_target != ext and wrapped_target in self.datatypes_by_extension:
+                            converters[wrapped_target] = converter
             # Ensure ext-level converters are present
             if ext in self.datatype_converters.keys():
                 converters.update(self.datatype_converters[ext])

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -37,6 +37,12 @@ from galaxy.util.checkers import (
     COMPRESSION_CHECK_FUNCTIONS,
     is_tar,
 )
+from galaxy.util.crypt4gh import (
+    check_crypt4gh,
+    infer_crypt4gh_file_ext,
+    is_crypt4gh_file_ext,
+    wrap_crypt4gh_file_ext,
+)
 from galaxy.util.path import StrPath
 
 try:
@@ -591,6 +597,8 @@ def guess_ext(fname_or_file_prefix: Union[str, "FilePrefix"], sniff_order, is_bi
 
 
 def guess_ext_from_file_name(fname, registry, requested_ext="auto"):
+    if is_crypt4gh_file_ext(fname):
+        return infer_crypt4gh_file_ext(fname, registry, requested_ext=requested_ext)
     if requested_ext != "auto":
         return requested_ext
     return registry.get_datatype_from_filename(fname).file_ext
@@ -910,6 +918,7 @@ def handle_uploaded_dataset_file_internal(
     check_content: bool = True,
     is_binary: bool | None = None,
     uploaded_file_ext: str | None = None,
+    uploaded_filename: str | None = None,
     convert_to_posix_lines: bool | None = None,
     convert_spaces_to_tabs: bool | None = None,
 ) -> HandleUploadedDatasetFileInternalResponse:
@@ -932,7 +941,24 @@ def handle_uploaded_dataset_file_internal(
 
         is_binary = file_prefix.binary
         guessed_ext = ext
-        if ext in AUTO_DETECT_EXTENSIONS:
+        is_crypt4gh_upload = check_crypt4gh(converted_path)
+        if is_crypt4gh_upload:
+            if ext in AUTO_DETECT_EXTENSIONS:
+                # User didn't select a type — infer inner type from filename.
+                # Prefer the full original filename so multi-part extensions
+                # like ``somename.bam.c4gh`` are correctly unwrapped.
+                upload_name = uploaded_filename or file_prefix.filename or (f"x.{uploaded_file_ext}" if uploaded_file_ext else None)
+                if upload_name is None:
+                    upload_name = ""
+                guessed_ext = infer_crypt4gh_file_ext(
+                    upload_name,
+                    datatypes_registry,
+                    requested_ext=ext,
+                )
+            else:
+                # User selected a type — wrap it with crypt4gh.
+                guessed_ext = wrap_crypt4gh_file_ext(ext)
+        elif ext in AUTO_DETECT_EXTENSIONS:
             # TODO: skip this if we haven't actually converted the dataset
             guessed_ext = guess_ext(
                 converted_path,
@@ -940,7 +966,7 @@ def handle_uploaded_dataset_file_internal(
                 auto_decompress=file_prefix.auto_decompress,
             )
 
-        if not is_binary and not is_compressed and (convert_to_posix_lines or convert_spaces_to_tabs):
+        if not is_binary and not is_compressed and not is_crypt4gh_upload and (convert_to_posix_lines or convert_spaces_to_tabs):
             # Convert universal line endings to Posix line endings, spaces to tabs (if desired)
             convert_fxn = convert_function(convert_to_posix_lines, convert_spaces_to_tabs)
             line_count, _converted_path, converted_newlines, converted_spaces = convert_fxn(
@@ -951,7 +977,7 @@ def handle_uploaded_dataset_file_internal(
                     os.unlink(converted_path)
                 assert _converted_path
                 converted_path = _converted_path
-            if ext in AUTO_DETECT_EXTENSIONS:
+            if ext in AUTO_DETECT_EXTENSIONS and not is_crypt4gh_upload:
                 ext = guess_ext(converted_path, sniff_order=datatypes_registry.sniff_order)
         else:
             ext = guessed_ext

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -947,7 +947,11 @@ def handle_uploaded_dataset_file_internal(
                 # User didn't select a type — infer inner type from filename.
                 # Prefer the full original filename so multi-part extensions
                 # like ``somename.bam.c4gh`` are correctly unwrapped.
-                upload_name = uploaded_filename or file_prefix.filename or (f"x.{uploaded_file_ext}" if uploaded_file_ext else None)
+                upload_name = (
+                    uploaded_filename
+                    or file_prefix.filename
+                    or (f"x.{uploaded_file_ext}" if uploaded_file_ext else None)
+                )
                 if upload_name is None:
                     upload_name = ""
                 guessed_ext = infer_crypt4gh_file_ext(
@@ -966,7 +970,12 @@ def handle_uploaded_dataset_file_internal(
                 auto_decompress=file_prefix.auto_decompress,
             )
 
-        if not is_binary and not is_compressed and not is_crypt4gh_upload and (convert_to_posix_lines or convert_spaces_to_tabs):
+        if (
+            not is_binary
+            and not is_compressed
+            and not is_crypt4gh_upload
+            and (convert_to_posix_lines or convert_spaces_to_tabs)
+        ):
             # Convert universal line endings to Posix line endings, spaces to tabs (if desired)
             convert_fxn = convert_function(convert_to_posix_lines, convert_spaces_to_tabs)
             line_count, _converted_path, converted_newlines, converted_spaces = convert_fxn(

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -69,6 +69,7 @@ def handle_upload(
                 in_place=in_place,
                 check_content=check_content,
                 uploaded_file_ext=os.path.splitext(name)[1].lower().lstrip("."),
+                uploaded_filename=name,
                 convert_to_posix_lines=convert_to_posix_lines,
                 convert_spaces_to_tabs=convert_spaces_to_tabs,
             )

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -56,6 +56,7 @@ cloudauthz==0.6.0
 colorama==0.4.6 ; sys_platform == 'win32'
 coloredlogs==15.0.1
 conda-package-streaming==0.13.0
+crypt4gh==1.8.6
 cryptography==50.0.0
 ct3==3.4.0.post5
 cwl-upgrader==1.2.15

--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -10,11 +10,7 @@ from typing import (
 from galaxy.job_execution.datasets import DeferrableObjectsT
 from galaxy.job_execution.setup import JobIO
 from galaxy.model import Job
-
-
-def dataset_path_to_extra_path(path: str) -> str:
-    base_path = path[0 : -len(".dat")]
-    return f"{base_path}_files"
+from galaxy.util import dataset_path_to_extra_path
 
 
 class ComputeEnvironment(metaclass=ABCMeta):

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -89,6 +89,7 @@ class JobIO(UsesDictVisibleKeys):
         "tool_source_class",
         "tool_dir",
         "is_task",
+        "crypt4gh_config",
     )
 
     def __init__(
@@ -117,6 +118,7 @@ class JobIO(UsesDictVisibleKeys):
         tool_source_class: Optional["str"] = "XmlToolSource",
         tool_dir: StrPath | None = None,
         is_task: bool = False,
+        crypt4gh_config: dict[str, Any] | None = None,
     ):
         user_context_instance: FileSourcesUserContext
         self.file_sources_dict = file_sources_dict
@@ -147,6 +149,7 @@ class JobIO(UsesDictVisibleKeys):
         self.is_task = is_task
         self.tool_source = tool_source
         self.tool_source_class = tool_source_class
+        self.crypt4gh_config = crypt4gh_config
         self.job_outputs = JobOutputs()
         self._dataset_path_rewriter: DatasetPathRewriter | None = None
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1802,10 +1802,13 @@ class MinimalJobWrapper(HasResourceParameters):
     def _assert_crypt4gh_job_readiness(self, job: Job) -> None:
         """Fail-closed readiness guard for Crypt4GH-wrapped input datasets.
 
-        Delegates to :func:`galaxy.util.crypt4gh.assert_crypt4gh_job_readiness`
-        and fails the job with an actionable error if any Crypt4GH input
-        is missing required compute metadata or has an expired keypair.
+        Fails the job with an actionable error message if any Crypt4GH-wrapped input
+        is missing required compute metadata or has an expired or invalid encryption key.
         """
+        # Skip the check for metadata tools, because those tools
+        # only read dataset metadata and should not require recrypt.
+        if job.tool_id == "__SET_METADATA__":
+            return
         errors = assert_crypt4gh_job_readiness(job)
         if errors:
             error_message = "Crypt4GH job readiness check failed:\n" + "\n".join(errors)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2353,7 +2353,7 @@ class MinimalJobWrapper(HasResourceParameters):
         if getattr(self.app.config, "enable_crypt4gh_transparent_staging", False) and CRYPT4GH_CLEANUP_FAILED_MARKER in (tool_stderr or ""):
             cleanup_failure_msg = (
                 "Crypt4GH plaintext cleanup failed on compute side — "
-                "plaintext staging artifacts may remain. "
+                "plaintext data may remain on the compute node. "
                 "Contact the compute site administrator."
             )
             if final_job_state == job.states.OK:
@@ -2583,7 +2583,7 @@ class MinimalJobWrapper(HasResourceParameters):
             except Exception:
                 cleanup_msg = (
                     "Crypt4GH plaintext cleanup failed — "
-                    "plaintext staging artifacts may remain on the compute side. "
+                    "plaintext data may remain on the compute node. "
                     "Contact the compute site administrator."
                 )
                 log.exception("(%d) %s", self.job_id, cleanup_msg)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -102,6 +102,10 @@ from galaxy.tool_util.output_checker import (
     DETECTED_JOB_STATE,
 )
 from galaxy.tool_util.parser.stdio import StdioErrorLevel
+from galaxy.tools.crypt4gh_remote_execution import (
+    Crypt4GHRemoteExecutionError,
+    verify_crypt4gh_pre_success_output_evidence,
+)
 from galaxy.tools.evaluation import (
     PartialToolEvaluator,
     ToolEvaluator,
@@ -115,7 +119,11 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.bunch import Bunch
-from galaxy.util.crypt4gh import assert_crypt4gh_job_readiness
+from galaxy.util.crypt4gh import (
+    assert_crypt4gh_job_readiness,
+    cleanup_crypt4gh_plaintext_artifacts,
+    CRYPT4GH_CLEANUP_FAILED_MARKER,
+)
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.path import external_chown
 from galaxy.util.xml_macros import load
@@ -139,6 +147,27 @@ DEFAULT_LOCAL_WORKERS = 4
 
 DEFAULT_CLEANUP_JOB = "always"
 VALID_TOOL_CLASSES = ["local", "requires_galaxy", "user_defined"]
+
+
+def _extract_crypt4gh_cleanup_traceback(stderr: str) -> str:
+    """Extract the Python traceback emitted by the Crypt4GH cleanup one-liner.
+
+    The cleanup step runs ``python -c '...'`` whose traceback (if it raises)
+    is captured as part of *stderr*.  This returns the traceback block — from
+    ``Traceback (most recent call last):`` up to and including the final
+    exception line — or an empty string if none is found.
+    """
+    marker = "Traceback (most recent call last):"
+    idx = stderr.find(marker)
+    if idx == -1:
+        return ""
+    # The traceback ends at the first blank line after the exception line,
+    # or at the CRYPT4GH_CLEANUP_FAILED_MARKER line, whichever comes first.
+    end = stderr.find(CRYPT4GH_CLEANUP_FAILED_MARKER, idx)
+    if end == -1:
+        end = len(stderr)
+    block = stderr[idx:end].rstrip()
+    return block
 
 
 class ResubmitConfigDict(TypedDict, total=False):
@@ -1820,6 +1849,30 @@ class MinimalJobWrapper(HasResourceParameters):
             self.fail(error_message)
             raise JobNotReadyException(error_message)
 
+    def _verify_crypt4gh_outputs(self, job: Job, output_dataset_associations) -> str | None:
+        """Fail-closed verification that Crypt4GH outputs are properly encrypted.
+
+        Returns an error message string if verification fails, or None if
+        outputs are valid or Crypt4GH staging is not active for this job.
+
+        This runs in :meth:`finish` after all outputs are discovered and
+        before ``set_final_state``, so a failure here flips the job to
+        ERROR and the existing ERROR-state handling applies.
+        """
+        if not getattr(self.app.config, "enable_crypt4gh_transparent_staging", False):
+            return None
+        if job.tool_id == "__SET_METADATA__":
+            return None
+
+        try:
+            verify_crypt4gh_pre_success_output_evidence(
+                working_directory=self.working_directory,
+                output_dataset_associations=output_dataset_associations,
+            )
+        except Crypt4GHRemoteExecutionError as exc:
+            return str(exc)
+        return None
+
     def _pause_job_if_over_quota(self, job):
         quota_source_map = self.app.object_store.get_quota_source_map()
         if self.app.quota_agent.is_over_quota(quota_source_map, job):
@@ -2174,6 +2227,25 @@ class MinimalJobWrapper(HasResourceParameters):
         else:
             final_job_state = job.states.ERROR
 
+        if (
+            getattr(self.app.config, "enable_crypt4gh_transparent_staging", False)
+            and tool_stderr
+            and CRYPT4GH_CLEANUP_FAILED_MARKER in tool_stderr
+        ):
+            cleanup_traceback = _extract_crypt4gh_cleanup_traceback(tool_stderr)
+            if cleanup_traceback:
+                existing_traceback = job.traceback or ""
+                job.traceback = (
+                    f"{existing_traceback}\n{cleanup_traceback}" if existing_traceback else cleanup_traceback
+                )
+                tool_stderr = tool_stderr.replace(cleanup_traceback, "").strip()
+                job.set_streams(
+                    job.tool_stdout,
+                    tool_stderr,
+                    job_stdout=job_stdout,
+                    job_stderr=job_stderr,
+                )
+
         if not extended_metadata and self.outputs_to_working_directory and not self.__link_file_check():
             # output will be moved by job if metadata_strategy is extended_metadata, so skip moving here
             for dataset_path in self.job_io.get_output_fnames():
@@ -2266,6 +2338,56 @@ class MinimalJobWrapper(HasResourceParameters):
                 ):
                     # We don't set datsets in error state to OK because discover_outputs may have already set the state to error
                     dataset_assoc.dataset.dataset.state = Dataset.states.OK
+
+        # Fail-closed: detect compute-side Crypt4GH plaintext cleanup failures
+        # reported via the stderr marker emitted by the shell wrapper.
+        # The cleanup step always runs (even on tool/postrun failure), so the
+        # marker can appear alongside other errors.  When the job would
+        # otherwise succeed, a cleanup failure flips it to ERROR.  When the
+        # job is already failing, we still surface the cleanup failure in the
+        # job info so users know plaintext artifacts may remain.
+        #
+        # This runs after the extended-metadata import so that job.info set
+        # here is not overwritten by the import (which carries info: null
+        # from the compute side).
+        if getattr(self.app.config, "enable_crypt4gh_transparent_staging", False) and CRYPT4GH_CLEANUP_FAILED_MARKER in (tool_stderr or ""):
+            cleanup_failure_msg = (
+                "Crypt4GH plaintext cleanup failed on compute side — "
+                "plaintext staging artifacts may remain. "
+                "Contact the compute site administrator."
+            )
+            if final_job_state == job.states.OK:
+                if getattr(self.app.config, "crypt4gh_cleanup_failure_is_job_failure", False):
+                    log.warning("(%s) %s", self.get_id_tag(), cleanup_failure_msg)
+                    final_job_state = job.states.ERROR
+                    job.info = cleanup_failure_msg
+                    # Surface the message on output datasets so users see it in the history
+                    for dataset_assoc in output_dataset_associations:
+                        dataset_assoc.dataset.info = cleanup_failure_msg
+                else:
+                    log.warning("(%s) %s (job not failed — crypt4gh_cleanup_failure_is_job_failure is false)", self.get_id_tag(), cleanup_failure_msg)
+            else:
+                # Job is already failing — append the cleanup failure to job.info
+                # and dataset.info so the reason is visible to the user.
+                log.warning("(%s) %s (job already failing from tool/postrun error)", self.get_id_tag(), cleanup_failure_msg)
+                existing_info = job.info or ""
+                job.info = f"{existing_info}\n{cleanup_failure_msg}" if existing_info else cleanup_failure_msg
+                for dataset_assoc in output_dataset_associations:
+                    ds = dataset_assoc.dataset
+                    existing_ds_info = ds.info or ""
+                    ds.info = f"{existing_ds_info}\n{cleanup_failure_msg}" if existing_ds_info else cleanup_failure_msg
+
+        # Fail-closed: verify Crypt4GH outputs before allowing success.
+        # Placed here so that if verification flips final_job_state to ERROR,
+        # the existing ERROR-state handling below runs naturally.
+        if final_job_state == job.states.OK:
+            crypt4gh_verify_error = self._verify_crypt4gh_outputs(job, output_dataset_associations)
+            if crypt4gh_verify_error:
+                log.warning("(%s) Crypt4GH output verification failed: %s", self.get_id_tag(), crypt4gh_verify_error)
+                final_job_state = job.states.ERROR
+                job.info = crypt4gh_verify_error
+                for dataset_assoc in output_dataset_associations:
+                    dataset_assoc.dataset.info = crypt4gh_verify_error
 
         if job.states.ERROR == final_job_state:
             for dataset_assoc in output_dataset_associations:
@@ -2449,6 +2571,28 @@ class MinimalJobWrapper(HasResourceParameters):
                 JobWorkingDirectory(job, self.object_store).delete()
         except Exception:
             log.exception("Unable to cleanup job %d", self.job_id)
+
+        # Deterministic Crypt4GH plaintext cleanup — runs on both success and
+        # failure paths.  The _crypt directory is a subdirectory of the job
+        # working directory, so the object-store delete above would eventually
+        # remove it; this explicit step provides fail-closed semantics so
+        # cleanup failures can be surfaced for sensitive deployments.
+        if getattr(self.app.config, "enable_crypt4gh_transparent_staging", False):
+            try:
+                cleanup_crypt4gh_plaintext_artifacts(working_directory=self.working_directory)
+            except Exception:
+                cleanup_msg = (
+                    "Crypt4GH plaintext cleanup failed — "
+                    "plaintext staging artifacts may remain on the compute side. "
+                    "Contact the compute site administrator."
+                )
+                log.exception("(%d) %s", self.job_id, cleanup_msg)
+                if getattr(self.app.config, "crypt4gh_cleanup_failure_is_job_failure", False):
+                    job = self.get_job()
+                    existing_info = job.info or ""
+                    job.info = f"{existing_info}\n{cleanup_msg}" if existing_info else cleanup_msg
+                    self.sa_session.add(job)
+                    self.sa_session.commit()
 
     def _collect_metrics(self, has_metrics, job_metrics_directory=None):
         job = has_metrics.get_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -71,6 +71,7 @@ from galaxy.job_execution.setup import (
 from galaxy.jobs.job_destination import JobDestination
 from galaxy.jobs.mapper import (
     JobMappingException,
+    JobNotReadyException,
     JobRunnerMapper,
 )
 from galaxy.jobs.runners import (
@@ -114,6 +115,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.bunch import Bunch
+from galaxy.util.crypt4gh import assert_crypt4gh_job_readiness
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.path import external_chown
 from galaxy.util.xml_macros import load
@@ -1781,6 +1783,7 @@ class MinimalJobWrapper(HasResourceParameters):
 
     def enqueue(self):
         job = self.get_job()
+        self._assert_crypt4gh_job_readiness(job)
         # Change to queued state before handing to worker thread so the runner won't pick it up again
         if self.is_task:
             self.change_state(Job.states.QUEUED, flush=False, job=job)
@@ -1795,6 +1798,20 @@ class MinimalJobWrapper(HasResourceParameters):
         if job.state == model.Job.states.PAUSED:
             return False
         return True
+
+    def _assert_crypt4gh_job_readiness(self, job: Job) -> None:
+        """Fail-closed readiness guard for Crypt4GH-wrapped input datasets.
+
+        Delegates to :func:`galaxy.util.crypt4gh.assert_crypt4gh_job_readiness`
+        and fails the job with an actionable error if any Crypt4GH input
+        is missing required compute metadata or has an expired keypair.
+        """
+        errors = assert_crypt4gh_job_readiness(job)
+        if errors:
+            error_message = "Crypt4GH job readiness check failed:\n" + "\n".join(errors)
+            log.warning("(%s) %s", job.id, error_message)
+            self.fail(error_message)
+            raise JobNotReadyException(error_message)
 
     def _pause_job_if_over_quota(self, job):
         quota_source_map = self.app.object_store.get_quota_source_map()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2350,7 +2350,9 @@ class MinimalJobWrapper(HasResourceParameters):
         # This runs after the extended-metadata import so that job.info set
         # here is not overwritten by the import (which carries info: null
         # from the compute side).
-        if getattr(self.app.config, "enable_crypt4gh_transparent_staging", False) and CRYPT4GH_CLEANUP_FAILED_MARKER in (tool_stderr or ""):
+        if getattr(
+            self.app.config, "enable_crypt4gh_transparent_staging", False
+        ) and CRYPT4GH_CLEANUP_FAILED_MARKER in (tool_stderr or ""):
             cleanup_failure_msg = (
                 "Crypt4GH plaintext cleanup failed on compute side — "
                 "plaintext data may remain on the compute node. "
@@ -2365,11 +2367,19 @@ class MinimalJobWrapper(HasResourceParameters):
                     for dataset_assoc in output_dataset_associations:
                         dataset_assoc.dataset.info = cleanup_failure_msg
                 else:
-                    log.warning("(%s) %s (job not failed — crypt4gh_cleanup_failure_is_job_failure is false)", self.get_id_tag(), cleanup_failure_msg)
+                    log.warning(
+                        "(%s) %s (job not failed — crypt4gh_cleanup_failure_is_job_failure is false)",
+                        self.get_id_tag(),
+                        cleanup_failure_msg,
+                    )
             else:
                 # Job is already failing — append the cleanup failure to job.info
                 # and dataset.info so the reason is visible to the user.
-                log.warning("(%s) %s (job already failing from tool/postrun error)", self.get_id_tag(), cleanup_failure_msg)
+                log.warning(
+                    "(%s) %s (job already failing from tool/postrun error)",
+                    self.get_id_tag(),
+                    cleanup_failure_msg,
+                )
                 existing_info = job.info or ""
                 job.info = f"{existing_info}\n{cleanup_failure_msg}" if existing_info else cleanup_failure_msg
                 for dataset_assoc in output_dataset_associations:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1117,6 +1117,10 @@ class MinimalJobWrapper(HasResourceParameters):
                 tool_source_class=type(self.tool.tool_source).__name__ if self.tool else None,
                 tool_dir=tool_dir,
                 is_task=self.is_task,
+                crypt4gh_config={
+                    "reencryption_service_url": self.app.config.crypt4gh_reencryption_service_url,
+                    "enable_crypt4gh_transparent_staging": self.app.config.enable_crypt4gh_transparent_staging,
+                },
             )
         return self._job_io
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -661,11 +661,26 @@ class BaseJobRunner:
                     tool_stdout = ""
                     tool_stderr = "Job cancelled"
                 else:
-                    # Should we instead just move on ?
-                    # In the end the only consequence here is that we won't be able to determine
-                    # if the job failed for known tool reasons (check_tool_output).
-                    # OTOH I don't know if this can even be reached
-                    # Deal with it if we ever get reports about this.
+                    # tool_stdout/tool_stderr are missing — this can happen when
+                    # remote_tool_eval.py fails and the && chain prevents cd working, so the
+                    # shell redirection creates files at the wrong path.  Surface
+                    # the remote_tool_eval traceback as a job-level error (not a
+                    # tool error) since the tool never actually ran.
+                    eval_traceback_path = os.path.join(
+                        job_wrapper.working_directory, "metadata", "outputs_populated", "traceback.txt"
+                    )
+                    if os.path.exists(eval_traceback_path):
+                        with open(eval_traceback_path) as tb:
+                            eval_traceback = tb.read()
+                        job_wrapper.fail(
+                            f"Job setup failed during remote_tool_eval:\n{eval_traceback}",
+                            tool_stdout="",
+                            tool_stderr="",
+                            exit_code=exit_code,
+                            job_stdout=job_stdout,
+                            job_stderr=job_stderr,
+                        )
+                        return
                     raise
 
             check_output_detected_state = job_wrapper.check_tool_output(

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -40,10 +40,7 @@ from pulsar.client.staging import DEFAULT_DYNAMIC_COLLECTION_PATTERN
 from sqlalchemy import select
 
 from galaxy import model
-from galaxy.job_execution.compute_environment import (
-    ComputeEnvironment,
-    dataset_path_to_extra_path,
-)
+from galaxy.job_execution.compute_environment import ComputeEnvironment
 from galaxy.jobs.command_factory import build_command
 from galaxy.jobs.handler import JobHandlerQueue
 from galaxy.jobs.job_destination import JobDestination
@@ -58,6 +55,7 @@ from galaxy.tool_util.parser.output_collection_def import FilePatternDatasetColl
 from galaxy.tool_util.parser.output_objects import ToolOutput
 from galaxy.tools.parameters.basic import ParameterValueError
 from galaxy.util import (
+    dataset_path_to_extra_path,
     galaxy_directory,
     specs,
     string_as_bool_or_none,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -257,6 +257,7 @@ class ConfigSerializer(base.ModelSerializer):
             "enable_webhooks": lambda item, key, **context: (
                 hasattr(self.app, "webhooks_registry") and bool(self.app.webhooks_registry.webhooks)
             ),
+            "enable_crypt4gh_transparent_staging": _use_config,
         }
 
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -258,6 +258,7 @@ class ConfigSerializer(base.ModelSerializer):
                 hasattr(self.app, "webhooks_registry") and bool(self.app.webhooks_registry.webhooks)
             ),
             "enable_crypt4gh_transparent_staging": _use_config,
+            "crypt4gh_cleanup_failure_is_job_failure": _use_config,
         }
 
 

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -877,22 +877,24 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
         super().add_deserializers()
         deletable.PurgableDeserializerMixin.add_deserializers(self)
 
-        self.deserializers.update(
-            {
-                "name": self.deserialize_basestring,
-                "info": self.deserialize_basestring,
-                "datatype": self.deserialize_datatype,
-            }
-        )
+        dataset_deserializers: dict[str, base.Deserializer] = {
+            "name": self.deserialize_basestring,
+            "info": self.deserialize_basestring,
+            "datatype": self.deserialize_datatype,
+            "metadata": self.deserialize_metadata,
+        }
+        self.deserializers.update(dataset_deserializers)
         self.deserializable_keyset.update(self.deserializers.keys())
 
     # TODO: untested
-    def deserialize_metadata(self, dataset_assoc, metadata_key, metadata_dict, **context):
+    def deserialize_metadata(self, item, key, val, **context):
         """ """
+        metadata_key = key
+        metadata_dict = val
         self.validate.matches_type(metadata_key, metadata_dict, dict)
         returned = {}
-        for key, val in metadata_dict.items():
-            returned[key] = self.deserialize_metadatum(dataset_assoc, key, val, **context)
+        for metadata_name, metadata_val in metadata_dict.items():
+            returned[metadata_name] = self.deserialize_metadatum(item, metadata_name, metadata_val, **context)
         return returned
 
     def deserialize_metadatum(self, dataset_assoc, key, val, **context):

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -47,6 +47,7 @@ from galaxy.schema.tasks import (
     PurgeDatasetsTaskRequest,
 )
 from galaxy.structured_app import MinimalManagerApp
+from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
 from galaxy.util.hash_util import memory_bound_hexdigest
 
 log = logging.getLogger(__name__)
@@ -562,6 +563,11 @@ class DatasetAssociationManager(
         assert dataset_assoc.dataset
         path = dataset_assoc.dataset.get_file_name()
         datatype = sniff.guess_ext(path, self.app.datatypes_registry.sniff_order)
+        datatype = preserve_crypt4gh_inner_file_ext(
+            datatype,
+            current_ext=dataset_assoc.extension,
+            metadata_inner_ext=getattr(dataset_assoc.metadata, "crypt4gh_inner_ext", None),
+        )
         self.app.datatypes_registry.change_datatype(dataset_assoc, datatype)
         session.commit()
         self.set_metadata(trans, dataset_assoc)

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -47,7 +47,10 @@ from galaxy.schema.tasks import (
     PurgeDatasetsTaskRequest,
 )
 from galaxy.structured_app import MinimalManagerApp
-from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
+from galaxy.util.crypt4gh import (
+    preserve_crypt4gh_inner_file_ext,
+    validate_crypt4gh_compute_metadata,
+)
 from galaxy.util.hash_util import memory_bound_hexdigest
 
 log = logging.getLogger(__name__)
@@ -900,6 +903,7 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
         if metadata_specification.get("readonly"):
             return
         unwrapped_val = metadata_specification.unwrap(val)
+        validate_crypt4gh_compute_metadata(dataset_assoc, key, unwrapped_val)
         setattr(dataset_assoc.metadata, key, unwrapped_val)
         # ...?
         return unwrapped_val

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -38,8 +38,13 @@ except Exception:
     METADATA_DIRECTORY = os.path.join(WORKING_DIRECTORY, "metadata")
     EXPORT_STORE_DIRECTORY = os.path.join(METADATA_DIRECTORY, "outputs_populated")
     os.makedirs(EXPORT_STORE_DIRECTORY, exist_ok=True)
-    with open(os.path.join(EXPORT_STORE_DIRECTORY, "traceback.txt"), "w") as out:
-        out.write(traceback.format_exc())
+    traceback_path = os.path.join(EXPORT_STORE_DIRECTORY, "traceback.txt")
+    # Don't overwrite a traceback from remote_tool_eval.py — that failure is
+    # the root cause and should be surfaced to the user, not masked by the
+    # secondary metadata-collection failure.
+    if not os.path.exists(traceback_path):
+        with open(traceback_path, "w") as out:
+            out.write(traceback.format_exc())
     raise
 """
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -30,7 +30,6 @@ import galaxy.datatypes.registry
 import galaxy.model.mapping
 from galaxy.datatypes import sniff
 from galaxy.datatypes.data import validate
-from galaxy.job_execution.compute_environment import dataset_path_to_extra_path
 from galaxy.job_execution.output_collect import (
     collect_dynamic_outputs,
     collect_extra_files,
@@ -69,6 +68,7 @@ from galaxy.tool_util.parser.stdio import (
 )
 from galaxy.tool_util.provided_metadata import parse_tool_provided_metadata
 from galaxy.util import (
+    dataset_path_to_extra_path,
     safe_contains,
     stringify_dictionary_keys,
     unicodify,

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -38,6 +38,7 @@ from galaxy.objectstore import (
     ObjectStore,
     ObjectStorePopulator,
 )
+from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
 from galaxy.util.hash_util import verify_hash
 from .dereference import get_replacement_dataset
 
@@ -279,6 +280,11 @@ class DatasetInstanceMaterializer:
         if dataset_instance.extension != "auto":
             return
         sniffed = guess_ext(path, self._datatypes_registry.sniff_order)
+        sniffed = preserve_crypt4gh_inner_file_ext(
+            sniffed,
+            current_ext=dataset_instance.extension,
+            metadata_inner_ext=getattr(dataset_instance.metadata, "crypt4gh_inner_ext", None),
+        )
         if sniffed and sniffed != "auto":
             dataset_instance.extension = sniffed
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1837,8 +1837,8 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
     def workflow_run_specify_inputs(self, inputs: dict[str, Any]):
         workflow_run = self.components.workflow_run
         for label, value in inputs.items():
-            input_div_element = workflow_run.input_data_div(label=label).wait_for_visible()
-            hid = value.pop("hid")
+            input_div_element = workflow_run.input_select_field(label=label).wait_for_visible()
+            hid = value["hid"] if isinstance(value, dict) else value
             self.select_set_value(input_div_element, f"{hid}: ")
 
     def workflow_run_submit(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -44,7 +44,6 @@ from galaxy.exceptions import (
     ToolInputsNotReadyException,
 )
 from galaxy.job_execution import output_collect
-from galaxy.job_execution.compute_environment import dataset_path_to_extra_path
 from galaxy.job_execution.output_collect import (
     BaseJobContext,
     MetadataSourceProvider,
@@ -206,6 +205,7 @@ from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.tools.parameters.wrapped_json import json_wrap
 from galaxy.util import (
     asbool,
+    dataset_path_to_extra_path,
     in_directory,
     Params,
     parse_xml_string,

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -1,0 +1,2769 @@
+"""Crypt4GH helpers for remote tool execution and output finalization."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import errno
+import importlib
+import io
+import ipaddress
+import json
+import os
+import re
+import shlex
+import shutil
+import ssl
+from collections.abc import (
+    Mapping,
+    Sequence,
+)
+from dataclasses import dataclass
+from datetime import (
+    datetime,
+    timedelta,
+    timezone,
+)
+from logging import getLogger
+from pathlib import Path
+from typing import (
+    Any,
+    BinaryIO,
+    cast,
+    Protocol,
+    TYPE_CHECKING,
+)
+from urllib.parse import urlsplit
+
+import aiohttp
+import crypt4gh.header
+import crypt4gh.lib
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from dateutil.parser import isoparse
+
+from galaxy.job_execution.compute_environment import (
+    dataset_path_to_extra_path,
+    SharedComputeEnvironment,
+)
+from galaxy.util.crypt4gh import read_crypt4gh_header
+
+try:
+    _optional_truststore: Any = importlib.import_module("truststore")
+except Exception:
+    _optional_truststore = None
+
+if TYPE_CHECKING:
+    from galaxy.job_execution.setup import JobIO
+    from galaxy.model import (
+        DatasetInstance,
+        Job,
+    )
+
+log = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ReencryptionHttpResponse:
+    status_code: int
+    text: str
+    json_payload: Any
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+
+def _is_dev_style_https_reencryption_url(*, reencryption_service_url: str) -> bool:
+    parsed_url = urlsplit(reencryption_service_url)
+    if parsed_url.scheme.lower() != "https":
+        return False
+
+    hostname = parsed_url.hostname
+    if not hostname:
+        return False
+
+    if hostname == "localhost":
+        return True
+
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return "." not in hostname
+
+
+def _ssl_context_for_reencryption_url(
+    *,
+    reencryption_service_url: str,
+    truststore_module: Any,
+) -> ssl.SSLContext | None:
+    if not _is_dev_style_https_reencryption_url(reencryption_service_url=reencryption_service_url):
+        return None
+
+    if truststore_module is None:
+        log.warning(
+            "Crypt4GH re-encryption service URL %s matches local/dev HTTPS pattern, "
+            "but truststore is unavailable; falling back to default TLS handling",
+            reencryption_service_url,
+        )
+        return None
+
+    try:
+        ssl_context = truststore_module.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        log.warning(
+            "Failed to initialize truststore SSL context for Crypt4GH re-encryption service URL %s; "
+            "falling back to default TLS handling",
+            reencryption_service_url,
+            exc_info=True,
+        )
+        return None
+
+    return ssl_context
+
+
+async def _post_reencryption_json_async(
+    *,
+    endpoint: str,
+    payload: dict[str, str],
+    ssl_context: ssl.SSLContext | None,
+) -> _ReencryptionHttpResponse:
+    timeout = aiohttp.ClientTimeout(total=30)
+    ssl_option: ssl.SSLContext | bool = ssl_context if ssl_context is not None else True
+    async with aiohttp.ClientSession(timeout=timeout) as request_session:
+        async with request_session.post(endpoint, json=payload, ssl=ssl_option) as response:
+            response_text = await response.text()
+            try:
+                response_json: Any = json.loads(response_text) if response_text else None
+            except ValueError:
+                response_json = None
+
+            return _ReencryptionHttpResponse(
+                status_code=response.status,
+                text=response_text,
+                json_payload=response_json,
+            )
+
+
+async def _post_many_reencryption_json_async(
+    *,
+    endpoint: str,
+    payloads: Sequence[dict[str, str]],
+    ssl_context: ssl.SSLContext | None,
+) -> list[_ReencryptionHttpResponse]:
+    timeout = aiohttp.ClientTimeout(total=30)
+    ssl_option: ssl.SSLContext | bool = ssl_context if ssl_context is not None else True
+    async with aiohttp.ClientSession(timeout=timeout) as request_session:
+        requests_to_send = [request_session.post(endpoint, json=payload, ssl=ssl_option) for payload in payloads]
+        responses = await asyncio.gather(*requests_to_send)
+        try:
+            results: list[_ReencryptionHttpResponse] = []
+            for response in responses:
+                response_text = await response.text()
+                try:
+                    response_json: Any = json.loads(response_text) if response_text else None
+                except ValueError:
+                    response_json = None
+
+                results.append(
+                    _ReencryptionHttpResponse(
+                        status_code=response.status,
+                        text=response_text,
+                        json_payload=response_json,
+                    )
+                )
+            return results
+        finally:
+            for response in responses:
+                response.release()
+
+
+def _post_reencryption_json(
+    *, reencryption_service_url: str, endpoint: str, payload: dict[str, str]
+) -> _ReencryptionHttpResponse:
+    ssl_context = _ssl_context_for_reencryption_url(
+        reencryption_service_url=reencryption_service_url,
+        truststore_module=_optional_truststore,
+    )
+    return asyncio.run(
+        _post_reencryption_json_async(
+            endpoint=endpoint,
+            payload=payload,
+            ssl_context=ssl_context,
+        )
+    )
+
+
+def _post_many_reencryption_json(
+    *,
+    reencryption_service_url: str,
+    endpoint: str,
+    payloads: Sequence[dict[str, str]],
+) -> list[_ReencryptionHttpResponse]:
+    ssl_context = _ssl_context_for_reencryption_url(
+        reencryption_service_url=reencryption_service_url,
+        truststore_module=_optional_truststore,
+    )
+    return asyncio.run(
+        _post_many_reencryption_json_async(
+            endpoint=endpoint,
+            payloads=payloads,
+            ssl_context=ssl_context,
+        )
+    )
+
+
+class _Crypt4GHAppConfig(Protocol):
+    enable_crypt4gh_transparent_input_matching: bool
+    enable_crypt4gh_remote_execution_staging: bool
+    enable_crypt4gh_transparent_staging: bool
+    outputs_to_working_directory: bool
+    metadata_strategy: str
+    crypt4gh_reencryption_service_url: str | None
+    tool_evaluation_strategy: str | None
+
+
+class Crypt4GHRemoteExecutionError(Exception):
+    """Raised when execution-side Crypt4GH setup must fail closed."""
+
+
+CRYPT4GH_PLAINTEXT_CLEANUP_FAILED_MARKER = "CRYPT4GH_PLAINTEXT_CLEANUP_FAILED"
+_DEFAULT_MINIMUM_TTL = timedelta(days=1)
+_DESTINATION_WALLTIME_BUFFER = timedelta(hours=1)
+_CRYPT4GH_FILE_SUFFIX = ".c4gh"
+
+
+class _HeaderThenBodyStream:
+    """Stream wrapper that prepends a replacement Crypt4GH header."""
+
+    def __init__(self, *, header_bytes: bytes, body_stream: BinaryIO) -> None:
+        self._header = memoryview(header_bytes)
+        self._header_pos = 0
+        self._body_stream = body_stream
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            header_remainder = self._header[self._header_pos :].tobytes()
+            self._header_pos = len(self._header)
+            body_remainder = self._body_stream.read()
+            return header_remainder + body_remainder
+
+        if size == 0:
+            return b""
+
+        chunks: list[bytes] = []
+        header_remaining = len(self._header) - self._header_pos
+        if header_remaining > 0:
+            take = min(size, header_remaining)
+            chunks.append(self._header[self._header_pos : self._header_pos + take].tobytes())
+            self._header_pos += take
+
+        body_remaining = size - sum(len(chunk) for chunk in chunks)
+        if body_remaining > 0:
+            chunks.append(self._body_stream.read(body_remaining))
+
+        return b"".join(chunks)
+
+    def readinto(self, buffer: bytearray) -> int:
+        data = self.read(len(buffer))
+        bytes_read = len(data)
+        if bytes_read:
+            buffer[:bytes_read] = data
+        return bytes_read
+
+
+@dataclass(frozen=True)
+class _RecryptToJobKeyResult:
+    crypt4gh_header: str
+    crypt4gh_compute_public_key: str
+    crypt4gh_compute_keypair_id: str
+    crypt4gh_compute_keypair_expiration_date: str
+
+
+@dataclass(frozen=True)
+class _DeclaredCrypt4GHOutputTarget:
+    association_name: str
+    output_path: str
+    dataset_output_path: str | None
+    extra_files_output_path: str | None
+    extra_files_manifest_path: str | None
+    plaintext_path: str
+    encrypted_marker_path: str
+    encrypted_ext: str
+    clear_compute_keypair: bool
+    allowed_root_paths: tuple[str, ...] = ()
+    plaintext_root_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ComputeKeyContext:
+    """Compute-side key context inferred from recrypt responses."""
+
+    public_key: str
+    keypair_id: str
+    keypair_expiration_date: str
+
+
+class Crypt4GHRemoteComputeEnvironment(SharedComputeEnvironment):
+    """Compute environment that rewrites remote input paths for Crypt4GH jobs."""
+
+    def __init__(
+        self,
+        *,
+        job_io: JobIO,
+        job: Job,
+        input_path_overrides_by_dataset_id: Mapping[int, str],
+        compute_public_key: str | None,
+        compute_keypair_id: str | None,
+        compute_keypair_expiration_date: str | None,
+    ) -> None:
+        super().__init__(job_io=job_io, job=job)
+        self._input_path_overrides_by_dataset_id = dict(input_path_overrides_by_dataset_id)
+        self.compute_public_key = compute_public_key
+        self.compute_keypair_id = compute_keypair_id
+        self.compute_keypair_expiration_date = compute_keypair_expiration_date
+
+    def input_path_rewrite(self, dataset: DatasetInstance) -> str:
+        """Return plaintext override path for staged Crypt4GH input datasets."""
+
+        dataset_object = getattr(dataset, "dataset", None)
+        dataset_id = getattr(dataset_object, "id", None)
+        if isinstance(dataset_id, int):
+            rewritten_path = self._input_path_overrides_by_dataset_id.get(dataset_id)
+            if rewritten_path:
+                return rewritten_path
+        return super().input_path_rewrite(dataset)
+
+
+Crypt4GHComputeEnvironment = Crypt4GHRemoteComputeEnvironment
+
+
+def _crypt4gh_staging_enabled(app_config: _Crypt4GHAppConfig) -> bool:
+    return bool(
+        getattr(app_config, "enable_crypt4gh_remote_execution_staging", False)
+        or getattr(app_config, "enable_crypt4gh_transparent_staging", False)
+    )
+
+
+def build_crypt4gh_remote_compute_environment(
+    *,
+    job_io: JobIO,
+    job: Job,
+    working_directory: str,
+    reencryption_service_url: str,
+    minimum_ttl: timedelta | None = None,
+    now: datetime | None = None,
+) -> Crypt4GHRemoteComputeEnvironment:
+    """Build remote compute environment with staged plaintext Crypt4GH inputs."""
+
+    crypt4gh_inputs = _collect_crypt4gh_inputs(job_io)
+    if not crypt4gh_inputs:
+        raise Crypt4GHRemoteExecutionError("Crypt4GH remote execution requested but no Crypt4GH inputs were detected")
+
+    destination_params = dict(getattr(job, "destination_params", {}) or {})
+    effective_minimum_ttl = _minimum_ttl_for_destination(
+        destination_params=destination_params,
+        fallback_minimum_ttl=minimum_ttl or _DEFAULT_MINIMUM_TTL,
+    )
+    current_time = now or datetime.now(timezone.utc)
+    _assert_minimum_ttl(datasets=crypt4gh_inputs, minimum_ttl=effective_minimum_ttl, now=current_time)
+
+    crypt_inputs_workspace = _ensure_crypt4gh_inputs_workspace(working_directory)
+    job_private_key, job_public_key = _generate_job_keypair()
+    input_path_overrides_by_dataset_id, compute_context = _prepare_plaintext_inputs(
+        datasets=crypt4gh_inputs,
+        crypt_inputs_workspace=crypt_inputs_workspace,
+        reencryption_service_url=reencryption_service_url,
+        job_public_key=job_public_key,
+        job_private_key=job_private_key,
+    )
+
+    return Crypt4GHRemoteComputeEnvironment(
+        job_io=job_io,
+        job=job,
+        input_path_overrides_by_dataset_id=input_path_overrides_by_dataset_id,
+        compute_public_key=compute_context.public_key,
+        compute_keypair_id=compute_context.keypair_id,
+        compute_keypair_expiration_date=compute_context.keypair_expiration_date,
+    )
+
+
+def _prepare_plaintext_inputs(
+    *,
+    datasets: Sequence[DatasetInstance],
+    crypt_inputs_workspace: Path,
+    reencryption_service_url: str,
+    job_public_key: str,
+    job_private_key: bytes,
+) -> tuple[dict[int, str], _ComputeKeyContext]:
+    endpoint = f"{reencryption_service_url.rstrip('/')}/recrypt_header_to_job_key"
+    recrypt_payloads = _build_recrypt_payloads(datasets=datasets, job_public_key=job_public_key)
+    responses = _post_many_reencryption_json(
+        reencryption_service_url=reencryption_service_url,
+        endpoint=endpoint,
+        payloads=[payload["request_payload"] for payload in recrypt_payloads],
+    )
+    if len(responses) != len(recrypt_payloads):
+        raise Crypt4GHRemoteExecutionError(
+            "Compute-side recryptor B must return one response per dataset for /recrypt_header_to_job_key"
+        )
+
+    input_path_overrides_by_dataset_id: dict[int, str] = {}
+    compute_context: _ComputeKeyContext | None = None
+
+    for payload, response in zip(recrypt_payloads, responses):
+        recrypt_result = _parse_recrypt_header_to_job_key_response(
+            response=response,
+            endpoint=endpoint,
+        )
+        dataset_id, plaintext_path = _prepare_plaintext_input_for_dataset(
+            dataset=cast(Any, payload["dataset"]),
+            source_header=cast(str, payload["source_header"]),
+            recrypt_header=recrypt_result.crypt4gh_header,
+            crypt_inputs_workspace=crypt_inputs_workspace,
+            job_private_key=job_private_key,
+        )
+        input_path_overrides_by_dataset_id[dataset_id] = plaintext_path
+
+        candidate_context = _ComputeKeyContext(
+            public_key=recrypt_result.crypt4gh_compute_public_key,
+            keypair_id=recrypt_result.crypt4gh_compute_keypair_id,
+            keypair_expiration_date=recrypt_result.crypt4gh_compute_keypair_expiration_date,
+        )
+        if compute_context is None:
+            compute_context = candidate_context
+        else:
+            _assert_consistent_compute_key_context(existing=compute_context, candidate=candidate_context)
+
+    if compute_context is None:
+        raise Crypt4GHRemoteExecutionError("Crypt4GH remote execution requested but no Crypt4GH inputs were detected")
+
+    return input_path_overrides_by_dataset_id, compute_context
+
+
+def _build_recrypt_payloads(
+    *,
+    datasets: Sequence[DatasetInstance],
+    job_public_key: str,
+) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for dataset in datasets:
+        dataset_object = getattr(dataset, "dataset", None)
+        dataset_id = getattr(dataset_object, "id", None)
+        if not isinstance(dataset_id, int):
+            raise Crypt4GHRemoteExecutionError("Crypt4GH input dataset is missing a persisted dataset id")
+
+        metadata = getattr(dataset, "metadata", None)
+        source_header = getattr(metadata, "crypt4gh_header", None)
+        compute_header = getattr(metadata, "crypt4gh_compute_header", None)
+        keypair_id = getattr(metadata, "crypt4gh_compute_keypair_id", None)
+        if not source_header or not compute_header or not keypair_id:
+            raise Crypt4GHRemoteExecutionError(
+                "Crypt4GH input metadata must include crypt4gh_header, crypt4gh_compute_header, and crypt4gh_compute_keypair_id"
+            )
+
+        payloads.append(
+            {
+                "dataset": dataset,
+                "dataset_id": dataset_id,
+                "source_header": cast(str, source_header),
+                "request_payload": {
+                    "crypt4gh_header": cast(str, compute_header),
+                    "crypt4gh_compute_keypair_id": cast(str, keypair_id),
+                    "crypt4gh_job_public_key": job_public_key,
+                },
+            }
+        )
+    return payloads
+
+
+def _parse_recrypt_header_to_job_key_response(
+    *,
+    response: _ReencryptionHttpResponse,
+    endpoint: str,
+) -> _RecryptToJobKeyResult:
+    if not response.ok:
+        raise Crypt4GHRemoteExecutionError(
+            f"Compute-side recryptor B returned HTTP {response.status_code} for {endpoint}: "
+            f"{_summarize_http_error_response(response)}"
+        )
+
+    try:
+        response_json = response.json_payload
+        if not isinstance(response_json, dict):
+            raise ValueError("Response body is not a JSON object")
+
+        return _RecryptToJobKeyResult(
+            crypt4gh_header=cast(str, response_json["crypt4gh_header"]),
+            crypt4gh_compute_public_key=cast(str, response_json["crypt4gh_compute_public_key"]),
+            crypt4gh_compute_keypair_id=cast(str, response_json["crypt4gh_compute_keypair_id"]),
+            crypt4gh_compute_keypair_expiration_date=cast(
+                str, response_json["crypt4gh_compute_keypair_expiration_date"]
+            ),
+        )
+    except (ValueError, KeyError, TypeError) as exc:
+        raise Crypt4GHRemoteExecutionError(
+            "Compute-side recryptor B returned an invalid /recrypt_header_to_job_key payload"
+        ) from exc
+
+
+def _assert_consistent_compute_key_context(*, existing: _ComputeKeyContext, candidate: _ComputeKeyContext) -> None:
+    if existing.public_key != candidate.public_key:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH job inputs reference multiple compute public keys; mixed key contexts are unsupported"
+        )
+    if existing.keypair_id != candidate.keypair_id:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH job inputs reference multiple compute keypair ids; mixed key contexts are unsupported"
+        )
+    if existing.keypair_expiration_date != candidate.keypair_expiration_date:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH job inputs reference multiple compute key expiry timestamps; mixed key contexts are unsupported"
+        )
+
+
+def should_run_crypt4gh_remote_execution(
+    *,
+    job_io: JobIO,
+    app_config: _Crypt4GHAppConfig,
+    destination_params: dict[str, Any],
+    provided_metadata_style: str | None = None,
+    minimum_ttl: timedelta | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Decide whether execution-side Crypt4GH setup is allowed for this job.
+
+    The helper is intentionally small for the Task 3 contract:
+    - top-level gate: ``enable_crypt4gh_remote_execution_staging``
+    - execution path only when ``tool_evaluation_strategy == "remote"``
+    - only if at least one Crypt4GH input dataset is present
+    - setup failures must fail closed
+    """
+
+    if not _crypt4gh_staging_enabled(app_config):
+        return False
+
+    if _effective_tool_evaluation_strategy(destination_params=destination_params, app_config=app_config) != "remote":
+        return False
+
+    crypt4gh_inputs = _collect_crypt4gh_inputs(job_io)
+    if not crypt4gh_inputs:
+        return False
+
+    if provided_metadata_style == "legacy":
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH remote execution is not supported for tools with legacy provided_metadata_style; "
+            "use a tool with profile >= 17.09 or set provided_metadata_style to \"default\""
+        )
+
+    effective_minimum_ttl = _minimum_ttl_for_destination(
+        destination_params=destination_params,
+        fallback_minimum_ttl=minimum_ttl or _DEFAULT_MINIMUM_TTL,
+    )
+    current_time = now or datetime.now(timezone.utc)
+    _assert_minimum_ttl(datasets=crypt4gh_inputs, minimum_ttl=effective_minimum_ttl, now=current_time)
+    return True
+
+
+def assert_crypt4gh_job_readiness(
+    *,
+    job_io: JobIO,
+    tool: Any | None,
+    app_config: _Crypt4GHAppConfig,
+    destination_params: Mapping[str, Any],
+    metadata_strategy: str,
+    reencryption_service_url: str | None = None,
+) -> None:
+    """Fail closed when Crypt4GH transparent-adapted jobs are misconfigured.
+
+    Transparent input matching and remote execution staging are intentionally split:
+    transparent input matching may be enabled alone, but if a job depends on
+    transparent adaptation (tool input does not explicitly accept ``.c4gh``),
+    remote-execution prerequisites must be satisfied.
+    """
+
+    remote_execution_staging_enabled = bool(getattr(app_config, "enable_crypt4gh_remote_execution_staging", False))
+    transparent_input_matching_enabled = bool(getattr(app_config, "enable_crypt4gh_transparent_input_matching", False))
+
+    required_remote_settings = [
+        "enable_crypt4gh_transparent_input_matching = true",
+        "enable_crypt4gh_remote_execution_staging = true",
+        "tool_evaluation_strategy = remote",
+        "outputs_to_working_directory = true",
+        "metadata_strategy = extended",
+        "crypt4gh_reencryption_service_url",
+    ]
+
+    def _missing_remote_settings_summary() -> str:
+        return "; required settings: " + ", ".join(required_remote_settings)
+
+    if remote_execution_staging_enabled and not transparent_input_matching_enabled:
+        raise Crypt4GHRemoteExecutionError(
+            "Invalid Crypt4GH configuration: enable_crypt4gh_remote_execution_staging requires "
+            "enable_crypt4gh_transparent_input_matching = true" + _missing_remote_settings_summary()
+        )
+
+    crypt4gh_input_names = _collect_crypt4gh_input_names(job_io=job_io)
+    if not crypt4gh_input_names:
+        return
+
+    transparent_adapted_inputs = _collect_transparent_adapted_crypt4gh_input_names(job_io=job_io, tool=tool)
+
+    if not remote_execution_staging_enabled:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH input handling requires enable_crypt4gh_remote_execution_staging = true"
+            + _missing_remote_settings_summary()
+        )
+
+    if _effective_tool_evaluation_strategy(destination_params=destination_params, app_config=app_config) != "remote":
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH input handling requires tool_evaluation_strategy = remote" + _missing_remote_settings_summary()
+        )
+
+    if not bool(getattr(app_config, "outputs_to_working_directory", False)):
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH input handling requires outputs_to_working_directory = true" + _missing_remote_settings_summary()
+        )
+
+    if metadata_strategy != "extended":
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH input handling requires metadata_strategy = extended" + _missing_remote_settings_summary()
+        )
+
+    effective_reencryption_service_url = str(
+        reencryption_service_url or getattr(app_config, "crypt4gh_reencryption_service_url", "") or ""
+    ).strip()
+    if not effective_reencryption_service_url:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH input handling requires crypt4gh_reencryption_service_url" + _missing_remote_settings_summary()
+        )
+
+    del transparent_adapted_inputs
+
+
+def _collect_crypt4gh_input_names(*, job_io: JobIO) -> list[str]:
+    job = getattr(job_io, "job", None)
+    if not job:
+        return []
+
+    input_associations = [
+        *list(getattr(job, "input_datasets", []) or []),
+        *list(getattr(job, "input_library_datasets", []) or []),
+    ]
+    if not input_associations:
+        return []
+
+    crypt4gh_input_names: list[str] = []
+    for input_association in input_associations:
+        dataset = getattr(input_association, "dataset", None)
+        if dataset is None or not _is_crypt4gh_dataset_instance(dataset):
+            continue
+
+        input_name = getattr(input_association, "name", "")
+        if not isinstance(input_name, str) or not input_name:
+            input_name = "<unnamed>"
+        crypt4gh_input_names.append(input_name)
+
+    return crypt4gh_input_names
+
+
+def _effective_tool_evaluation_strategy(
+    *, destination_params: Mapping[str, Any], app_config: _Crypt4GHAppConfig
+) -> str:
+    destination_strategy = destination_params.get("tool_evaluation_strategy")
+    if isinstance(destination_strategy, str) and destination_strategy:
+        return destination_strategy
+
+    global_strategy = getattr(app_config, "tool_evaluation_strategy", None)
+    if isinstance(global_strategy, str) and global_strategy:
+        return global_strategy
+
+    return ""
+
+
+def _collect_transparent_adapted_crypt4gh_input_names(*, job_io: JobIO, tool: Any | None) -> list[str]:
+    job = getattr(job_io, "job", None)
+    if not job:
+        return []
+
+    input_associations = [
+        *list(getattr(job, "input_datasets", []) or []),
+        *list(getattr(job, "input_library_datasets", []) or []),
+    ]
+    if not input_associations:
+        return []
+
+    tool_inputs = getattr(tool, "inputs", {}) if tool is not None else {}
+    adapted_names: list[str] = []
+    for input_association in input_associations:
+        dataset = getattr(input_association, "dataset", None)
+        if dataset is None or not _is_crypt4gh_dataset_instance(dataset):
+            continue
+
+        input_name = getattr(input_association, "name", "")
+        if not isinstance(input_name, str) or not input_name:
+            adapted_names.append("<unnamed>")
+            continue
+
+        tool_input = tool_inputs.get(input_name) if isinstance(tool_inputs, Mapping) else None
+        if _tool_input_explicitly_accepts_crypt4gh(tool_input):
+            continue
+
+        adapted_names.append(input_name)
+
+    return adapted_names
+
+
+def _is_crypt4gh_dataset_instance(dataset: Any) -> bool:
+    metadata = getattr(dataset, "metadata", None)
+    if metadata and getattr(metadata, "crypt4gh_header", None):
+        return True
+
+    return str(getattr(dataset, "ext", "") or "").endswith(".c4gh")
+
+
+def _tool_input_explicitly_accepts_crypt4gh(tool_input: Any) -> bool:
+    if tool_input is None:
+        return False
+
+    extensions = getattr(tool_input, "extensions", None)
+    if not isinstance(extensions, Sequence):
+        return False
+
+    return any(isinstance(extension, str) and extension.endswith(".c4gh") for extension in extensions)
+
+
+def _minimum_ttl_for_destination(
+    *, destination_params: Mapping[str, Any], fallback_minimum_ttl: timedelta
+) -> timedelta:
+    walltime_value = destination_params.get("walltime")
+    walltime_delta = _parse_destination_walltime(walltime_value)
+    if walltime_delta is None:
+        return fallback_minimum_ttl
+    derived_minimum_ttl = walltime_delta + _DESTINATION_WALLTIME_BUFFER
+    return max(fallback_minimum_ttl, derived_minimum_ttl)
+
+
+def _parse_destination_walltime(walltime_value: Any) -> timedelta | None:
+    if not isinstance(walltime_value, str):
+        return None
+    parts = walltime_value.strip().split(":")
+    if len(parts) != 3:
+        return None
+    try:
+        hours, minutes, seconds = (int(part) for part in parts)
+    except ValueError:
+        return None
+    if hours < 0 or minutes < 0 or seconds < 0:
+        return None
+    if minutes >= 60 or seconds >= 60:
+        return None
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+def _collect_crypt4gh_inputs(job_io: JobIO) -> list[DatasetInstance]:
+    datasets: list[DatasetInstance] = []
+    for dataset in job_io.get_input_datasets():
+        metadata = getattr(dataset, "metadata", None)
+        if metadata and getattr(metadata, "crypt4gh_header", None):
+            datasets.append(dataset)
+    return datasets
+
+
+def _ensure_crypt4gh_inputs_workspace(working_directory: str) -> Path:
+    workspace = Path(working_directory) / "_crypt" / "inputs"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+def cleanup_crypt4gh_plaintext_artifacts(*, working_directory: str) -> None:
+    """Delete staged Crypt4GH plaintext input and output directories."""
+
+    crypt_root = Path(working_directory) / "_crypt"
+    for child_name in ("inputs", "outputs"):
+        child_path = crypt_root / child_name
+        if child_path.exists():
+            shutil.rmtree(child_path)
+
+
+def _format_crypt4gh_public_key(public_key: bytes) -> str:
+    encoded_public_key = base64.b64encode(public_key).decode("ascii")
+    return "\n".join(
+        [
+            "-----BEGIN CRYPT4GH PUBLIC KEY-----",
+            encoded_public_key,
+            "-----END CRYPT4GH PUBLIC KEY-----",
+        ]
+    )
+
+
+def _generate_job_keypair() -> tuple[bytes, str]:
+    private_key = X25519PrivateKey.generate()
+    private_key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private_key_bytes, _format_crypt4gh_public_key(public_key_bytes)
+
+
+def _prepare_plaintext_input_for_dataset(
+    *,
+    dataset: DatasetInstance,
+    source_header: str,
+    recrypt_header: str,
+    crypt_inputs_workspace: Path,
+    job_private_key: bytes,
+) -> tuple[int, str]:
+    dataset_object = getattr(dataset, "dataset", None)
+    dataset_id = getattr(dataset_object, "id", None)
+    if not isinstance(dataset_id, int):
+        raise Crypt4GHRemoteExecutionError("Crypt4GH input dataset is missing a persisted dataset id")
+
+    dataset_workspace = crypt_inputs_workspace / f"ds_{dataset_id}"
+    dataset_workspace.mkdir(parents=True, exist_ok=True)
+    plaintext_path = dataset_workspace / "plaintext"
+
+    source_dataset_path = Path(dataset.get_file_name())
+    _decrypt_recrypted_input(
+        source_dataset_path=source_dataset_path,
+        source_header=source_header,
+        recrypted_header=recrypt_header,
+        plaintext_path=plaintext_path,
+        job_private_key=job_private_key,
+    )
+    return dataset_id, str(plaintext_path)
+
+
+def collect_declared_crypt4gh_output_targets(
+    *,
+    job_io: JobIO,
+    tool_outputs: Mapping[str, Any],
+    datatypes_registry: Any,
+    working_directory: str,
+) -> list[dict[str, Any]]:
+    """Collect declared non-discovery outputs that require Crypt4GH finalization."""
+
+    targets: list[dict[str, Any]] = []
+    marker_dir = Path(working_directory) / "_c4gh_stage" / "outputs"
+    plaintext_root = Path(working_directory) / "_crypt" / "outputs"
+    tool_working_directory = Path(working_directory) / "working"
+
+    for output_name, (dataset, dataset_path) in job_io.get_output_hdas_and_fnames().items():
+        if output_name.startswith("__new_primary_file_"):
+            continue
+
+        output_name_for_tool_lookup = _resolve_output_name_for_tool_lookup(
+            output_name=output_name,
+            tool_outputs=tool_outputs,
+        )
+        if output_name_for_tool_lookup is None:
+            raise Crypt4GHRemoteExecutionError(
+                f"Crypt4GH output target '{output_name}' has no matching tool output declaration"
+            )
+        dataset_object = getattr(dataset, "dataset", None)
+        dataset_id = getattr(dataset_object, "id", None)
+        if not isinstance(dataset_id, int):
+            raise Crypt4GHRemoteExecutionError(
+                f"Crypt4GH output target '{output_name}' is missing a persisted dataset id"
+            )
+
+        tool_output = tool_outputs.get(output_name_for_tool_lookup)
+        if _is_discovery_routed_output(tool_output):
+            continue
+
+        base_ext = _resolve_base_output_extension(dataset=dataset, tool_output=tool_output)
+        if base_ext is None:
+            if _has_output_collectors(tool_output):
+                continue
+            raise Crypt4GHRemoteExecutionError(
+                f"Crypt4GH output target '{output_name}' could not resolve encrypted output extension"
+            )
+
+        encrypted_ext = _ensure_crypt4gh_output_datatype(
+            datatypes_registry=datatypes_registry,
+            base_ext=base_ext,
+        )
+        output_path, output_path_source = _resolve_output_path_with_source(
+            dataset_path=dataset_path,
+            tool_output=tool_output,
+            tool_working_directory=tool_working_directory,
+        )
+        _assert_output_path_inside_job_working_directory(
+            output_path=output_path,
+            output_path_source=output_path_source,
+            working_directory=working_directory,
+            output_name=output_name,
+        )
+        _print_declared_output_target_debug(
+            output_name=output_name,
+            output_name_for_tool_lookup=output_name_for_tool_lookup,
+            output_path=output_path,
+            output_path_source=output_path_source,
+            from_work_dir=getattr(tool_output, "from_work_dir", None),
+            false_path=getattr(dataset_path, "false_path", None),
+            real_path=getattr(dataset_path, "real_path", None),
+            working_directory=working_directory,
+        )
+
+        target = _DeclaredCrypt4GHOutputTarget(
+            association_name=output_name,
+            output_path=output_path,
+            dataset_output_path=cast(str | None, getattr(dataset_path, "real_path", None)),
+            extra_files_output_path=cast(str | None, getattr(dataset_path, "false_extra_files_path", None))
+            or dataset_path_to_extra_path(output_path),
+            extra_files_manifest_path=str(marker_dir / f"ds_{dataset_id}.extra_files_manifest.json"),
+            plaintext_path=str(plaintext_root / f"ds_{dataset_id}" / "plaintext"),
+            encrypted_marker_path=str(marker_dir / f"ds_{dataset_id}.encrypted"),
+            encrypted_ext=encrypted_ext,
+            clear_compute_keypair=True,
+            allowed_root_paths=_declared_output_allowed_root_paths(
+                working_directory=working_directory,
+                dataset_output_path=cast(str | None, getattr(dataset_path, "real_path", None)),
+            ),
+            plaintext_root_paths=(str(Path(working_directory).resolve()),),
+        )
+        targets.append(_declared_output_target_to_mapping(target))
+
+    return targets
+
+
+def collect_discovery_crypt4gh_output_specs(
+    *,
+    job_io: JobIO,
+    tool_outputs: Mapping[str, Any],
+    datatypes_registry: Any,
+    working_directory: str,
+) -> list[dict[str, Any]]:
+    """Collect discovery-output specs for postrun encryption scanning.
+
+    The resulting specs are intentionally serialization-friendly and can be
+    passed to the postrun helper script.
+    """
+
+    discovery_specs: list[dict[str, Any]] = []
+    tool_working_directory = Path(working_directory) / "working"
+    discovered_marker_map_path = str(Path(working_directory) / "_c4gh_stage" / "outputs" / "discovered_designations.json")
+
+    for output_name, tool_output in tool_outputs.items():
+        collectors = list(getattr(tool_output, "dataset_collector_descriptions", []) or [])
+        if not collectors:
+            continue
+
+        base_ext = getattr(tool_output, "format", None)
+        if not base_ext or base_ext in ("auto", "data", "_sniff_", "input"):
+            continue
+        encrypted_ext = _ensure_crypt4gh_output_datatype(
+            datatypes_registry=datatypes_registry,
+            base_ext=cast(str, base_ext),
+        )
+
+        for collector in collectors:
+            directory = str(getattr(collector, "directory", "") or "")
+            if os.path.isabs(directory):
+                scan_root = directory
+            elif directory:
+                scan_root = str(tool_working_directory / directory)
+            else:
+                scan_root = str(tool_working_directory)
+
+            discover_via = str(getattr(collector, "discover_via", "pattern") or "pattern")
+            pattern = str(getattr(collector, "pattern", "") or "")
+            if not pattern:
+                pattern = r"(?P<designation>.+)"
+
+            discovery_specs.append(
+                {
+                    "output_name": output_name,
+                    "discover_via": discover_via,
+                    "pattern": pattern,
+                    "scan_root": scan_root,
+                    "encrypted_ext": encrypted_ext,
+                    "assign_primary_output": bool(getattr(collector, "assign_primary_output", False)),
+                    "recurse": bool(getattr(collector, "recurse", False)),
+                    "match_relative_path": bool(getattr(collector, "match_relative_path", False)),
+                    "discovered_marker_map_path": discovered_marker_map_path,
+                    "allowed_root_paths": [str(Path(working_directory).resolve())],
+                    "plaintext_root_paths": [str(Path(working_directory).resolve())],
+                }
+            )
+
+    return discovery_specs
+
+
+def finalize_discovered_crypt4gh_payloads(
+    *,
+    discovery_specs: Sequence[Mapping[str, Any]],
+    working_directory: str,
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None = None,
+) -> list[dict[str, Any]]:
+    """Scan discovery roots and finalize discovered payloads in-place."""
+
+    payload_metadata: list[dict[str, Any]] = []
+    for spec in discovery_specs:
+        if str(spec.get("discover_via", "pattern")) != "pattern":
+            continue
+
+        scan_root = Path(str(spec.get("scan_root", "") or ""))
+        if not scan_root.exists() or not scan_root.is_dir():
+            continue
+
+        pattern_text = str(spec.get("pattern", "") or "")
+        try:
+            compiled_pattern = re.compile(pattern_text)
+        except re.error:
+            continue
+
+        recurse = bool(spec.get("recurse", False))
+        walk_iter = os.walk(scan_root) if recurse else [(str(scan_root), [], os.listdir(scan_root))]
+        for root, _dirs, files in walk_iter:
+            for file_name in files:
+                source_path = Path(root) / file_name
+                if source_path.name.endswith(".c4gh"):
+                    continue
+
+                candidate_text = str(source_path.relative_to(scan_root)) if bool(spec.get("match_relative_path", False)) else source_path.name
+                match = compiled_pattern.match(candidate_text)
+                if not match:
+                    continue
+
+                designation = match.groupdict().get("designation") if match.groupdict() else None
+                designation = designation or source_path.stem
+                encrypted_ext = str(spec["encrypted_ext"])
+                output_path = str(source_path.with_name(f"{source_path.name}.c4gh"))
+
+                finalize_about_to_persist_crypt4gh_payload(
+                    output_path=output_path,
+                    plaintext_path=str(Path(working_directory) / "_crypt" / "outputs" / "discovered" / designation / "plaintext"),
+                    encrypted_ext=encrypted_ext,
+                    reencryption_service_url=reencryption_service_url,
+                    compute_public_key=compute_public_key,
+                    compute_keypair_id=compute_keypair_id,
+                    compute_keypair_expiration_date=compute_keypair_expiration_date,
+                    encrypted_marker_path="",
+                    dataset_output_path="",
+                    designation=designation,
+                    discovered_marker_map_path=str(spec.get("discovered_marker_map_path", "") or ""),
+                    allowed_root_paths=cast(Sequence[str], spec.get("allowed_root_paths", [])),
+                    plaintext_root_paths=cast(Sequence[str], spec.get("plaintext_root_paths", [])),
+                    clear_compute_keypair=False,
+                )
+                os.replace(source_path, source_path.with_suffix(f"{source_path.suffix}.plaintext"))
+                os.replace(output_path, source_path)
+
+                payload_metadata.append(
+                    {
+                        "output_name": str(spec.get("output_name", "")),
+                        "designation": designation,
+                        "filename": source_path.name,
+                        "encrypted_ext": encrypted_ext,
+                    }
+                )
+
+    return payload_metadata
+
+
+def emit_crypt4gh_galaxy_metadata(
+    *,
+    output_targets: Sequence[Mapping[str, Any]],
+    output_metadata: Sequence[Mapping[str, Any]],
+    discovered_payload_metadata: Sequence[Mapping[str, Any]],
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None,
+    galaxy_json_path: str,
+) -> None:
+    """Merge Crypt4GH metadata for declared and discovered outputs into galaxy.json."""
+
+    existing: dict[str, Any] = {}
+    galaxy_json = Path(galaxy_json_path)
+    if galaxy_json.exists():
+        try:
+            loaded = json.loads(galaxy_json.read_text())
+            if isinstance(loaded, dict):
+                existing = loaded
+        except Exception:
+            existing = {}
+
+    for metadata_entry in output_metadata:
+        association_name = str(metadata_entry.get("association_name", "") or "")
+        if not association_name:
+            continue
+        association_payload = existing.setdefault(association_name, {})
+        if not isinstance(association_payload, dict):
+            association_payload = {}
+            existing[association_name] = association_payload
+        encrypted_ext = str(metadata_entry.get("encrypted_ext", "") or "")
+        if encrypted_ext:
+            association_payload["ext"] = encrypted_ext
+        metadata_payload = association_payload.setdefault("metadata", {})
+        if not isinstance(metadata_payload, dict):
+            metadata_payload = {}
+            association_payload["metadata"] = metadata_payload
+        payload_metadata = metadata_entry.get("metadata") if isinstance(metadata_entry.get("metadata"), dict) else {}
+        metadata_payload.update(cast(dict[str, Any], payload_metadata))
+        metadata_payload["crypt4gh_compute_keypair_id"] = compute_keypair_id
+        metadata_payload["crypt4gh_compute_keypair_expiration_date"] = str(compute_keypair_expiration_date or "")
+        if "crypt4gh_inner_ext" not in metadata_payload and encrypted_ext.endswith(".c4gh"):
+            metadata_payload["crypt4gh_inner_ext"] = encrypted_ext[: -len(".c4gh")]
+
+    for discovered_entry in discovered_payload_metadata:
+        output_name = str(discovered_entry.get("output_name", "") or "")
+        if not output_name:
+            continue
+        output_payload = existing.setdefault(output_name, {})
+        if not isinstance(output_payload, dict):
+            output_payload = {}
+            existing[output_name] = output_payload
+        datasets = output_payload.setdefault("datasets", [])
+        if not isinstance(datasets, list):
+            datasets = []
+            output_payload["datasets"] = datasets
+        encrypted_ext = str(discovered_entry.get("encrypted_ext", "") or "")
+        designation = str(discovered_entry.get("designation", "") or "")
+        filename = str(discovered_entry.get("filename", "") or "")
+        metadata_payload = {
+            "crypt4gh_compute_keypair_id": compute_keypair_id,
+            "crypt4gh_compute_keypair_expiration_date": str(compute_keypair_expiration_date or ""),
+        }
+        if encrypted_ext.endswith(".c4gh"):
+            metadata_payload["crypt4gh_inner_ext"] = encrypted_ext[: -len(".c4gh")]
+        datasets.append(
+            {
+                "name": designation,
+                "designation": designation,
+                "filename": filename,
+                "ext": encrypted_ext,
+                "metadata": metadata_payload,
+            }
+        )
+
+    galaxy_json.parent.mkdir(parents=True, exist_ok=True)
+    galaxy_json.write_text(json.dumps(existing))
+
+
+def build_crypt4gh_postrun_command(
+    *,
+    tool_command: str,
+    output_targets: Sequence[Mapping[str, Any]],
+    discovery_specs: Sequence[Mapping[str, Any]],
+    galaxy_json_path: str,
+    working_directory: str,
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None,
+    python_executable: str,
+) -> str:
+    """Build a wrapped shell command that finalizes Crypt4GH outputs after tool success."""
+
+    galaxy_lib_dir = str(Path(__file__).resolve().parents[2])
+
+    postrun_script = (
+        "import json\n"
+        f"from galaxy.tools.crypt4gh_remote_execution import finalize_declared_crypt4gh_outputs, finalize_discovered_crypt4gh_payloads, emit_crypt4gh_galaxy_metadata\n"
+        f"_OUTPUT_TARGETS = json.loads({json.dumps(json.dumps(list(output_targets)))})\n"
+        f"_DISCOVERY_SPECS = json.loads({json.dumps(json.dumps(list(discovery_specs)))})\n"
+        f"_DECLARED_METADATA = finalize_declared_crypt4gh_outputs(output_targets=_OUTPUT_TARGETS, reencryption_service_url={json.dumps(reencryption_service_url)}, compute_public_key={json.dumps(compute_public_key)}, compute_keypair_id={json.dumps(compute_keypair_id)}, compute_keypair_expiration_date={json.dumps(compute_keypair_expiration_date)})\n"
+        f"_DISCOVERED_METADATA = finalize_discovered_crypt4gh_payloads(discovery_specs=_DISCOVERY_SPECS, working_directory={json.dumps(working_directory)}, reencryption_service_url={json.dumps(reencryption_service_url)}, compute_public_key={json.dumps(compute_public_key)}, compute_keypair_id={json.dumps(compute_keypair_id)}, compute_keypair_expiration_date={json.dumps(compute_keypair_expiration_date)})\n"
+        f"emit_crypt4gh_galaxy_metadata(output_targets=_OUTPUT_TARGETS, output_metadata=_DECLARED_METADATA, discovered_payload_metadata=_DISCOVERED_METADATA, compute_keypair_id={json.dumps(compute_keypair_id)}, compute_keypair_expiration_date={json.dumps(compute_keypair_expiration_date)}, galaxy_json_path={json.dumps(galaxy_json_path)})\n"
+    )
+    postrun_command = (
+        f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
+        f"{shlex.quote(python_executable)} -c {shlex.quote(postrun_script)}"
+    )
+    cleanup_script = f"from galaxy.tools.crypt4gh_remote_execution import cleanup_crypt4gh_plaintext_artifacts; cleanup_crypt4gh_plaintext_artifacts(working_directory={json.dumps(working_directory)})"
+    cleanup_command = (
+        f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
+        f"{shlex.quote(python_executable)} -c {shlex.quote(cleanup_script)}"
+    )
+    return build_crypt4gh_cleanup_wrapped_command(
+        tool_command=tool_command,
+        postrun_command=postrun_command,
+        cleanup_command=cleanup_command,
+    )
+
+
+def _is_discovery_routed_output(tool_output: Any) -> bool:
+    if tool_output is None:
+        return False
+    collectors = list(getattr(tool_output, "dataset_collector_descriptions", []) or [])
+    return any(bool(getattr(collector, "assign_primary_output", False)) for collector in collectors)
+
+
+def _has_output_collectors(tool_output: Any) -> bool:
+    if tool_output is None:
+        return False
+    collectors = list(getattr(tool_output, "dataset_collector_descriptions", []) or [])
+    return len(collectors) > 0
+
+
+def _resolve_output_name_for_tool_lookup(*, output_name: str, tool_outputs: Mapping[str, Any]) -> str | None:
+    if output_name in tool_outputs:
+        return output_name
+    if output_name.startswith("__new_primary_file_"):
+        return output_name[len("__new_primary_file_") :].split("|", 1)[0]
+    return None
+
+
+def _resolve_base_output_extension(*, dataset: Any, tool_output: Any) -> str | None:
+    base_ext = cast(str, getattr(dataset, "ext", "") or "")
+    if not base_ext:
+        return None
+
+    if base_ext.endswith(".c4gh"):
+        base_ext = base_ext[: -len(".c4gh")]
+
+    if base_ext in ("auto", "data", "_sniff_"):
+        declared_ext = getattr(tool_output, "format", None) if tool_output else None
+        if declared_ext and declared_ext not in ("auto", "data", "_sniff_", "input"):
+            return cast(str, declared_ext)
+        return None
+    return base_ext
+
+
+def _ensure_crypt4gh_output_datatype(*, datatypes_registry: Any, base_ext: str) -> str:
+    encrypted_ext = f"{base_ext}.c4gh"
+    if datatypes_registry.get_datatype_by_extension(encrypted_ext) is None:
+        datatypes_registry.get_or_create_crypt4gh_datatype(base_ext)
+    return encrypted_ext
+
+
+def _resolve_output_path(*, dataset_path: Any, tool_output: Any, tool_working_directory: Path) -> str:
+    output_path, _output_path_source = _resolve_output_path_with_source(
+        dataset_path=dataset_path,
+        tool_output=tool_output,
+        tool_working_directory=tool_working_directory,
+    )
+    return output_path
+
+
+def _resolve_output_path_with_source(
+    *, dataset_path: Any, tool_output: Any, tool_working_directory: Path
+) -> tuple[str, str]:
+    from_work_dir = getattr(tool_output, "from_work_dir", None) if tool_output else None
+    if from_work_dir:
+        from_work_dir_path = Path(str(from_work_dir))
+        if from_work_dir_path.is_absolute():
+            return str(from_work_dir_path), "from_work_dir:absolute"
+        return str(tool_working_directory / from_work_dir_path), "from_work_dir:relative"
+
+    false_path = getattr(dataset_path, "false_path", None)
+    if false_path:
+        return cast(str, false_path), "false_path"
+
+    real_path = getattr(dataset_path, "real_path", None)
+    if real_path:
+        return cast(str, real_path), "real_path"
+
+    return str(dataset_path), "dataset_path:str"
+
+
+def _print_declared_output_target_debug(
+    *,
+    output_name: str,
+    output_name_for_tool_lookup: str,
+    output_path: str,
+    output_path_source: str,
+    from_work_dir: Any,
+    false_path: Any,
+    real_path: Any,
+    working_directory: str,
+) -> None:
+    if os.getenv("GALAXY_CRYPT4GH_DEBUG", "") != "1":
+        return
+
+    debug_payload = {
+        "event": "crypt4gh_declared_output_target",
+        "output_name": output_name,
+        "tool_output_name": output_name_for_tool_lookup,
+        "output_path": output_path,
+        "output_path_source": output_path_source,
+        "from_work_dir": str(from_work_dir or ""),
+        "false_path": str(false_path or ""),
+        "real_path": str(real_path or ""),
+        "working_directory": working_directory,
+    }
+    print(f"CRYPT4GH_DEBUG {json.dumps(debug_payload, sort_keys=True)}", flush=True)
+
+
+def _assert_output_path_inside_job_working_directory(
+    *,
+    output_path: str,
+    output_path_source: str,
+    working_directory: str,
+    output_name: str,
+) -> None:
+    resolved_working_directory = Path(working_directory).resolve(strict=False)
+    resolved_output_path = Path(output_path).resolve(strict=False)
+
+    try:
+        resolved_output_path.relative_to(resolved_working_directory)
+    except ValueError as exc:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH declared output target "
+            f"'{output_name}' resolved {output_path_source} outside job working directory: {output_path}"
+        ) from exc
+
+
+def _declared_output_target_to_mapping(target: _DeclaredCrypt4GHOutputTarget) -> dict[str, Any]:
+    mapping = {
+        "association_name": target.association_name,
+        "output_path": target.output_path,
+        "plaintext_path": target.plaintext_path,
+        "encrypted_marker_path": target.encrypted_marker_path,
+        "encrypted_ext": target.encrypted_ext,
+        "clear_compute_keypair": target.clear_compute_keypair,
+    }
+    if target.dataset_output_path:
+        mapping["dataset_output_path"] = target.dataset_output_path
+    if target.extra_files_output_path:
+        mapping["extra_files_output_path"] = target.extra_files_output_path
+    if target.extra_files_manifest_path:
+        mapping["extra_files_manifest_path"] = target.extra_files_manifest_path
+    if target.allowed_root_paths:
+        mapping["allowed_root_paths"] = list(target.allowed_root_paths)
+    if target.plaintext_root_paths:
+        mapping["plaintext_root_paths"] = list(target.plaintext_root_paths)
+    return mapping
+
+
+def _declared_output_allowed_root_paths(*, working_directory: str, dataset_output_path: str | None) -> tuple[str, ...]:
+    resolved_roots: list[str] = []
+    seen_roots: set[str] = set()
+
+    def _add_root(path_value: str) -> None:
+        resolved_root = str(Path(path_value).resolve())
+        if resolved_root in seen_roots:
+            return
+        seen_roots.add(resolved_root)
+        resolved_roots.append(resolved_root)
+
+    _add_root(working_directory)
+    if dataset_output_path:
+        _add_root(str(Path(dataset_output_path).resolve().parent))
+
+    return tuple(resolved_roots)
+
+
+def finalize_declared_crypt4gh_outputs(
+    *,
+    output_targets: Sequence[Mapping[str, Any]],
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Encrypt declared outputs to user keys and persist extension markers."""
+
+    current_time = now or datetime.now(timezone.utc)
+    if compute_keypair_expiration_date:
+        _assert_key_valid_for_output_finalization(
+            compute_keypair_expiration_date=compute_keypair_expiration_date,
+            now=current_time,
+        )
+
+    output_metadata: list[dict[str, Any]] = []
+    resolved_targets = _iter_unique_existing_output_targets(output_targets)
+    try:
+        for concrete_target, output_path in resolved_targets:
+            payload_metadata = _finalize_output_target(
+                concrete_target=concrete_target,
+                output_path=output_path,
+                reencryption_service_url=reencryption_service_url,
+                compute_public_key=compute_public_key,
+                compute_keypair_id=compute_keypair_id,
+            )
+            output_metadata.append(payload_metadata)
+            _finalize_extra_files_payloads(
+                concrete_target=concrete_target,
+                reencryption_service_url=reencryption_service_url,
+                compute_public_key=compute_public_key,
+                compute_keypair_id=compute_keypair_id,
+            )
+    except Exception:
+        _purge_output_targets_after_finalization_failure(resolved_targets)
+        raise
+    return output_metadata
+
+
+def finalize_about_to_persist_crypt4gh_payload(
+    *,
+    output_path: str,
+    plaintext_path: str,
+    encrypted_ext: str,
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None = None,
+    encrypted_marker_path: str = "",
+    dataset_output_path: str = "",
+    designation: str = "",
+    discovered_marker_map_path: str = "",
+    extra_files_output_path: str = "",
+    extra_files_manifest_path: str = "",
+    allowed_root_paths: Sequence[str] = (),
+    plaintext_root_paths: Sequence[str] = (),
+    clear_compute_keypair: bool = True,
+) -> None:
+    resolved_allowed_root_paths = [str(path) for path in allowed_root_paths if str(path)]
+    if not resolved_allowed_root_paths:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH finalize_about_to_persist requires explicit allowed_root_paths provenance"
+        )
+
+    concrete_target: dict[str, Any] = {
+        "output_path": output_path,
+        "plaintext_path": plaintext_path,
+        "encrypted_ext": encrypted_ext,
+        "encrypted_marker_path": encrypted_marker_path,
+        "clear_compute_keypair": clear_compute_keypair,
+    }
+    if dataset_output_path:
+        concrete_target["dataset_output_path"] = dataset_output_path
+    if designation:
+        concrete_target["designation"] = designation
+    if discovered_marker_map_path:
+        concrete_target["discovered_marker_map_path"] = discovered_marker_map_path
+    if extra_files_output_path:
+        concrete_target["extra_files_output_path"] = extra_files_output_path
+    if extra_files_manifest_path:
+        concrete_target["extra_files_manifest_path"] = extra_files_manifest_path
+    concrete_target["allowed_root_paths"] = resolved_allowed_root_paths
+    resolved_plaintext_root_paths = [str(path) for path in plaintext_root_paths if str(path)]
+    if resolved_plaintext_root_paths:
+        concrete_target["plaintext_root_paths"] = resolved_plaintext_root_paths
+
+    allowed_roots = _resolve_allowed_root_paths(concrete_target)
+    plaintext_roots = _resolve_plaintext_root_paths(concrete_target, fallback_roots=allowed_roots)
+    _assert_path_within_allowed_roots(
+        Path(output_path),
+        allowed_root_paths=allowed_roots,
+        context="finalize output_path",
+    )
+    if dataset_output_path:
+        _assert_path_within_allowed_roots(
+            Path(dataset_output_path),
+            allowed_root_paths=allowed_roots,
+            context="finalize dataset_output_path",
+        )
+    if encrypted_marker_path:
+        _assert_path_within_allowed_roots(
+            Path(encrypted_marker_path),
+            allowed_root_paths=allowed_roots,
+            context="finalize encrypted_marker_path",
+        )
+    if extra_files_output_path:
+        _assert_path_within_allowed_roots(
+            Path(extra_files_output_path),
+            allowed_root_paths=allowed_roots,
+            context="finalize extra_files_output_path",
+        )
+    if extra_files_manifest_path:
+        _assert_path_within_allowed_roots(
+            Path(extra_files_manifest_path),
+            allowed_root_paths=allowed_roots,
+            context="finalize extra_files_manifest_path",
+        )
+    _assert_path_within_allowed_roots(
+        Path(plaintext_path),
+        allowed_root_paths=plaintext_roots,
+        context="finalize plaintext_path",
+    )
+
+    if compute_keypair_expiration_date:
+        _assert_key_valid_for_output_finalization(
+            compute_keypair_expiration_date=compute_keypair_expiration_date,
+            now=datetime.now(timezone.utc),
+        )
+
+    resolved_target = (concrete_target, Path(output_path))
+    try:
+        _finalize_output_target(
+            concrete_target=concrete_target,
+            output_path=Path(output_path),
+            reencryption_service_url=reencryption_service_url,
+            compute_public_key=compute_public_key,
+            compute_keypair_id=compute_keypair_id,
+        )
+        _finalize_extra_files_payloads(
+            concrete_target=concrete_target,
+            reencryption_service_url=reencryption_service_url,
+            compute_public_key=compute_public_key,
+            compute_keypair_id=compute_keypair_id,
+        )
+    except Exception:
+        _purge_output_targets_after_finalization_failure([resolved_target])
+        raise
+
+
+def _purge_output_targets_after_finalization_failure(
+    resolved_targets: Sequence[tuple[dict[str, Any], Path]],
+) -> None:
+    for concrete_target, output_path in resolved_targets:
+        allowed_roots = _resolve_allowed_root_paths(concrete_target)
+        candidate_paths = [output_path]
+        dataset_output_path_value = str(concrete_target.get("dataset_output_path", "") or "")
+        if dataset_output_path_value:
+            candidate_paths.append(Path(dataset_output_path_value))
+        for candidate_path in candidate_paths:
+            try:
+                _assert_path_within_allowed_roots(
+                    candidate_path,
+                    allowed_root_paths=allowed_roots,
+                    context="purge plaintext output candidate",
+                )
+                if candidate_path.exists():
+                    candidate_path.unlink()
+            except FileNotFoundError as exc:
+                log.warning(
+                    "Observed concurrent mutation while removing plaintext output candidate %s after Crypt4GH finalization failure (%s: %s)",
+                    candidate_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            except Exception as exc:
+                log.exception(
+                    "Failed to remove plaintext output candidate %s after Crypt4GH finalization failure (%s: %s)",
+                    candidate_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+
+        marker_path_value = str(concrete_target.get("encrypted_marker_path", "") or "")
+        if marker_path_value:
+            marker_path = Path(marker_path_value)
+            try:
+                _assert_path_within_allowed_roots(
+                    marker_path,
+                    allowed_root_paths=allowed_roots,
+                    context="purge encrypted marker",
+                )
+                if marker_path.exists():
+                    marker_path.unlink()
+            except FileNotFoundError as exc:
+                log.warning(
+                    "Observed concurrent mutation while removing encrypted marker %s after Crypt4GH finalization failure (%s: %s)",
+                    marker_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            except Exception as exc:
+                log.exception(
+                    "Failed to remove encrypted marker %s after Crypt4GH finalization failure (%s: %s)",
+                    marker_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+
+        extra_files_output_path_value = str(concrete_target.get("extra_files_output_path", "") or "")
+        if extra_files_output_path_value:
+            extra_files_output_path = Path(extra_files_output_path_value)
+            try:
+                _assert_path_within_allowed_roots(
+                    extra_files_output_path,
+                    allowed_root_paths=allowed_roots,
+                    context="purge plaintext extra_files candidate",
+                )
+                if extra_files_output_path.is_symlink():
+                    extra_files_output_path.unlink()
+                elif extra_files_output_path.exists() and extra_files_output_path.is_dir():
+                    shutil.rmtree(extra_files_output_path)
+                elif extra_files_output_path.exists():
+                    extra_files_output_path.unlink()
+            except FileNotFoundError as exc:
+                log.warning(
+                    "Observed concurrent mutation while removing plaintext extra_files candidate %s after Crypt4GH finalization failure (%s: %s)",
+                    extra_files_output_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            except OSError as exc:
+                if isinstance(exc, (NotADirectoryError, IsADirectoryError, FileNotFoundError)) or exc.errno in (
+                    errno.ENOTDIR,
+                    errno.EISDIR,
+                    errno.ENOENT,
+                ):
+                    log.warning(
+                        "Observed concurrent mutation while removing plaintext extra_files candidate %s after Crypt4GH finalization failure (%s: %s)",
+                        extra_files_output_path,
+                        exc.__class__.__name__,
+                        exc,
+                    )
+                    continue
+                log.exception(
+                    "Failed to remove plaintext extra_files candidate %s after Crypt4GH finalization failure (%s: %s)",
+                    extra_files_output_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            except Exception as exc:
+                log.exception(
+                    "Failed to remove plaintext extra_files candidate %s after Crypt4GH finalization failure (%s: %s)",
+                    extra_files_output_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+
+        extra_files_manifest_path_value = str(concrete_target.get("extra_files_manifest_path", "") or "")
+        if extra_files_manifest_path_value:
+            extra_files_manifest_path = Path(extra_files_manifest_path_value)
+            try:
+                _assert_path_within_allowed_roots(
+                    extra_files_manifest_path,
+                    allowed_root_paths=allowed_roots,
+                    context="purge extra_files manifest",
+                )
+                if extra_files_manifest_path.exists():
+                    extra_files_manifest_path.unlink()
+            except FileNotFoundError as exc:
+                log.warning(
+                    "Observed concurrent mutation while removing extra_files manifest %s after Crypt4GH finalization failure (%s: %s)",
+                    extra_files_manifest_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            except Exception as exc:
+                log.exception(
+                    "Failed to remove extra_files manifest %s after Crypt4GH finalization failure (%s: %s)",
+                    extra_files_manifest_path,
+                    exc.__class__.__name__,
+                    exc,
+                )
+
+
+def _iter_unique_existing_output_targets(
+    output_targets: Sequence[Mapping[str, Any]],
+) -> list[tuple[dict[str, Any], Path]]:
+    encrypted_paths: set[str] = set()
+    resolved_targets: list[tuple[dict[str, Any], Path]] = []
+    for target in output_targets:
+        declared_output_path = target.get("output_path")
+        if declared_output_path:
+            declared_output = Path(str(declared_output_path))
+            if not declared_output.exists():
+                raise Crypt4GHRemoteExecutionError(f"Crypt4GH declared output path does not exist: {declared_output}")
+
+        for concrete_target in _resolve_output_targets(target):
+            allowed_roots = _resolve_allowed_root_paths(concrete_target)
+            output_path = Path(concrete_target["output_path"])
+            _assert_path_within_allowed_roots(
+                output_path,
+                allowed_root_paths=allowed_roots,
+                context="finalize output_path",
+            )
+
+            dataset_output_path_value = str(concrete_target.get("dataset_output_path", "") or "")
+            if dataset_output_path_value:
+                _assert_path_within_allowed_roots(
+                    Path(dataset_output_path_value),
+                    allowed_root_paths=allowed_roots,
+                    context="finalize dataset_output_path",
+                )
+
+            marker_path_value = str(concrete_target.get("encrypted_marker_path", "") or "")
+            if marker_path_value:
+                _assert_path_within_allowed_roots(
+                    Path(marker_path_value),
+                    allowed_root_paths=allowed_roots,
+                    context="finalize encrypted_marker_path",
+                )
+
+            extra_files_output_path_value = str(concrete_target.get("extra_files_output_path", "") or "")
+            if extra_files_output_path_value:
+                _assert_path_within_allowed_roots(
+                    Path(extra_files_output_path_value),
+                    allowed_root_paths=allowed_roots,
+                    context="finalize extra_files_output_path",
+                )
+
+            extra_files_manifest_path_value = str(concrete_target.get("extra_files_manifest_path", "") or "")
+            if extra_files_manifest_path_value:
+                _assert_path_within_allowed_roots(
+                    Path(extra_files_manifest_path_value),
+                    allowed_root_paths=allowed_roots,
+                    context="finalize extra_files_manifest_path",
+                )
+
+            plaintext_path_value = str(concrete_target.get("plaintext_path", "") or "")
+            if plaintext_path_value:
+                plaintext_roots = _resolve_plaintext_root_paths(concrete_target, fallback_roots=allowed_roots)
+                _assert_path_within_allowed_roots(
+                    Path(plaintext_path_value),
+                    allowed_root_paths=plaintext_roots,
+                    context="finalize plaintext_path",
+                )
+
+            if not output_path.exists():
+                association_name = str(concrete_target.get("association_name", "") or "<unknown>")
+                raise Crypt4GHRemoteExecutionError(
+                    "Crypt4GH declared output target path is missing before finalization: "
+                    f"association={association_name} path={output_path}"
+                )
+
+            output_path_key = str(output_path)
+            if output_path_key in encrypted_paths:
+                continue
+
+            encrypted_paths.add(output_path_key)
+            resolved_targets.append((concrete_target, output_path))
+    return resolved_targets
+
+
+def _finalize_output_target(
+    *,
+    concrete_target: Mapping[str, Any],
+    output_path: Path,
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+) -> dict[str, Any]:
+    plaintext_path = Path(concrete_target["plaintext_path"])
+    plaintext_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(output_path, plaintext_path)
+    dataset_output_path_value = str(concrete_target.get("dataset_output_path", "") or "")
+    dataset_output_path = Path(dataset_output_path_value) if dataset_output_path_value else None
+
+    compute_encrypted_path = Path(f"{output_path}.compute.c4gh")
+    final_tmp_path = Path(f"{output_path}.c4gh.tmp")
+    output_replaced = False
+    compute_encrypted_header = ""
+    user_encrypted_header = ""
+    try:
+        _encrypt_plaintext_to_compute_key(
+            plaintext_path=plaintext_path,
+            compute_encrypted_path=compute_encrypted_path,
+            compute_public_key=compute_public_key,
+        )
+        compute_encrypted_header = base64.b64encode(read_crypt4gh_header(str(compute_encrypted_path))).decode("ascii")
+        _rewrite_output_header_to_user_key(
+            compute_encrypted_path=compute_encrypted_path,
+            final_output_tmp_path=final_tmp_path,
+            reencryption_service_url=reencryption_service_url,
+            compute_keypair_id=compute_keypair_id,
+        )
+        os.replace(final_tmp_path, output_path)
+        output_replaced = True
+        user_encrypted_header = base64.b64encode(read_crypt4gh_header(str(output_path))).decode("ascii")
+        _write_output_markers(concrete_target)
+    except Exception as exc:
+        if not output_replaced and output_path.exists():
+            output_path.unlink()
+        if not output_replaced and dataset_output_path and dataset_output_path.exists():
+            dataset_output_path.unlink()
+        raise Crypt4GHRemoteExecutionError(
+            f"Failed to finalize encrypted Crypt4GH output at {output_path}: {exc}"
+        ) from exc
+    finally:
+        if compute_encrypted_path.exists():
+            compute_encrypted_path.unlink()
+        if final_tmp_path.exists():
+            final_tmp_path.unlink()
+
+    encrypted_ext = str(concrete_target["encrypted_ext"])
+    inner_ext = encrypted_ext[: -len(".c4gh")] if encrypted_ext.endswith(".c4gh") else encrypted_ext
+    return {
+        "association_name": str(concrete_target.get("association_name", "")),
+        "output_path": str(output_path),
+        "encrypted_ext": encrypted_ext,
+        "metadata": {
+            "crypt4gh_header": user_encrypted_header,
+            "crypt4gh_compute_header": compute_encrypted_header,
+            "crypt4gh_inner_ext": inner_ext,
+        },
+    }
+
+
+def _write_output_markers(concrete_target: Mapping[str, Any]) -> None:
+    marker_path_value = concrete_target.get("encrypted_marker_path")
+    if marker_path_value:
+        marker_path = Path(marker_path_value)
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text(f"{concrete_target['encrypted_ext']}\n")
+
+    designation = str(concrete_target.get("designation", "") or "")
+    discovered_marker_map_path = str(concrete_target.get("discovered_marker_map_path", "") or "")
+    if designation and discovered_marker_map_path:
+        _write_discovered_designation_marker(
+            marker_map_path=Path(discovered_marker_map_path),
+            designation=designation,
+            encrypted_ext=concrete_target["encrypted_ext"],
+        )
+
+
+def _resolve_output_targets(target: Mapping[str, Any]) -> list[dict[str, Any]]:
+    output_path = target.get("output_path")
+    if output_path:
+        concrete_target = {
+            "output_path": str(output_path),
+            "plaintext_path": str(target["plaintext_path"]),
+            "encrypted_ext": str(target["encrypted_ext"]),
+            "encrypted_marker_path": str(target.get("encrypted_marker_path", "")),
+            "clear_compute_keypair": bool(target.get("clear_compute_keypair", False)),
+            "association_name": str(target.get("association_name", "")),
+        }
+        dataset_output_path = target.get("dataset_output_path")
+        if dataset_output_path:
+            concrete_target["dataset_output_path"] = str(dataset_output_path)
+        extra_files_output_path = target.get("extra_files_output_path")
+        if extra_files_output_path:
+            concrete_target["extra_files_output_path"] = str(extra_files_output_path)
+        extra_files_manifest_path = target.get("extra_files_manifest_path")
+        if extra_files_manifest_path:
+            concrete_target["extra_files_manifest_path"] = str(extra_files_manifest_path)
+        allowed_root_paths = target.get("allowed_root_paths")
+        if isinstance(allowed_root_paths, (list, tuple)):
+            concrete_target["allowed_root_paths"] = [str(path) for path in allowed_root_paths if str(path)]
+        plaintext_root_paths = target.get("plaintext_root_paths")
+        if isinstance(plaintext_root_paths, (list, tuple)):
+            concrete_target["plaintext_root_paths"] = [str(path) for path in plaintext_root_paths if str(path)]
+        return [concrete_target]
+
+    if target.get("discover_pattern") is not None:
+        raise Crypt4GHRemoteExecutionError(
+            "Crypt4GH declared output finalization requires explicit output_path targets; "
+            "discovered payloads must be finalized via discovery/persistence hooks"
+        )
+
+    return []
+
+
+def _write_discovered_designation_marker(*, marker_map_path: Path, designation: str, encrypted_ext: str) -> None:
+    marker_map_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_map: dict[str, str] = {}
+    if marker_map_path.exists():
+        try:
+            loaded = json.loads(marker_map_path.read_text())
+            if isinstance(loaded, dict):
+                marker_map = {str(key): str(value) for key, value in loaded.items()}
+        except Exception:
+            marker_map = {}
+    marker_map[designation] = encrypted_ext
+    marker_map_path.write_text(json.dumps(marker_map))
+
+
+def _finalize_extra_files_payloads(
+    *,
+    concrete_target: Mapping[str, Any],
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+) -> None:
+    extra_files_output_path_value = str(concrete_target.get("extra_files_output_path", "") or "")
+    if not extra_files_output_path_value:
+        return
+
+    extra_files_output_path = Path(extra_files_output_path_value)
+    if not extra_files_output_path.exists() or not extra_files_output_path.is_dir():
+        return
+
+    extra_files_manifest_path_value = str(concrete_target.get("extra_files_manifest_path", "") or "")
+    if not extra_files_manifest_path_value:
+        raise Crypt4GHRemoteExecutionError("Crypt4GH extra_files finalization requires an extra_files manifest path")
+
+    extra_files_manifest_path = Path(extra_files_manifest_path_value)
+    if extra_files_manifest_path.exists():
+        extra_files_manifest_path.unlink()
+
+    base_plaintext_path = Path(str(concrete_target["plaintext_path"]))
+    expected_entries: set[str] = set()
+    for root, _dirs, files in os.walk(extra_files_output_path):
+        root_path = Path(root)
+        for file_name in files:
+            source_path = root_path / file_name
+            relative_path = os.path.relpath(source_path, extra_files_output_path)
+            normalized_relative_path = relative_path.replace(os.sep, "/")
+            encrypted_relative_path = _encrypted_extra_files_relative_path(relative_path=normalized_relative_path)
+
+            extra_file_target = dict(concrete_target)
+            extra_file_target["output_path"] = str(source_path)
+            extra_file_target["plaintext_path"] = str(
+                base_plaintext_path.parent / "extra_files" / encrypted_relative_path / "plaintext"
+            )
+            extra_file_target["encrypted_marker_path"] = ""
+            extra_file_target.pop("dataset_output_path", None)
+            allowed_roots = _resolve_allowed_root_paths(extra_file_target)
+            _assert_path_within_allowed_roots(
+                source_path,
+                allowed_root_paths=allowed_roots,
+                context="finalize extra_files payload",
+            )
+
+            payload_path = _rename_extra_files_payload_with_suffix_if_needed(
+                source_path=source_path,
+                extra_files_root=extra_files_output_path,
+                encrypted_relative_path=encrypted_relative_path,
+                allowed_root_paths=allowed_roots,
+            )
+            expected_entries.add(encrypted_relative_path)
+
+            extra_file_target["output_path"] = str(payload_path)
+
+            _finalize_output_target(
+                concrete_target=extra_file_target,
+                output_path=payload_path,
+                reencryption_service_url=reencryption_service_url,
+                compute_public_key=compute_public_key,
+                compute_keypair_id=compute_keypair_id,
+            )
+            _write_extra_files_manifest_entry(
+                manifest_path=extra_files_manifest_path,
+                relative_path=encrypted_relative_path,
+                encrypted_ext=str(concrete_target["encrypted_ext"]),
+            )
+            _assert_crypt4gh_payload_header(path=payload_path)
+
+    _assert_extra_files_manifest_complete(
+        manifest_path=extra_files_manifest_path,
+        expected_entries=expected_entries,
+    )
+
+
+def _write_extra_files_manifest_entry(*, manifest_path: Path, relative_path: str, encrypted_ext: str) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_payload: dict[str, Any] = {"files": {}}
+    if manifest_path.exists():
+        try:
+            loaded_payload = json.loads(manifest_path.read_text())
+            if isinstance(loaded_payload, dict):
+                manifest_payload = loaded_payload
+        except Exception:
+            manifest_payload = {"files": {}}
+
+    files_payload = manifest_payload.get("files")
+    if not isinstance(files_payload, dict):
+        files_payload = {}
+        manifest_payload["files"] = files_payload
+
+    files_payload[relative_path] = encrypted_ext
+    manifest_path.write_text(json.dumps(manifest_payload))
+
+
+def _encrypted_extra_files_relative_path(*, relative_path: str) -> str:
+    if relative_path.endswith(_CRYPT4GH_FILE_SUFFIX):
+        return relative_path
+    return f"{relative_path}{_CRYPT4GH_FILE_SUFFIX}"
+
+
+def _rename_extra_files_payload_with_suffix_if_needed(
+    *,
+    source_path: Path,
+    extra_files_root: Path,
+    encrypted_relative_path: str,
+    allowed_root_paths: Sequence[Path],
+) -> Path:
+    encrypted_path = extra_files_root / encrypted_relative_path
+    if encrypted_path == source_path:
+        return source_path
+
+    _assert_path_within_allowed_roots(
+        encrypted_path,
+        allowed_root_paths=allowed_root_paths,
+        context="finalize extra_files encrypted payload",
+    )
+    if encrypted_path.exists():
+        raise Crypt4GHRemoteExecutionError(
+            f"Crypt4GH extra_files encrypted payload already exists: {encrypted_path}"
+        )
+
+    encrypted_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.rename(encrypted_path)
+    return encrypted_path
+
+
+def _assert_extra_files_manifest_complete(*, manifest_path: Path, expected_entries: set[str]) -> None:
+    if not expected_entries:
+        return
+
+    if not manifest_path.exists():
+        raise Crypt4GHRemoteExecutionError("Crypt4GH extra_files manifest missing entries")
+
+    try:
+        manifest_payload = json.loads(manifest_path.read_text())
+    except Exception as exc:
+        raise Crypt4GHRemoteExecutionError(f"Crypt4GH extra_files manifest is unreadable: {manifest_path}") from exc
+
+    files_payload = manifest_payload.get("files") if isinstance(manifest_payload, dict) else None
+    if not isinstance(files_payload, dict):
+        raise Crypt4GHRemoteExecutionError(f"Crypt4GH extra_files manifest has invalid structure: {manifest_path}")
+
+    missing_entries = expected_entries - set(files_payload.keys())
+    if missing_entries:
+        raise Crypt4GHRemoteExecutionError("Crypt4GH extra_files manifest missing entries")
+
+
+def _assert_crypt4gh_payload_header(*, path: Path) -> None:
+    with path.open("rb") as payload_stream:
+        if payload_stream.read(8) != b"crypt4gh":
+            raise Crypt4GHRemoteExecutionError(f"Crypt4GH extra_files payload remained plaintext: {path}")
+
+
+def verify_crypt4gh_pre_success_output_evidence(
+    *,
+    working_directory: str,
+    output_dataset_associations: Sequence[Any],
+) -> None:
+    marker_dirs = _resolve_pre_success_marker_directories(working_directory=working_directory)
+    if not marker_dirs:
+        return
+
+    discovered_designations: set[str] = set()
+    discovered_parent_output_names: set[str] = set()
+    for output_dataset_assoc in output_dataset_associations:
+        association_name = getattr(output_dataset_assoc, "name", "")
+        designation = _resolve_discovered_designation(association_name)
+        if designation:
+            discovered_designations.add(designation)
+
+        discovered_parent_output_name = _resolve_discovered_parent_output_name(association_name)
+        if discovered_parent_output_name:
+            discovered_parent_output_names.add(discovered_parent_output_name)
+
+    dataset_candidates: dict[int, dict[str, Any]] = {}
+    for output_dataset_assoc in output_dataset_associations:
+        association_name = getattr(output_dataset_assoc, "name", "")
+        designation = _resolve_discovered_designation(association_name)
+        if not designation and association_name in discovered_parent_output_names:
+            continue
+
+        dataset_instance = getattr(output_dataset_assoc, "dataset", None)
+        dataset = getattr(dataset_instance, "dataset", None)
+        dataset_id = getattr(dataset, "id", None)
+        if not isinstance(dataset_id, int):
+            continue
+
+        dataset_payload_path = _dataset_payload_path(dataset)
+        if not dataset_payload_path:
+            continue
+
+        require_payload_marker = not bool(designation)
+        candidate = dataset_candidates.get(dataset_id)
+        if candidate is None:
+            dataset_candidates[dataset_id] = {
+                "dataset": dataset,
+                "require_payload_marker": require_payload_marker,
+                "discovered_designation": designation,
+            }
+        else:
+            candidate["require_payload_marker"] = (
+                bool(candidate.get("require_payload_marker", False)) or require_payload_marker
+            )
+            if designation and not candidate.get("discovered_designation"):
+                candidate["discovered_designation"] = designation
+
+    diagnostics: list[str] = []
+    for dataset_id in sorted(dataset_candidates):
+        candidate = dataset_candidates[dataset_id]
+        _verify_payload_header_evidence(
+            dataset_id=dataset_id,
+            dataset=candidate.get("dataset"),
+            diagnostics=diagnostics,
+        )
+        if bool(candidate.get("require_payload_marker", False)):
+            _verify_payload_marker_evidence(marker_dirs=marker_dirs, dataset_id=dataset_id, diagnostics=diagnostics)
+        _verify_extra_files_manifest_evidence(
+            marker_dirs=marker_dirs,
+            dataset_id=dataset_id,
+            dataset=candidate.get("dataset"),
+            discovered_designation=str(candidate.get("discovered_designation", "") or ""),
+            diagnostics=diagnostics,
+        )
+
+    _verify_no_residual_plaintext_staging_artifacts(
+        working_directory=working_directory,
+        diagnostics=diagnostics,
+    )
+
+    if discovered_designations:
+        _verify_discovered_mapping_evidence(
+            marker_dirs=marker_dirs,
+            discovered_designations=discovered_designations,
+            diagnostics=diagnostics,
+        )
+
+    if diagnostics:
+        diagnostics_text = "; ".join(diagnostics)
+        log.error("Crypt4GH pre-success verifier failed in %s: %s", working_directory, diagnostics_text)
+        raise Crypt4GHRemoteExecutionError(f"Crypt4GH pre-success verifier failed: {diagnostics_text}")
+
+
+def _resolve_pre_success_marker_directories(*, working_directory: str) -> list[Path]:
+    working_directory_path = Path(working_directory)
+    candidates = [
+        working_directory_path / "_c4gh_stage" / "outputs",
+        working_directory_path / "working" / "_c4gh_stage" / "outputs",
+    ]
+    parent_directory = working_directory_path.parent
+    if parent_directory != working_directory_path:
+        candidates.append(parent_directory / "_c4gh_stage" / "outputs")
+
+    marker_dirs: list[Path] = []
+    seen_dirs: set[str] = set()
+    for candidate in candidates:
+        candidate_key = str(candidate)
+        if candidate_key in seen_dirs:
+            continue
+        seen_dirs.add(candidate_key)
+        if candidate.is_dir():
+            marker_dirs.append(candidate)
+    return marker_dirs
+
+
+def _resolve_discovered_designation(association_name: Any) -> str:
+    if not isinstance(association_name, str) or not association_name.startswith("__new_primary_file_"):
+        return ""
+
+    split_name = association_name[len("__new_primary_file_") :].split("|", 1)
+    if len(split_name) != 2:
+        return ""
+
+    designation = split_name[1]
+    if designation.endswith("__"):
+        designation = designation[:-2]
+    return designation
+
+
+def _resolve_discovered_parent_output_name(association_name: Any) -> str:
+    if not isinstance(association_name, str) or not association_name.startswith("__new_primary_file_"):
+        return ""
+
+    split_name = association_name[len("__new_primary_file_") :].split("|", 1)
+    if len(split_name) != 2:
+        return ""
+
+    return split_name[0]
+
+
+def _verify_payload_marker_evidence(*, marker_dirs: Sequence[Path], dataset_id: int, diagnostics: list[str]) -> None:
+    found_marker = False
+    saw_unreadable_marker = False
+    saw_invalid_marker = False
+
+    for marker_dir in marker_dirs:
+        marker_path = marker_dir / f"ds_{dataset_id}.encrypted"
+        if not marker_path.exists():
+            continue
+
+        found_marker = True
+        try:
+            marker_ext = marker_path.read_text().strip()
+        except Exception:
+            saw_unreadable_marker = True
+            continue
+
+        if marker_ext:
+            return
+        saw_invalid_marker = True
+
+    if not found_marker:
+        diagnostics.append(f"payload marker missing for dataset_id={dataset_id}")
+    elif saw_invalid_marker:
+        diagnostics.append(f"payload marker invalid for dataset_id={dataset_id}")
+    elif saw_unreadable_marker:
+        diagnostics.append(f"payload marker unreadable for dataset_id={dataset_id}")
+
+
+def _verify_payload_header_evidence(*, dataset_id: int, dataset: Any, diagnostics: list[str]) -> None:
+    dataset_path = _dataset_payload_path(dataset)
+    if not dataset_path:
+        return
+
+    payload_path = Path(dataset_path)
+    if not payload_path.exists():
+        diagnostics.append(f"payload path missing for dataset_id={dataset_id}")
+        return
+
+    try:
+        with payload_path.open("rb") as payload_stream:
+            payload_prefix = payload_stream.read(8)
+    except Exception:
+        diagnostics.append(f"payload unreadable for dataset_id={dataset_id}")
+        return
+
+    if payload_prefix != b"crypt4gh":
+        diagnostics.append(f"payload remained plaintext for dataset_id={dataset_id}")
+
+
+def _verify_discovered_mapping_evidence(
+    *, marker_dirs: Sequence[Path], discovered_designations: set[str], diagnostics: list[str]
+) -> None:
+    mapping_paths = [marker_dir / "discovered_designations.json" for marker_dir in marker_dirs]
+    existing_paths = [mapping_path for mapping_path in mapping_paths if mapping_path.exists()]
+    if not existing_paths:
+        for designation in sorted(discovered_designations):
+            diagnostics.append(f"discovered-output mapping missing for designation={designation}")
+        return
+
+    merged_mapping: dict[str, str] = {}
+    saw_unreadable_mapping = False
+    saw_invalid_mapping = False
+    for mapping_path in existing_paths:
+        try:
+            loaded_mapping = json.loads(mapping_path.read_text())
+        except Exception:
+            saw_unreadable_mapping = True
+            continue
+
+        if not isinstance(loaded_mapping, dict):
+            saw_invalid_mapping = True
+            continue
+
+        for key, value in loaded_mapping.items():
+            merged_mapping[str(key)] = str(value)
+
+    if not merged_mapping:
+        if saw_invalid_mapping:
+            diagnostics.append("discovered-output mapping invalid")
+            return
+        if saw_unreadable_mapping:
+            diagnostics.append("discovered-output mapping unreadable")
+            return
+        for designation in sorted(discovered_designations):
+            diagnostics.append(f"discovered-output mapping missing for designation={designation}")
+        return
+
+    for designation in sorted(discovered_designations):
+        if not any(bool(value) and key == designation for key, value in merged_mapping.items()):
+            diagnostics.append(f"discovered-output mapping missing for designation={designation}")
+
+
+def _verify_extra_files_manifest_evidence(
+    *,
+    marker_dirs: Sequence[Path],
+    dataset_id: int,
+    dataset: Any,
+    discovered_designation: str,
+    diagnostics: list[str],
+) -> None:
+    dataset_path = _dataset_payload_path(dataset)
+    if not dataset_path:
+        return
+
+    extra_files_path = Path(dataset_path_to_extra_path(dataset_path))
+    if not extra_files_path.exists() or not extra_files_path.is_dir():
+        return
+
+    observed_entries: set[str] = set()
+    for root, _dirs, files in os.walk(extra_files_path):
+        root_path = Path(root)
+        for file_name in files:
+            source_path = root_path / file_name
+            relative_path = os.path.relpath(source_path, extra_files_path)
+            observed_entries.add(relative_path.replace(os.sep, "/"))
+
+    manifest_paths = [marker_dir / f"ds_{dataset_id}.extra_files_manifest.json" for marker_dir in marker_dirs]
+    discovered_designation = discovered_designation or _resolve_discovered_designation(
+        getattr(dataset, "designation", "")
+    )
+    if discovered_designation:
+        designation_token = _safe_discovered_designation_token(discovered_designation)
+        manifest_paths.extend(
+            marker_dir / f"designation_{designation_token}.extra_files_manifest.json" for marker_dir in marker_dirs
+        )
+
+    existing_paths: list[Path] = []
+    seen_manifest_paths: set[str] = set()
+    for manifest_path in manifest_paths:
+        manifest_path_key = str(manifest_path)
+        if manifest_path_key in seen_manifest_paths:
+            continue
+        seen_manifest_paths.add(manifest_path_key)
+        if manifest_path.exists():
+            existing_paths.append(manifest_path)
+    if not existing_paths:
+        diagnostics.append(f"extra_files manifest missing for dataset_id={dataset_id}")
+        return
+
+    saw_unreadable_manifest = False
+    saw_invalid_manifest = False
+    saw_missing_entries = False
+    complete_manifest_found = False
+    expected_payload_entries: set[str] = set()
+    for manifest_path in existing_paths:
+        try:
+            manifest_payload = json.loads(manifest_path.read_text())
+        except Exception:
+            saw_unreadable_manifest = True
+            continue
+
+        files_payload = manifest_payload.get("files") if isinstance(manifest_payload, dict) else None
+        if not isinstance(files_payload, dict):
+            saw_invalid_manifest = True
+            continue
+
+        manifest_entries = set(files_payload.keys())
+        if not observed_entries:
+            if manifest_entries:
+                complete_manifest_found = True
+                expected_payload_entries = manifest_entries
+                break
+            continue
+
+        missing_entries = observed_entries - manifest_entries
+        if not missing_entries:
+            complete_manifest_found = True
+            expected_payload_entries = manifest_entries
+            break
+        saw_missing_entries = True
+
+    if complete_manifest_found:
+        _verify_extra_files_payload_header_evidence(
+            dataset_id=dataset_id,
+            extra_files_path=extra_files_path,
+            expected_entries=expected_payload_entries,
+            diagnostics=diagnostics,
+        )
+        return
+
+    if saw_missing_entries:
+        diagnostics.append(f"extra_files manifest missing entries for dataset_id={dataset_id}")
+    elif saw_invalid_manifest:
+        diagnostics.append(f"extra_files manifest invalid for dataset_id={dataset_id}")
+    elif saw_unreadable_manifest:
+        diagnostics.append(f"extra_files manifest unreadable for dataset_id={dataset_id}")
+
+
+def _verify_no_residual_plaintext_staging_artifacts(*, working_directory: str, diagnostics: list[str]) -> None:
+    crypt_root = Path(working_directory) / "_crypt"
+    plaintext_roots = (crypt_root / "outputs", crypt_root / "inputs")
+
+    for plaintext_root in plaintext_roots:
+        if not plaintext_root.exists() or not plaintext_root.is_dir():
+            continue
+
+        for root, _dirs, files in os.walk(plaintext_root):
+            root_path = Path(root)
+            for file_name in files:
+                if file_name != "plaintext":
+                    continue
+
+                leaked_path = root_path / file_name
+                diagnostics.append(f"plaintext staging artifact remained at path={leaked_path}")
+
+
+def _verify_extra_files_payload_header_evidence(
+    *,
+    dataset_id: int,
+    extra_files_path: Path,
+    expected_entries: set[str],
+    diagnostics: list[str],
+) -> None:
+    for relative_path in sorted(expected_entries):
+        payload_path = extra_files_path / relative_path
+        if payload_path.is_symlink():
+            diagnostics.append(f"extra_files payload symlink for dataset_id={dataset_id} path={relative_path}")
+            continue
+
+        if not payload_path.exists():
+            diagnostics.append(f"extra_files payload missing for dataset_id={dataset_id} path={relative_path}")
+            continue
+
+        try:
+            with payload_path.open("rb") as payload_stream:
+                payload_prefix = payload_stream.read(8)
+        except Exception:
+            diagnostics.append(f"extra_files payload unreadable for dataset_id={dataset_id} path={relative_path}")
+            continue
+
+        if payload_prefix != b"crypt4gh":
+            diagnostics.append(f"extra_files payload remained plaintext for dataset_id={dataset_id} path={relative_path}")
+
+
+def _safe_discovered_designation_token(designation: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", designation).strip("._-")
+    return sanitized or "designation"
+
+
+def _resolve_allowed_root_paths(concrete_target: Mapping[str, Any]) -> tuple[Path, ...]:
+    configured_paths = concrete_target.get("allowed_root_paths")
+    resolved_paths: list[Path] = []
+
+    if isinstance(configured_paths, (list, tuple)):
+        for path_value in configured_paths:
+            try:
+                candidate = Path(str(path_value)).resolve(strict=False)
+            except Exception:
+                continue
+            resolved_paths.append(candidate)
+
+    if not resolved_paths:
+        default_paths = [
+            concrete_target.get("output_path"),
+            concrete_target.get("dataset_output_path"),
+            concrete_target.get("extra_files_output_path"),
+            concrete_target.get("extra_files_manifest_path"),
+            concrete_target.get("encrypted_marker_path"),
+            concrete_target.get("plaintext_path"),
+        ]
+        for path_value in default_paths:
+            if not path_value:
+                continue
+            try:
+                resolved_paths.append(Path(str(path_value)).resolve(strict=False).parent)
+            except Exception:
+                continue
+
+    deduped_paths: list[Path] = []
+    seen: set[str] = set()
+    for resolved_path in resolved_paths:
+        key = str(resolved_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped_paths.append(resolved_path)
+
+    return tuple(deduped_paths)
+
+
+def _resolve_plaintext_root_paths(
+    concrete_target: Mapping[str, Any], *, fallback_roots: Sequence[Path]
+) -> tuple[Path, ...]:
+    configured_paths = concrete_target.get("plaintext_root_paths")
+    resolved_paths: list[Path] = []
+
+    if isinstance(configured_paths, (list, tuple)):
+        for path_value in configured_paths:
+            try:
+                candidate = Path(str(path_value)).resolve(strict=False)
+            except Exception:
+                continue
+            resolved_paths.append(candidate)
+
+    if not resolved_paths:
+        resolved_paths = list(fallback_roots)
+
+    deduped_paths: list[Path] = []
+    seen: set[str] = set()
+    for resolved_path in resolved_paths:
+        key = str(resolved_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped_paths.append(resolved_path)
+
+    return tuple(deduped_paths)
+
+
+def _assert_path_within_allowed_roots(path: Path, *, allowed_root_paths: Sequence[Path], context: str) -> None:
+    if not allowed_root_paths:
+        return
+
+    resolved_path = path.resolve(strict=False)
+    for root_path in allowed_root_paths:
+        try:
+            resolved_path.relative_to(root_path)
+            return
+        except ValueError:
+            continue
+
+    raise Crypt4GHRemoteExecutionError(f"Crypt4GH {context} path is outside allowed roots: {path}")
+
+
+def _dataset_payload_path(dataset: Any) -> str:
+    get_file_name = getattr(dataset, "get_file_name", None)
+    if not callable(get_file_name):
+        return ""
+
+    try:
+        return str(get_file_name(sync_cache=False) or "")
+    except TypeError:
+        return str(get_file_name() or "")
+
+
+def build_crypt4gh_cleanup_wrapped_command(
+    *, tool_command: str, cleanup_command: str, postrun_command: str = ""
+) -> str:
+    """Wrap tool command with postrun and cleanup steps that preserve failures."""
+
+    postrun_command = postrun_command.strip()
+    cleanup_command = cleanup_command.strip()
+    if not cleanup_command:
+        if not postrun_command:
+            return tool_command
+        lines = _build_tool_and_postrun_shell_lines(
+            tool_command=tool_command,
+            postrun_command=postrun_command,
+            include_exit_checks=True,
+        )
+        return "\n".join(lines)
+
+    lines = _build_tool_and_postrun_shell_lines(
+        tool_command=tool_command,
+        postrun_command=postrun_command,
+        include_exit_checks=False,
+    )
+    marker_line = (
+        f'    echo "{CRYPT4GH_PLAINTEXT_CLEANUP_FAILED_MARKER}: cleanup failed with exit code '
+        '${_CRYPT4GH_CLEANUP_EXIT}" >&2'
+    )
+    lines.extend(
+        [
+            "if (",
+            cleanup_command,
+            "); then",
+            "    _CRYPT4GH_CLEANUP_EXIT=0",
+            "else",
+            "    _CRYPT4GH_CLEANUP_EXIT=$?",
+            marker_line,
+            "fi",
+            "if [ $_CRYPT4GH_TOOL_EXIT -ne 0 ]; then",
+            "    exit $_CRYPT4GH_TOOL_EXIT",
+            "fi",
+            "if [ $_CRYPT4GH_POSTRUN_EXIT -ne 0 ]; then",
+            "    exit $_CRYPT4GH_POSTRUN_EXIT",
+            "fi",
+            "if [ $_CRYPT4GH_CLEANUP_EXIT -ne 0 ]; then",
+            "    exit $_CRYPT4GH_CLEANUP_EXIT",
+            "fi",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_tool_and_postrun_shell_lines(
+    *, tool_command: str, postrun_command: str, include_exit_checks: bool
+) -> list[str]:
+    lines = [
+        "if (",
+        tool_command,
+        "); then",
+        "    _CRYPT4GH_TOOL_EXIT=0",
+        "else",
+        "    _CRYPT4GH_TOOL_EXIT=$?",
+        "fi",
+    ]
+    if postrun_command:
+        lines.extend(
+            [
+                "if [ $_CRYPT4GH_TOOL_EXIT -eq 0 ]; then",
+                "    if (",
+                postrun_command,
+                "    ); then",
+                "        _CRYPT4GH_POSTRUN_EXIT=0",
+                "    else",
+                "        _CRYPT4GH_POSTRUN_EXIT=$?",
+                "    fi",
+                "else",
+                "    _CRYPT4GH_POSTRUN_EXIT=0",
+                "fi",
+            ]
+        )
+    else:
+        lines.append("_CRYPT4GH_POSTRUN_EXIT=0")
+
+    if include_exit_checks:
+        lines.extend(
+            [
+                "if [ $_CRYPT4GH_TOOL_EXIT -ne 0 ]; then",
+                "    exit $_CRYPT4GH_TOOL_EXIT",
+                "fi",
+                "if [ $_CRYPT4GH_POSTRUN_EXIT -ne 0 ]; then",
+                "    exit $_CRYPT4GH_POSTRUN_EXIT",
+                "fi",
+            ]
+        )
+    return lines
+
+
+def _encrypt_plaintext_to_compute_key(
+    *,
+    plaintext_path: Path,
+    compute_encrypted_path: Path,
+    compute_public_key: str,
+) -> None:
+    recipient_key = _parse_crypt4gh_public_key(compute_public_key)
+    ephemeral_private_key = X25519PrivateKey.generate().private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    with plaintext_path.open("rb") as plaintext_stream, compute_encrypted_path.open("wb") as encrypted_stream:
+        crypt4gh.lib.encrypt([(0, ephemeral_private_key, recipient_key)], plaintext_stream, encrypted_stream)
+
+
+def _rewrite_output_header_to_user_key(
+    *,
+    compute_encrypted_path: Path,
+    final_output_tmp_path: Path,
+    reencryption_service_url: str,
+    compute_keypair_id: str,
+) -> None:
+    with compute_encrypted_path.open("rb") as encrypted_stream:
+        list(crypt4gh.header.parse(encrypted_stream))
+        header_length = encrypted_stream.tell()
+        encrypted_stream.seek(0)
+        encrypted_header = encrypted_stream.read(header_length)
+
+    recrypted_header = _recrypt_header_to_user_key(
+        reencryption_service_url=reencryption_service_url,
+        crypt4gh_header=base64.b64encode(encrypted_header).decode("ascii"),
+        compute_keypair_id=compute_keypair_id,
+    )
+    recrypted_header_bytes = _decode_header(recrypted_header)
+    _header_length(recrypted_header_bytes)
+
+    with compute_encrypted_path.open("rb") as encrypted_stream, final_output_tmp_path.open("wb") as final_stream:
+        encrypted_stream.seek(header_length)
+        final_stream.write(recrypted_header_bytes)
+        shutil.copyfileobj(encrypted_stream, final_stream)
+
+
+def _recrypt_header_to_user_key(
+    *,
+    reencryption_service_url: str,
+    crypt4gh_header: str,
+    compute_keypair_id: str,
+) -> str:
+    endpoint = f"{reencryption_service_url.rstrip('/')}/recrypt_header_to_user_key"
+    payload = {
+        "crypt4gh_header": crypt4gh_header,
+        "crypt4gh_compute_keypair_id": compute_keypair_id,
+    }
+    try:
+        response = _post_reencryption_json(
+            reencryption_service_url=reencryption_service_url,
+            endpoint=endpoint,
+            payload=payload,
+        )
+    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+        raise Crypt4GHRemoteExecutionError(f"Failed to contact compute-side recryptor B at {endpoint}: {exc}") from exc
+
+    if not response.ok:
+        raise Crypt4GHRemoteExecutionError(
+            f"Compute-side recryptor B returned HTTP {response.status_code} for {endpoint}: "
+            f"{_summarize_http_error_response(response)}"
+        )
+
+    try:
+        response_json = response.json_payload
+        if not isinstance(response_json, dict):
+            raise ValueError("Response body is not a JSON object")
+        return cast(str, response_json["crypt4gh_header"])
+    except (ValueError, KeyError, TypeError) as exc:
+        raise Crypt4GHRemoteExecutionError(
+            "Compute-side recryptor B returned an invalid /recrypt_header_to_user_key payload"
+        ) from exc
+
+
+def _parse_crypt4gh_public_key(public_key_pem: str) -> bytes:
+    lines = [line.strip() for line in public_key_pem.splitlines() if line.strip()]
+    if len(lines) < 3:
+        raise Crypt4GHRemoteExecutionError("Invalid CRYPT4GH public key payload")
+    try:
+        return base64.b64decode("".join(lines[1:-1]))
+    except ValueError as exc:
+        raise Crypt4GHRemoteExecutionError("Invalid CRYPT4GH public key payload") from exc
+
+
+def _summarize_http_error_response(response: _ReencryptionHttpResponse) -> str:
+    detail: Any = None
+    payload = response.json_payload
+
+    if isinstance(payload, dict):
+        for key in ("detail", "message", "error"):
+            candidate = payload.get(key)
+            if candidate:
+                detail = candidate
+                break
+        if detail is None and payload:
+            detail = payload
+    elif isinstance(payload, list):
+        detail = payload
+    elif isinstance(payload, str):
+        detail = payload
+    else:
+        detail = response.text
+
+    summary = re.sub(r"\s+", " ", str(detail or "")).strip()
+    if not summary:
+        return "no error details provided"
+    if len(summary) > 200:
+        return f"{summary[:200]}..."
+    return summary
+
+
+def _decrypt_recrypted_input(
+    *,
+    source_dataset_path: Path,
+    source_header: str,
+    recrypted_header: str,
+    plaintext_path: Path,
+    job_private_key: bytes,
+) -> None:
+    source_header_bytes = _decode_header(source_header)
+    recrypted_header_bytes = _decode_header(recrypted_header)
+    source_header_length = _header_length(source_header_bytes)
+    try:
+        with source_dataset_path.open("rb") as source_stream, plaintext_path.open("wb") as plaintext_stream:
+            source_stream.seek(source_header_length)
+            staged_stream = _HeaderThenBodyStream(header_bytes=recrypted_header_bytes, body_stream=source_stream)
+            crypt4gh.lib.decrypt([(0, job_private_key, None)], staged_stream, plaintext_stream)
+    except OSError as exc:
+        raise Crypt4GHRemoteExecutionError(
+            f"Failed to read or materialize Crypt4GH input for source dataset {source_dataset_path}: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise Crypt4GHRemoteExecutionError(f"Failed to decrypt staged Crypt4GH input {source_dataset_path}") from exc
+
+
+def _decode_header(encoded_header: str) -> bytes:
+    try:
+        return base64.b64decode(encoded_header)
+    except (ValueError, TypeError) as exc:
+        raise Crypt4GHRemoteExecutionError("Invalid base64-encoded Crypt4GH header") from exc
+
+
+def _header_length(header_bytes: bytes) -> int:
+    try:
+        stream = io.BytesIO(header_bytes)
+        list(crypt4gh.header.parse(stream))
+        return stream.tell()
+    except Exception as exc:
+        raise Crypt4GHRemoteExecutionError("Invalid Crypt4GH header payload") from exc
+
+
+def _assert_minimum_ttl(*, datasets: Sequence[DatasetInstance], minimum_ttl: timedelta, now: datetime) -> None:
+    for dataset in datasets:
+        metadata = getattr(dataset, "metadata", None)
+        expires_raw = getattr(metadata, "crypt4gh_compute_keypair_expiration_date", None)
+        if not expires_raw:
+            raise Crypt4GHRemoteExecutionError(
+                "Crypt4GH key metadata missing; minimum TTL cannot be validated before remote call"
+            )
+
+        expires_at = _parse_expiration(expires_raw)
+        ttl_left = expires_at - now
+        if ttl_left <= minimum_ttl:
+            raise Crypt4GHRemoteExecutionError(
+                "Crypt4GH compute key violates minimum TTL requirement before remote call"
+            )
+
+
+def _parse_expiration(expires_raw: datetime | str) -> datetime:
+    if isinstance(expires_raw, datetime):
+        expires_at = expires_raw
+    elif isinstance(expires_raw, str):
+        try:
+            expires_at = isoparse(expires_raw)
+        except ValueError as exc:
+            raise Crypt4GHRemoteExecutionError("Invalid Crypt4GH compute key expiration timestamp") from exc
+    else:
+        raise Crypt4GHRemoteExecutionError("Invalid Crypt4GH compute key expiration timestamp")
+
+    if expires_at.tzinfo is None:
+        raise Crypt4GHRemoteExecutionError("Invalid Crypt4GH compute key expiration timestamp - timezone is lacking")
+
+    return expires_at
+
+
+def _assert_key_valid_for_output_finalization(*, compute_keypair_expiration_date: str, now: datetime) -> None:
+    expires_at = _parse_expiration(compute_keypair_expiration_date)
+    if expires_at <= now:
+        raise Crypt4GHRemoteExecutionError("Crypt4GH compute key expired before output finalization; failing closed")

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -1399,10 +1399,34 @@ def build_crypt4gh_postrun_command(
         f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
         f"{shlex.quote(python_executable)} -c {shlex.quote(cleanup_script)}"
     )
+
+    # Collect declared Crypt4GH output paths so the shell wrapper can remove
+    # plaintext remnants when the postrun did not run or did not succeed.
+    # Discovered output paths are not included here because they are only
+    # known after the postrun runs; the regular _crypt/outputs cleanup and
+    # job-runner working-directory deletion handle those.
+    plaintext_output_paths: list[str] = []
+    for target in output_targets:
+        path = str(target.get("output_path", "") or "")
+        if path:
+            plaintext_output_paths.append(path)
+
+    plaintext_cleanup_command = ""
+    if plaintext_output_paths:
+        plaintext_cleanup_script = (
+            f"from galaxy.util.crypt4gh import cleanup_crypt4gh_plaintext_outputs; "
+            f"cleanup_crypt4gh_plaintext_outputs(output_paths={json.dumps(plaintext_output_paths)})"
+        )
+        plaintext_cleanup_command = (
+            f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
+            f"{shlex.quote(python_executable)} -c {shlex.quote(plaintext_cleanup_script)}"
+        )
+
     return build_crypt4gh_cleanup_wrapped_command(
         tool_command=tool_command,
         postrun_command=postrun_command,
         cleanup_command=cleanup_command,
+        plaintext_output_cleanup_command=plaintext_cleanup_command,
     )
 
 
@@ -2536,6 +2560,24 @@ def _verify_extra_files_manifest_evidence(
             expected_entries=expected_payload_entries,
             diagnostics=diagnostics,
         )
+        # Also check for unencrypted files that lack manifest entries.
+        unmanifested_entries = observed_entries - expected_payload_entries
+        for rel_path in sorted(unmanifested_entries):
+            unmanifested_file = extra_files_path / rel_path
+            if not unmanifested_file.exists():
+                continue
+            try:
+                with unmanifested_file.open("rb") as ef_stream:
+                    ef_prefix = ef_stream.read(8)
+            except Exception:
+                diagnostics.append(
+                    f"extra_files unmanifested payload unreadable for dataset_id={dataset_id} path={rel_path}"
+                )
+                continue
+            if ef_prefix != b"crypt4gh":
+                diagnostics.append(
+                    f"extra_files unmanifested plaintext payload for dataset_id={dataset_id} path={rel_path}"
+                )
         return
 
     if saw_missing_entries:
@@ -2557,11 +2599,17 @@ def _verify_no_residual_plaintext_staging_artifacts(*, working_directory: str, d
         for root, _dirs, files in os.walk(plaintext_root):
             root_path = Path(root)
             for file_name in files:
-                if file_name != "plaintext":
+                # Primary plaintext staging artifacts are named "plaintext".
+                if file_name == "plaintext":
+                    diagnostics.append(f"plaintext staging artifact remained at path={root_path / file_name}")
                     continue
 
-                leaked_path = root_path / file_name
-                diagnostics.append(f"plaintext staging artifact remained at path={leaked_path}")
+                # Input extra files are staged under plaintext_files/ directories.
+                # Any file remaining there (not cleaned up) is a residual artifact.
+                if "plaintext_files" in root_path.parts and not file_name.endswith(_CRYPT4GH_FILE_SUFFIX):
+                    diagnostics.append(
+                        f"plaintext extra_files staging artifact remained at path={root_path / file_name}"
+                    )
 
 
 def _verify_extra_files_payload_header_evidence(
@@ -2694,12 +2742,25 @@ def _dataset_payload_path(dataset: Any) -> str:
 
 
 def build_crypt4gh_cleanup_wrapped_command(
-    *, tool_command: str, cleanup_command: str, postrun_command: str = ""
+    *,
+    tool_command: str,
+    cleanup_command: str,
+    postrun_command: str = "",
+    plaintext_output_cleanup_command: str = "",
 ) -> str:
-    """Wrap tool command with postrun and cleanup steps that preserve failures."""
+    """Wrap tool command with postrun and cleanup steps that preserve failures.
+
+    When *plaintext_output_cleanup_command* is provided, it is executed after
+    the regular cleanup step **only if** the tool or postrun did not succeed.
+    This removes unencrypted output files left behind by a failed tool or a
+    failed/skipped postrun, ensuring no plaintext dataset persists on the
+    compute node.  A failure of this step is reported via the cleanup-failed
+    marker so the host side can surface it.
+    """
 
     postrun_command = postrun_command.strip()
     cleanup_command = cleanup_command.strip()
+    plaintext_output_cleanup_command = plaintext_output_cleanup_command.strip()
     if not cleanup_command:
         if not postrun_command:
             return tool_command
@@ -2729,6 +2790,35 @@ def build_crypt4gh_cleanup_wrapped_command(
             "    _CRYPT4GH_CLEANUP_EXIT=$?",
             marker_line,
             "fi",
+        ]
+    )
+
+    if plaintext_output_cleanup_command:
+        # Remove plaintext output files when the postrun did not succeed.
+        # This runs unconditionally after the regular cleanup step — the
+        # Python function itself checks for Crypt4GH magic bytes and only
+        # deletes files that are NOT encrypted.
+        plaintext_marker_line = (
+            f'    echo "{CRYPT4GH_CLEANUP_FAILED_MARKER}: plaintext output cleanup failed with exit code '
+            '${_CRYPT4GH_PLAINTEXT_CLEANUP_EXIT}" >&2'
+        )
+        lines.extend(
+            [
+                "if [ $_CRYPT4GH_TOOL_EXIT -ne 0 ] || [ $_CRYPT4GH_POSTRUN_EXIT -ne 0 ]; then",
+                "    if (",
+                plaintext_output_cleanup_command,
+                "    ); then",
+                "        _CRYPT4GH_PLAINTEXT_CLEANUP_EXIT=0",
+                "    else",
+                "        _CRYPT4GH_PLAINTEXT_CLEANUP_EXIT=$?",
+                plaintext_marker_line,
+                "    fi",
+                "fi",
+            ]
+        )
+
+    lines.extend(
+        [
             "if [ $_CRYPT4GH_TOOL_EXIT -ne 0 ]; then",
             "    exit $_CRYPT4GH_TOOL_EXIT",
             "fi",

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -1108,6 +1108,9 @@ def collect_discovery_crypt4gh_output_specs(
                     "discovered_marker_map_path": discovered_marker_map_path,
                     "allowed_root_paths": [str(Path(working_directory).resolve())],
                     "plaintext_root_paths": [str(Path(working_directory).resolve())],
+                    "extra_files_manifest_dir": str(
+                        Path(working_directory) / "_c4gh_stage" / "outputs"
+                    ),
                 }
             )
 
@@ -1183,6 +1186,18 @@ def finalize_discovered_crypt4gh_payloads(
                     clear_compute_keypair=False,
                 )
 
+                # Encrypt any extra files in a sibling _files directory.
+                _finalize_discovered_extra_files(
+                    source_path=source_path,
+                    encrypted_ext=encrypted_ext,
+                    designation=designation,
+                    reencryption_service_url=reencryption_service_url,
+                    compute_public_key=compute_public_key,
+                    compute_keypair_id=compute_keypair_id,
+                    compute_keypair_expiration_date=compute_keypair_expiration_date,
+                    spec=spec,
+                )
+
                 payload_metadata.append(
                     {
                         "output_name": str(spec.get("output_name", "")),
@@ -1193,6 +1208,82 @@ def finalize_discovered_crypt4gh_payloads(
                 )
 
     return payload_metadata
+
+
+def _finalize_discovered_extra_files(
+    *,
+    source_path: Path,
+    encrypted_ext: str,
+    designation: str,
+    reencryption_service_url: str,
+    compute_public_key: str,
+    compute_keypair_id: str,
+    compute_keypair_expiration_date: str | None,
+    spec: Mapping[str, Any],
+) -> None:
+    """Encrypt extra files for a discovered dataset.
+
+    Looks for a sibling ``_files`` directory next to *source_path* (derived
+    via :func:`dataset_path_to_extra_path`).  If it exists and contains
+    files, each non-``.c4gh`` file is encrypted in-place using the same
+    compute key.  A manifest is written to the marker directory for
+    host-side verification.
+    """
+    extra_files_path_str = dataset_path_to_extra_path(str(source_path))
+    extra_files_path = Path(extra_files_path_str)
+    if not extra_files_path.exists() or not extra_files_path.is_dir():
+        return None
+
+    manifest_dir = Path(str(spec.get("extra_files_manifest_dir", "") or ""))
+    designation_token = _safe_discovered_designation_token(designation)
+    manifest_path = manifest_dir / f"designation_{designation_token}.extra_files_manifest.json" if manifest_dir else None
+
+    allowed_root_paths = cast(Sequence[str], spec.get("allowed_root_paths", []))
+    plaintext_root_paths = cast(Sequence[str], spec.get("plaintext_root_paths", []))
+
+    manifest: dict[str, str] = {}
+    for root, _dirs, files in os.walk(extra_files_path):
+        root_path = Path(root)
+        for file_name in files:
+            file_path = root_path / file_name
+            if file_name.endswith(_CRYPT4GH_FILE_SUFFIX):
+                # Already encrypted — record in manifest and skip.
+                rel = os.path.relpath(file_path, extra_files_path).replace(os.sep, "/")
+                manifest[rel] = encrypted_ext
+                continue
+
+            rel_path = os.path.relpath(file_path, extra_files_path)
+            normalized_rel_path = rel_path.replace(os.sep, "/")
+            encrypted_rel_path = _encrypted_extra_files_relative_path(relative_path=normalized_rel_path)
+            encrypted_file_path = extra_files_path / encrypted_rel_path
+
+            # Rename the plaintext file to the .c4gh path before encryption,
+            # consistent with declared output extra files handling.
+            encrypted_file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.rename(encrypted_file_path)
+
+            finalize_about_to_persist_crypt4gh_payload(
+                output_path=str(encrypted_file_path),
+                plaintext_path=str(
+                    encrypted_file_path.parent / f"{encrypted_file_path.name}.plaintext"
+                ),
+                encrypted_ext=encrypted_ext,
+                reencryption_service_url=reencryption_service_url,
+                compute_public_key=compute_public_key,
+                compute_keypair_id=compute_keypair_id,
+                compute_keypair_expiration_date=compute_keypair_expiration_date,
+                encrypted_marker_path="",
+                dataset_output_path="",
+                allowed_root_paths=allowed_root_paths,
+                plaintext_root_paths=plaintext_root_paths,
+                clear_compute_keypair=False,
+            )
+            _assert_crypt4gh_payload_header(path=encrypted_file_path)
+            manifest[encrypted_rel_path] = encrypted_ext
+
+    if manifest and manifest_path:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps({"files": manifest}))
 
 
 def emit_crypt4gh_galaxy_metadata(
@@ -1506,13 +1597,13 @@ def finalize_declared_crypt4gh_outputs(
                 compute_public_key=compute_public_key,
                 compute_keypair_id=compute_keypair_id,
             )
-            output_metadata.append(payload_metadata)
             _finalize_extra_files_payloads(
                 concrete_target=concrete_target,
                 reencryption_service_url=reencryption_service_url,
                 compute_public_key=compute_public_key,
                 compute_keypair_id=compute_keypair_id,
             )
+            output_metadata.append(payload_metadata)
     except Exception:
         _purge_output_targets_after_finalization_failure(resolved_targets)
         raise

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -318,9 +318,13 @@ class Crypt4GHRemoteComputeEnvironment(SharedComputeEnvironment):
         compute_public_key: str | None,
         compute_keypair_id: str | None,
         compute_keypair_expiration_date: str | None,
+        input_extra_files_overrides_by_dataset_id: Mapping[int, str] | None = None,
     ) -> None:
         super().__init__(job_io=job_io, job=job)
         self._input_path_overrides_by_dataset_id = dict(input_path_overrides_by_dataset_id)
+        self._input_extra_files_overrides_by_dataset_id: dict[int, str] = dict(
+            input_extra_files_overrides_by_dataset_id or {}
+        )
         self.compute_public_key = compute_public_key
         self.compute_keypair_id = compute_keypair_id
         self.compute_keypair_expiration_date = compute_keypair_expiration_date
@@ -335,6 +339,21 @@ class Crypt4GHRemoteComputeEnvironment(SharedComputeEnvironment):
             if rewritten_path:
                 return rewritten_path
         return super().input_path_rewrite(dataset)
+
+    def input_extra_files_rewrite(self, dataset: DatasetInstance) -> str:
+        """Return staged plaintext extra-files path for Crypt4GH input datasets.
+
+        For Crypt4GH inputs whose extra files have been decrypted and staged,
+        return the plaintext staging directory.  For all other inputs, fall
+        back to the default compute-environment behaviour.
+        """
+        dataset_object = getattr(dataset, "dataset", None)
+        dataset_id = getattr(dataset_object, "id", None)
+        if isinstance(dataset_id, int):
+            extra_files_path = self._input_extra_files_overrides_by_dataset_id.get(dataset_id)
+            if extra_files_path:
+                return extra_files_path
+        return super().input_extra_files_rewrite(dataset)
 
 
 Crypt4GHComputeEnvironment = Crypt4GHRemoteComputeEnvironment
@@ -372,12 +391,14 @@ def build_crypt4gh_remote_compute_environment(
 
     crypt_inputs_workspace = _ensure_crypt4gh_inputs_workspace(working_directory)
     job_private_key, job_public_key = _generate_job_keypair()
-    input_path_overrides_by_dataset_id, compute_context = _prepare_plaintext_inputs(
-        datasets=crypt4gh_inputs,
-        crypt_inputs_workspace=crypt_inputs_workspace,
-        reencryption_service_url=reencryption_service_url,
-        job_public_key=job_public_key,
-        job_private_key=job_private_key,
+    input_path_overrides_by_dataset_id, input_extra_files_overrides_by_dataset_id, compute_context = (
+        _prepare_plaintext_inputs(
+            datasets=crypt4gh_inputs,
+            crypt_inputs_workspace=crypt_inputs_workspace,
+            reencryption_service_url=reencryption_service_url,
+            job_public_key=job_public_key,
+            job_private_key=job_private_key,
+        )
     )
 
     return Crypt4GHRemoteComputeEnvironment(
@@ -387,6 +408,7 @@ def build_crypt4gh_remote_compute_environment(
         compute_public_key=compute_context.public_key,
         compute_keypair_id=compute_context.keypair_id,
         compute_keypair_expiration_date=compute_context.keypair_expiration_date,
+        input_extra_files_overrides_by_dataset_id=input_extra_files_overrides_by_dataset_id,
     )
 
 
@@ -397,7 +419,7 @@ def _prepare_plaintext_inputs(
     reencryption_service_url: str,
     job_public_key: str,
     job_private_key: bytes,
-) -> tuple[dict[int, str], _ComputeKeyContext]:
+) -> tuple[dict[int, str], dict[int, str], _ComputeKeyContext]:
     endpoint = f"{reencryption_service_url.rstrip('/')}/recrypt_header_to_job_key"
     recrypt_payloads = _build_recrypt_payloads(datasets=datasets, job_public_key=job_public_key)
     responses = _post_many_reencryption_json(
@@ -411,6 +433,7 @@ def _prepare_plaintext_inputs(
         )
 
     input_path_overrides_by_dataset_id: dict[int, str] = {}
+    input_extra_files_overrides_by_dataset_id: dict[int, str] = {}
     compute_context: _ComputeKeyContext | None = None
 
     for payload, response in zip(recrypt_payloads, responses):
@@ -418,7 +441,7 @@ def _prepare_plaintext_inputs(
             response=response,
             endpoint=endpoint,
         )
-        dataset_id, plaintext_path = _prepare_plaintext_input_for_dataset(
+        dataset_id, plaintext_path, extra_files_path = _prepare_plaintext_input_for_dataset(
             dataset=cast(Any, payload["dataset"]),
             source_header=cast(str, payload["source_header"]),
             recrypt_header=recrypt_result.crypt4gh_header,
@@ -426,6 +449,8 @@ def _prepare_plaintext_inputs(
             job_private_key=job_private_key,
         )
         input_path_overrides_by_dataset_id[dataset_id] = plaintext_path
+        if extra_files_path:
+            input_extra_files_overrides_by_dataset_id[dataset_id] = extra_files_path
 
         candidate_context = _ComputeKeyContext(
             public_key=recrypt_result.crypt4gh_compute_public_key,
@@ -440,7 +465,7 @@ def _prepare_plaintext_inputs(
     if compute_context is None:
         raise Crypt4GHRemoteExecutionError("Crypt4GH remote execution requested but no Crypt4GH inputs were detected")
 
-    return input_path_overrides_by_dataset_id, compute_context
+    return input_path_overrides_by_dataset_id, input_extra_files_overrides_by_dataset_id, compute_context
 
 
 def _build_recrypt_payloads(
@@ -810,7 +835,13 @@ def _prepare_plaintext_input_for_dataset(
     recrypt_header: str,
     crypt_inputs_workspace: Path,
     job_private_key: bytes,
-) -> tuple[int, str]:
+) -> tuple[int, str, str | None]:
+    """Decrypt a Crypt4GH input dataset (and its extra files) to plaintext staging.
+
+    Returns ``(dataset_id, plaintext_path, extra_files_plaintext_path)``.
+    ``extra_files_plaintext_path`` is ``None`` when the dataset has no
+    extra files or they are not encrypted.
+    """
     dataset_object = getattr(dataset, "dataset", None)
     dataset_id = getattr(dataset_object, "id", None)
     if not isinstance(dataset_id, int):
@@ -828,7 +859,103 @@ def _prepare_plaintext_input_for_dataset(
         plaintext_path=plaintext_path,
         job_private_key=job_private_key,
     )
-    return dataset_id, str(plaintext_path)
+
+    extra_files_plaintext_path = _stage_input_extra_files(
+        dataset=dataset,
+        dataset_workspace=dataset_workspace,
+        recrypt_header=recrypt_header,
+        job_private_key=job_private_key,
+    )
+
+    return dataset_id, str(plaintext_path), extra_files_plaintext_path
+
+
+def _stage_input_extra_files(
+    *,
+    dataset: DatasetInstance,
+    dataset_workspace: Path,
+    recrypt_header: str,
+    job_private_key: bytes,
+) -> str | None:
+    """Decrypt or copy input extra files to the plaintext staging directory.
+
+    Walks the dataset's extra-files directory.  Files ending in ``.c4gh`` are
+    decrypted using the same recrypted header and job private key as the
+    primary file.  Non-encrypted files are copied as-is.  Returns the path
+    to the staging directory, or ``None`` if the dataset has no extra files.
+    """
+    source_extra_files_path = _resolve_input_extra_files_path(dataset)
+    if source_extra_files_path is None or not source_extra_files_path.is_dir():
+        return None
+
+    plaintext_extra_files_path = dataset_workspace / "plaintext_files"
+    plaintext_extra_files_path.mkdir(parents=True, exist_ok=True)
+
+    recrypted_header_bytes = _decode_header(recrypt_header)
+    found_any = False
+    for root, _dirs, files in os.walk(source_extra_files_path):
+        root_path = Path(root)
+        for file_name in files:
+            found_any = True
+            source_path = root_path / file_name
+            relative_path = os.path.relpath(source_path, source_extra_files_path)
+            dest_path = plaintext_extra_files_path / relative_path
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if file_name.endswith(_CRYPT4GH_FILE_SUFFIX):
+                _decrypt_extra_file(
+                    source_path=source_path,
+                    dest_path=dest_path,
+                    recrypted_header_bytes=recrypted_header_bytes,
+                    job_private_key=job_private_key,
+                )
+            else:
+                shutil.copy2(source_path, dest_path)
+
+    if not found_any:
+        return None
+
+    return str(plaintext_extra_files_path)
+
+
+def _resolve_input_extra_files_path(dataset: DatasetInstance) -> Path | None:
+    """Return the extra-files path for *dataset*, or ``None`` if unavailable."""
+    extra_files_path_str = getattr(dataset, "extra_files_path", None)
+    if extra_files_path_str:
+        return Path(str(extra_files_path_str))
+
+    # Fall back to deriving from the primary file path.
+    file_name = dataset.get_file_name()
+    if not file_name:
+        return None
+    derived = dataset_path_to_extra_path(str(file_name))
+    derived_path = Path(derived)
+    return derived_path if derived_path.is_dir() else None
+
+
+def _decrypt_extra_file(
+    *,
+    source_path: Path,
+    dest_path: Path,
+    recrypted_header_bytes: bytes,
+    job_private_key: bytes,
+) -> None:
+    """Decrypt a single Crypt4GH extra file to *dest_path* (without the ``.c4gh`` suffix)."""
+    try:
+        with source_path.open("rb") as source_stream, dest_path.open("wb") as plaintext_stream:
+            staged_stream = _HeaderThenBodyStream(
+                header_bytes=recrypted_header_bytes,
+                body_stream=source_stream,
+            )
+            crypt4gh.lib.decrypt([(0, job_private_key, None)], staged_stream, plaintext_stream)
+    except OSError as exc:
+        raise Crypt4GHRemoteExecutionError(
+            f"Failed to read Crypt4GH extra file {source_path}: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise Crypt4GHRemoteExecutionError(
+            f"Failed to decrypt Crypt4GH extra file {source_path}"
+        ) from exc
 
 
 def collect_declared_crypt4gh_output_targets(

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -217,8 +217,6 @@ def _post_many_reencryption_json(
 
 
 class _Crypt4GHAppConfig(Protocol):
-    enable_crypt4gh_transparent_input_matching: bool
-    enable_crypt4gh_remote_execution_staging: bool
     enable_crypt4gh_transparent_staging: bool
     outputs_to_working_directory: bool
     metadata_strategy: str
@@ -360,10 +358,7 @@ Crypt4GHComputeEnvironment = Crypt4GHRemoteComputeEnvironment
 
 
 def _crypt4gh_staging_enabled(app_config: _Crypt4GHAppConfig) -> bool:
-    return bool(
-        getattr(app_config, "enable_crypt4gh_remote_execution_staging", False)
-        or getattr(app_config, "enable_crypt4gh_transparent_staging", False)
-    )
+    return bool(getattr(app_config, "enable_crypt4gh_transparent_staging", False))
 
 
 def build_crypt4gh_remote_compute_environment(
@@ -561,7 +556,7 @@ def should_run_crypt4gh_remote_execution(
     """Decide whether execution-side Crypt4GH setup is allowed for this job.
 
     The helper is intentionally small for the Task 3 contract:
-    - top-level gate: ``enable_crypt4gh_remote_execution_staging``
+    - top-level gate: ``enable_crypt4gh_transparent_staging``
     - execution path only when ``tool_evaluation_strategy == "remote"``
     - only if at least one Crypt4GH input dataset is present
     - setup failures must fail closed
@@ -580,7 +575,7 @@ def should_run_crypt4gh_remote_execution(
     if provided_metadata_style == "legacy":
         raise Crypt4GHRemoteExecutionError(
             "Crypt4GH remote execution is not supported for tools with legacy provided_metadata_style; "
-            "use a tool with profile >= 17.09 or set provided_metadata_style to \"default\""
+            'use a tool with profile >= 17.09 or set provided_metadata_style to "default"'
         )
 
     effective_minimum_ttl = _minimum_ttl_for_destination(
@@ -603,18 +598,12 @@ def assert_crypt4gh_job_readiness(
 ) -> None:
     """Fail closed when Crypt4GH transparent-adapted jobs are misconfigured.
 
-    Transparent input matching and remote execution staging are intentionally split:
-    transparent input matching may be enabled alone, but if a job depends on
-    transparent adaptation (tool input does not explicitly accept ``.c4gh``),
-    remote-execution prerequisites must be satisfied.
+    If a job depends on transparent adaptation (tool input does not
+    explicitly accept ``.c4gh``), staging prerequisites must be satisfied.
     """
 
-    remote_execution_staging_enabled = bool(getattr(app_config, "enable_crypt4gh_remote_execution_staging", False))
-    transparent_input_matching_enabled = bool(getattr(app_config, "enable_crypt4gh_transparent_input_matching", False))
-
     required_remote_settings = [
-        "enable_crypt4gh_transparent_input_matching = true",
-        "enable_crypt4gh_remote_execution_staging = true",
+        "enable_crypt4gh_transparent_staging = true",
         "tool_evaluation_strategy = remote",
         "outputs_to_working_directory = true",
         "metadata_strategy = extended",
@@ -624,21 +613,15 @@ def assert_crypt4gh_job_readiness(
     def _missing_remote_settings_summary() -> str:
         return "; required settings: " + ", ".join(required_remote_settings)
 
-    if remote_execution_staging_enabled and not transparent_input_matching_enabled:
-        raise Crypt4GHRemoteExecutionError(
-            "Invalid Crypt4GH configuration: enable_crypt4gh_remote_execution_staging requires "
-            "enable_crypt4gh_transparent_input_matching = true" + _missing_remote_settings_summary()
-        )
-
     crypt4gh_input_names = _collect_crypt4gh_input_names(job_io=job_io)
     if not crypt4gh_input_names:
         return
 
     transparent_adapted_inputs = _collect_transparent_adapted_crypt4gh_input_names(job_io=job_io, tool=tool)
 
-    if not remote_execution_staging_enabled:
+    if not _crypt4gh_staging_enabled(app_config):
         raise Crypt4GHRemoteExecutionError(
-            "Crypt4GH input handling requires enable_crypt4gh_remote_execution_staging = true"
+            "Crypt4GH input handling requires enable_crypt4gh_transparent_staging = true"
             + _missing_remote_settings_summary()
         )
 
@@ -949,13 +932,9 @@ def _decrypt_extra_file(
             )
             crypt4gh.lib.decrypt([(0, job_private_key, None)], staged_stream, plaintext_stream)
     except OSError as exc:
-        raise Crypt4GHRemoteExecutionError(
-            f"Failed to read Crypt4GH extra file {source_path}: {exc}"
-        ) from exc
+        raise Crypt4GHRemoteExecutionError(f"Failed to read Crypt4GH extra file {source_path}: {exc}") from exc
     except Exception as exc:
-        raise Crypt4GHRemoteExecutionError(
-            f"Failed to decrypt Crypt4GH extra file {source_path}"
-        ) from exc
+        raise Crypt4GHRemoteExecutionError(f"Failed to decrypt Crypt4GH extra file {source_path}") from exc
 
 
 def collect_declared_crypt4gh_output_targets(
@@ -1066,7 +1045,9 @@ def collect_discovery_crypt4gh_output_specs(
 
     discovery_specs: list[dict[str, Any]] = []
     tool_working_directory = Path(working_directory) / "working"
-    discovered_marker_map_path = str(Path(working_directory) / "_c4gh_stage" / "outputs" / "discovered_designations.json")
+    discovered_marker_map_path = str(
+        Path(working_directory) / "_c4gh_stage" / "outputs" / "discovered_designations.json"
+    )
 
     for output_name, tool_output in tool_outputs.items():
         collectors = list(getattr(tool_output, "dataset_collector_descriptions", []) or [])
@@ -1108,9 +1089,7 @@ def collect_discovery_crypt4gh_output_specs(
                     "discovered_marker_map_path": discovered_marker_map_path,
                     "allowed_root_paths": [str(Path(working_directory).resolve())],
                     "plaintext_root_paths": [str(Path(working_directory).resolve())],
-                    "extra_files_manifest_dir": str(
-                        Path(working_directory) / "_c4gh_stage" / "outputs"
-                    ),
+                    "extra_files_manifest_dir": str(Path(working_directory) / "_c4gh_stage" / "outputs"),
                 }
             )
 
@@ -1151,7 +1130,11 @@ def finalize_discovered_crypt4gh_payloads(
                 if source_path.name.endswith(".c4gh"):
                     continue
 
-                candidate_text = str(source_path.relative_to(scan_root)) if bool(spec.get("match_relative_path", False)) else source_path.name
+                candidate_text = (
+                    str(source_path.relative_to(scan_root))
+                    if bool(spec.get("match_relative_path", False))
+                    else source_path.name
+                )
                 match = compiled_pattern.match(candidate_text)
                 if not match:
                     continue
@@ -1171,7 +1154,9 @@ def finalize_discovered_crypt4gh_payloads(
 
                 finalize_about_to_persist_crypt4gh_payload(
                     output_path=output_path,
-                    plaintext_path=str(Path(working_directory) / "_crypt" / "outputs" / "discovered" / designation / "plaintext"),
+                    plaintext_path=str(
+                        Path(working_directory) / "_crypt" / "outputs" / "discovered" / designation / "plaintext"
+                    ),
                     encrypted_ext=encrypted_ext,
                     reencryption_service_url=reencryption_service_url,
                     compute_public_key=compute_public_key,
@@ -1236,7 +1221,9 @@ def _finalize_discovered_extra_files(
 
     manifest_dir = Path(str(spec.get("extra_files_manifest_dir", "") or ""))
     designation_token = _safe_discovered_designation_token(designation)
-    manifest_path = manifest_dir / f"designation_{designation_token}.extra_files_manifest.json" if manifest_dir else None
+    manifest_path = (
+        manifest_dir / f"designation_{designation_token}.extra_files_manifest.json" if manifest_dir else None
+    )
 
     allowed_root_paths = cast(Sequence[str], spec.get("allowed_root_paths", []))
     plaintext_root_paths = cast(Sequence[str], spec.get("plaintext_root_paths", []))
@@ -1264,9 +1251,7 @@ def _finalize_discovered_extra_files(
 
             finalize_about_to_persist_crypt4gh_payload(
                 output_path=str(encrypted_file_path),
-                plaintext_path=str(
-                    encrypted_file_path.parent / f"{encrypted_file_path.name}.plaintext"
-                ),
+                plaintext_path=str(encrypted_file_path.parent / f"{encrypted_file_path.name}.plaintext"),
                 encrypted_ext=encrypted_ext,
                 reencryption_service_url=reencryption_service_url,
                 compute_public_key=compute_public_key,
@@ -2209,9 +2194,7 @@ def _rename_extra_files_payload_with_suffix_if_needed(
         context="finalize extra_files encrypted payload",
     )
     if encrypted_path.exists():
-        raise Crypt4GHRemoteExecutionError(
-            f"Crypt4GH extra_files encrypted payload already exists: {encrypted_path}"
-        )
+        raise Crypt4GHRemoteExecutionError(f"Crypt4GH extra_files encrypted payload already exists: {encrypted_path}")
 
     encrypted_path.parent.mkdir(parents=True, exist_ok=True)
     source_path.rename(encrypted_path)
@@ -2637,7 +2620,9 @@ def _verify_extra_files_payload_header_evidence(
             continue
 
         if payload_prefix != b"crypt4gh":
-            diagnostics.append(f"extra_files payload remained plaintext for dataset_id={dataset_id} path={relative_path}")
+            diagnostics.append(
+                f"extra_files payload remained plaintext for dataset_id={dataset_id} path={relative_path}"
+            )
 
 
 def _safe_discovered_designation_token(designation: str) -> str:
@@ -2777,7 +2762,7 @@ def build_crypt4gh_cleanup_wrapped_command(
         include_exit_checks=False,
     )
     marker_line = (
-        f'    echo "{CRYPT4GH_CLEANUP_FAILED_MARKER}: cleanup failed with exit code '
+        f'    echo "{CRYPT4GH_CLEANUP_FAILED_MARKER}: cleanup failed with exit code '  # noqa: ISC001
         '${_CRYPT4GH_CLEANUP_EXIT}" >&2'
     )
     lines.extend(

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -1029,7 +1029,15 @@ def finalize_discovered_crypt4gh_payloads(
                 designation = match.groupdict().get("designation") if match.groupdict() else None
                 designation = designation or source_path.stem
                 encrypted_ext = str(spec["encrypted_ext"])
-                output_path = str(source_path.with_name(f"{source_path.name}.c4gh"))
+                # Encrypt the discovered plaintext file in place: the file keeps its
+                # original name (so Galaxy's pattern discovery still matches it) while
+                # its bytes become a Crypt4GH payload.  finalize_about_to_persist_crypt4gh_payload
+                # -> _finalize_output_target copies output_path to the plaintext staging
+                # area (_crypt/outputs/discovered/<designation>/plaintext, removed by
+                # cleanup_crypt4gh_plaintext_artifacts) and os.replace-s the encrypted
+                # result back onto output_path.  Pointing output_path at a non-existent
+                # ``*.c4gh`` sidecar (the previous behaviour) made that copyfile fail.
+                output_path = str(source_path)
 
                 finalize_about_to_persist_crypt4gh_payload(
                     output_path=output_path,
@@ -1047,8 +1055,6 @@ def finalize_discovered_crypt4gh_payloads(
                     plaintext_root_paths=cast(Sequence[str], spec.get("plaintext_root_paths", [])),
                     clear_compute_keypair=False,
                 )
-                os.replace(source_path, source_path.with_suffix(f"{source_path.suffix}.plaintext"))
-                os.replace(output_path, source_path)
 
                 payload_metadata.append(
                     {

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -43,12 +43,14 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from dateutil.parser import isoparse
 
 from galaxy.job_execution.compute_environment import (
-    dataset_path_to_extra_path,
     SharedComputeEnvironment,
 )
+from galaxy.tools.actions import get_ext_or_implicit_ext
+from galaxy.util import dataset_path_to_extra_path
 from galaxy.util.crypt4gh import (
     CRYPT4GH_CLEANUP_FAILED_MARKER,
     read_crypt4gh_header,
+    unwrap_crypt4gh_file_ext,
 )
 
 try:
@@ -974,7 +976,7 @@ def collect_declared_crypt4gh_output_targets(
         if _is_discovery_routed_output(tool_output):
             continue
 
-        base_ext = _resolve_base_output_extension(dataset=dataset, tool_output=tool_output)
+        base_ext = _resolve_base_output_extension(dataset=dataset, tool_output=tool_output, job_io=job_io)
         if base_ext is None:
             if _has_output_collectors(tool_output):
                 continue
@@ -1437,7 +1439,7 @@ def _resolve_output_name_for_tool_lookup(*, output_name: str, tool_outputs: Mapp
     return None
 
 
-def _resolve_base_output_extension(*, dataset: Any, tool_output: Any) -> str | None:
+def _resolve_base_output_extension(*, dataset: Any, tool_output: Any, job_io: Any | None = None) -> str | None:
     base_ext = cast(str, getattr(dataset, "ext", "") or "")
     if not base_ext:
         return None
@@ -1445,12 +1447,26 @@ def _resolve_base_output_extension(*, dataset: Any, tool_output: Any) -> str | N
     if base_ext.endswith(".c4gh"):
         base_ext = base_ext[: -len(".c4gh")]
 
-    if base_ext in ("auto", "data", "_sniff_"):
-        declared_ext = getattr(tool_output, "format", None) if tool_output else None
-        if declared_ext and declared_ext not in ("auto", "data", "_sniff_", "input"):
-            return cast(str, declared_ext)
+    declared_ext = getattr(tool_output, "format", None) if tool_output else None
+    if declared_ext and declared_ext not in ("auto", "data", "_sniff_", "input"):
+        return cast(str, declared_ext)
+
+    def _normalize_resolved_ext(ext: str) -> str:
+        return unwrap_crypt4gh_file_ext(ext) or ext
+
+    if base_ext not in ("auto", "data", "_sniff_", "input"):
+        return base_ext
+    if job_io is None:
         return None
-    return base_ext
+
+    metadata_source = getattr(tool_output, "metadata_source", None)
+    if metadata_source:
+        for input_dataset in job_io.get_input_datasets():
+            if getattr(input_dataset, "name", None) == metadata_source:
+                return _normalize_resolved_ext(get_ext_or_implicit_ext(input_dataset))
+        return None
+
+    return None
 
 
 def _ensure_crypt4gh_output_datatype(*, datatypes_registry: Any, base_ext: str) -> str:

--- a/lib/galaxy/tools/crypt4gh_remote_execution.py
+++ b/lib/galaxy/tools/crypt4gh_remote_execution.py
@@ -46,7 +46,10 @@ from galaxy.job_execution.compute_environment import (
     dataset_path_to_extra_path,
     SharedComputeEnvironment,
 )
-from galaxy.util.crypt4gh import read_crypt4gh_header
+from galaxy.util.crypt4gh import (
+    CRYPT4GH_CLEANUP_FAILED_MARKER,
+    read_crypt4gh_header,
+)
 
 try:
     _optional_truststore: Any = importlib.import_module("truststore")
@@ -227,7 +230,6 @@ class Crypt4GHRemoteExecutionError(Exception):
     """Raised when execution-side Crypt4GH setup must fail closed."""
 
 
-CRYPT4GH_PLAINTEXT_CLEANUP_FAILED_MARKER = "CRYPT4GH_PLAINTEXT_CLEANUP_FAILED"
 _DEFAULT_MINIMUM_TTL = timedelta(days=1)
 _DESTINATION_WALLTIME_BUFFER = timedelta(hours=1)
 _CRYPT4GH_FILE_SUFFIX = ".c4gh"
@@ -776,16 +778,6 @@ def _ensure_crypt4gh_inputs_workspace(working_directory: str) -> Path:
     return workspace
 
 
-def cleanup_crypt4gh_plaintext_artifacts(*, working_directory: str) -> None:
-    """Delete staged Crypt4GH plaintext input and output directories."""
-
-    crypt_root = Path(working_directory) / "_crypt"
-    for child_name in ("inputs", "outputs"):
-        child_path = crypt_root / child_name
-        if child_path.exists():
-            shutil.rmtree(child_path)
-
-
 def _format_crypt4gh_public_key(public_key: bytes) -> str:
     encoded_public_key = base64.b64encode(public_key).decode("ascii")
     return "\n".join(
@@ -1178,7 +1170,7 @@ def build_crypt4gh_postrun_command(
         f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
         f"{shlex.quote(python_executable)} -c {shlex.quote(postrun_script)}"
     )
-    cleanup_script = f"from galaxy.tools.crypt4gh_remote_execution import cleanup_crypt4gh_plaintext_artifacts; cleanup_crypt4gh_plaintext_artifacts(working_directory={json.dumps(working_directory)})"
+    cleanup_script = f"from galaxy.util.crypt4gh import cleanup_crypt4gh_plaintext_artifacts; cleanup_crypt4gh_plaintext_artifacts(working_directory={json.dumps(working_directory)})"
     cleanup_command = (
         f"PYTHONPATH={shlex.quote(galaxy_lib_dir)}:$PYTHONPATH "
         f"{shlex.quote(python_executable)} -c {shlex.quote(cleanup_script)}"
@@ -2500,7 +2492,7 @@ def build_crypt4gh_cleanup_wrapped_command(
         include_exit_checks=False,
     )
     marker_line = (
-        f'    echo "{CRYPT4GH_PLAINTEXT_CLEANUP_FAILED_MARKER}: cleanup failed with exit code '
+        f'    echo "{CRYPT4GH_CLEANUP_FAILED_MARKER}: cleanup failed with exit code '
         '${_CRYPT4GH_CLEANUP_EXIT}" >&2'
     )
     lines.extend(
@@ -2518,9 +2510,6 @@ def build_crypt4gh_cleanup_wrapped_command(
             "fi",
             "if [ $_CRYPT4GH_POSTRUN_EXIT -ne 0 ]; then",
             "    exit $_CRYPT4GH_POSTRUN_EXIT",
-            "fi",
-            "if [ $_CRYPT4GH_CLEANUP_EXIT -ne 0 ]; then",
-            "    exit $_CRYPT4GH_CLEANUP_EXIT",
             "fi",
         ]
     )

--- a/lib/galaxy/tools/remote_tool_eval.py
+++ b/lib/galaxy/tools/remote_tool_eval.py
@@ -57,8 +57,6 @@ class ToolAppConfig(NamedTuple):
 
 
 class Crypt4GHGateConfig(NamedTuple):
-    enable_crypt4gh_transparent_input_matching: bool = False
-    enable_crypt4gh_remote_execution_staging: bool = False
     enable_crypt4gh_transparent_staging: bool = False
     outputs_to_working_directory: bool = True
     metadata_strategy: str = "extended"
@@ -190,7 +188,9 @@ def main(TMPDIR, WORKING_DIRECTORY, IMPORT_STORE_DIRECTORY) -> None:
             working_directory=WORKING_DIRECTORY,
         )
     else:
-        tool_evaluator.set_compute_environment(compute_environment=SharedComputeEnvironment(job_io=job_io, job=job_io.job))
+        tool_evaluator.set_compute_environment(
+            compute_environment=SharedComputeEnvironment(job_io=job_io, job=job_io.job)
+        )
 
     with open(os.path.join(WORKING_DIRECTORY, "tool_script.sh"), "a") as out:
         command_line, version_command_line, extra_filenames, environment_variables, *_ = tool_evaluator.build()

--- a/lib/galaxy/tools/remote_tool_eval.py
+++ b/lib/galaxy/tools/remote_tool_eval.py
@@ -1,10 +1,13 @@
 import json
 import os
 import shutil
+import sys
 import tempfile
 import traceback
 from collections.abc import Callable
 from typing import (
+    Any,
+    cast,
     NamedTuple,
 )
 
@@ -26,6 +29,14 @@ from galaxy.tools import (
     create_tool_from_representation,
     evaluation,
 )
+from galaxy.tools.crypt4gh_remote_execution import (
+    build_crypt4gh_postrun_command,
+    build_crypt4gh_remote_compute_environment,
+    collect_declared_crypt4gh_output_targets,
+    collect_discovery_crypt4gh_output_specs,
+    Crypt4GHRemoteExecutionError,
+    should_run_crypt4gh_remote_execution,
+)
 from galaxy.tools.data import (
     from_dict,
     ToolDataTableManager,
@@ -43,6 +54,16 @@ class ToolAppConfig(NamedTuple):
     root: str
     is_admin_user: Callable
     admin_users: list = []
+
+
+class Crypt4GHGateConfig(NamedTuple):
+    enable_crypt4gh_transparent_input_matching: bool = False
+    enable_crypt4gh_remote_execution_staging: bool = False
+    enable_crypt4gh_transparent_staging: bool = False
+    outputs_to_working_directory: bool = True
+    metadata_strategy: str = "extended"
+    crypt4gh_reencryption_service_url: str | None = None
+    tool_evaluation_strategy: str | None = "remote"
 
 
 class ToolApp(MinimalToolApp):
@@ -117,10 +138,78 @@ def main(TMPDIR, WORKING_DIRECTORY, IMPORT_STORE_DIRECTORY) -> None:
     tool_evaluator = evaluation.RemoteToolEvaluator(
         app=app, tool=tool, job=job_io.job, local_working_directory=WORKING_DIRECTORY
     )
-    tool_evaluator.set_compute_environment(compute_environment=SharedComputeEnvironment(job_io=job_io, job=job_io.job))
+
+    destination_params = dict(job_io.job.destination_params or {})
+    crypt4gh_config = cast(dict, job_io.crypt4gh_config or {})
+    reencryption_service_url = str(crypt4gh_config.get("reencryption_service_url") or "").strip()
+    crypt4gh_gate_config = Crypt4GHGateConfig(
+        enable_crypt4gh_transparent_staging=bool(crypt4gh_config.get("enable_crypt4gh_transparent_staging", False)),
+        crypt4gh_reencryption_service_url=reencryption_service_url or None,
+    )
+
+    crypt4gh_active = False
+    crypt4gh_output_targets: list[dict[str, object]] = []
+    crypt4gh_discovery_specs: list[dict[str, object]] = []
+    crypt4gh_compute_public_key = ""
+    crypt4gh_compute_keypair_id = ""
+    crypt4gh_compute_keypair_expiration_date = None
+
+    if reencryption_service_url and should_run_crypt4gh_remote_execution(
+        job_io=job_io,
+        app_config=cast(Any, crypt4gh_gate_config),
+        destination_params=destination_params,
+        provided_metadata_style=tool.provided_metadata_style,
+    ):
+        crypt4gh_compute_environment = build_crypt4gh_remote_compute_environment(
+            job_io=job_io,
+            job=job_io.job,
+            working_directory=WORKING_DIRECTORY,
+            reencryption_service_url=reencryption_service_url,
+        )
+        tool_evaluator.set_compute_environment(compute_environment=crypt4gh_compute_environment)
+        crypt4gh_active = True
+        crypt4gh_compute_public_key = str(crypt4gh_compute_environment.compute_public_key or "")
+        crypt4gh_compute_keypair_id = str(crypt4gh_compute_environment.compute_keypair_id or "")
+        crypt4gh_compute_keypair_expiration_date = crypt4gh_compute_environment.compute_keypair_expiration_date
+
+        if not crypt4gh_compute_public_key or not crypt4gh_compute_keypair_id:
+            raise Crypt4GHRemoteExecutionError(
+                "Crypt4GH compute environment did not return compute key context required for output finalization"
+            )
+
+        crypt4gh_output_targets = collect_declared_crypt4gh_output_targets(
+            job_io=job_io,
+            tool_outputs=tool.outputs,
+            datatypes_registry=datatypes_registry,
+            working_directory=WORKING_DIRECTORY,
+        )
+        crypt4gh_discovery_specs = collect_discovery_crypt4gh_output_specs(
+            job_io=job_io,
+            tool_outputs=tool.outputs,
+            datatypes_registry=datatypes_registry,
+            working_directory=WORKING_DIRECTORY,
+        )
+    else:
+        tool_evaluator.set_compute_environment(compute_environment=SharedComputeEnvironment(job_io=job_io, job=job_io.job))
+
     with open(os.path.join(WORKING_DIRECTORY, "tool_script.sh"), "a") as out:
         command_line, version_command_line, extra_filenames, environment_variables, *_ = tool_evaluator.build()
-        out.write(f"{version_command_line or ''}{command_line}")
+        tool_command = f"{version_command_line or ''}{command_line}"
+        if crypt4gh_active:
+            galaxy_json_path = os.path.join(WORKING_DIRECTORY, "working", "galaxy.json")
+            tool_command = build_crypt4gh_postrun_command(
+                tool_command=tool_command,
+                output_targets=crypt4gh_output_targets,
+                discovery_specs=crypt4gh_discovery_specs,
+                galaxy_json_path=galaxy_json_path,
+                working_directory=WORKING_DIRECTORY,
+                reencryption_service_url=reencryption_service_url,
+                compute_public_key=crypt4gh_compute_public_key,
+                compute_keypair_id=crypt4gh_compute_keypair_id,
+                compute_keypair_expiration_date=crypt4gh_compute_keypair_expiration_date,
+                python_executable=sys.executable,
+            )
+        out.write(tool_command)
 
 
 if __name__ == "__main__":

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -901,6 +901,16 @@ def in_directory(file, directory, local_path_module=os.path):
     return _safe_contains(directory, file)
 
 
+def dataset_path_to_extra_path(path: str) -> str:
+    """Return the extra-files path for a dataset path.
+
+    Given a dataset file path ending in ``.dat``, return the sibling
+    ``_files`` directory path used for extra-files storage.
+    """
+    base_path = path[0 : -len(".dat")]
+    return f"{base_path}_files"
+
+
 def merge_sorted_iterables(operator, *iterables):
     """
 

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -1,9 +1,9 @@
-"""Crypt4GH header parsing and file-extension helpers.
+"""Crypt4GH header parsing, file-extension helpers, and validation.
 
-This module provides strict, dependency-free utilities for detecting
-Crypt4GH files, validating their binary headers, and managing the
-``inner_ext.c4gh`` wrapper-extension convention used by the Galaxy
-datatype registry.
+This module provides utilities for detecting Crypt4GH files, validating
+their binary headers, managing the ``inner_ext.c4gh`` wrapper-extension
+convention used by the Galaxy datatype registry, and validating compute
+metadata / job readiness for Crypt4GH-wrapped datasets.
 
 Security invariants
 -------------------
@@ -13,11 +13,27 @@ Security invariants
 * Header bytes returned by :func:`read_crypt4gh_header` are the raw
   public header; callers are responsible for redacting them before
   logging.
+* Error messages are crafted to be actionable without leaking header
+  bytes or other sensitive material.
 """
 
+from __future__ import annotations
+
 import struct
+from datetime import datetime
 from re import fullmatch
-from typing import IO
+from typing import (
+    IO,
+    TYPE_CHECKING,
+)
+
+from galaxy.exceptions import RequestParameterInvalidException
+
+if TYPE_CHECKING:
+    from galaxy.model import (
+        DatasetInstance,
+        Job,
+    )
 
 # --- Constants -------------------------------------------------------------
 
@@ -187,7 +203,9 @@ def check_crypt4gh(file_path: str) -> bool:
 
 
 __all__ = (
+    "assert_crypt4gh_job_readiness",
     "check_crypt4gh",
+    "CRYPT4GH_COMPUTE_METADATA_KEYS",
     "CRYPT4GH_FILE_EXT",
     "CRYPT4GH_MAGIC",
     "CRYPT4GH_SUFFIX",
@@ -198,5 +216,162 @@ __all__ = (
     "preserve_crypt4gh_inner_file_ext",
     "read_crypt4gh_header",
     "unwrap_crypt4gh_file_ext",
+    "validate_crypt4gh_compute_metadata",
+    "validate_crypt4gh_keypair_expiration",
     "wrap_crypt4gh_file_ext",
 )
+
+
+# --- Compute metadata validation (dataset-level) ---------------------------
+
+#: Metadata field names that can be set by the recrypt action.
+CRYPT4GH_COMPUTE_METADATA_KEYS = frozenset(
+    {
+        "crypt4gh_compute_header",
+        "crypt4gh_compute_keypair_id",
+        "crypt4gh_compute_keypair_expiration_date",
+    }
+)
+
+
+def validate_crypt4gh_compute_metadata(
+    dataset_assoc: DatasetInstance,
+    key: str,
+    val: object,
+) -> None:
+    """Validate a single Crypt4GH compute metadata update.
+
+    Called from :class:`DatasetAssociationDeserializer.deserialize_metadatum`
+    before the value is persisted.
+
+    Only Crypt4GH-wrapped datasets may receive compute metadata.  The
+    keypair expiration date must be a valid ISO 8601 string that is in
+    the future.
+
+    :raises RequestParameterInvalidException: if the dataset is not
+        Crypt4GH-wrapped, is in an active job, or the expiration date
+        is invalid or expired.
+    """
+    if key not in CRYPT4GH_COMPUTE_METADATA_KEYS:
+        return
+
+    ext = dataset_assoc.ext or ""
+    if not is_crypt4gh_file_ext(ext):
+        raise RequestParameterInvalidException(
+            f"Crypt4GH compute metadata '{key}' can only be set on Crypt4GH-wrapped datasets, not '{ext}'."
+        )
+
+    if not dataset_assoc.ok_to_edit_metadata():
+        raise RequestParameterInvalidException(
+            "Dataset metadata could not be updated because it is used as input or output of a running job."
+        )
+
+    if key == "crypt4gh_compute_keypair_expiration_date" and val:
+        validate_crypt4gh_keypair_expiration(str(val))
+
+
+def validate_crypt4gh_keypair_expiration(val: str) -> None:
+    """Ensure the keypair expiration date is valid ISO 8601 and in the future.
+
+    :raises RequestParameterInvalidException: if the value is not
+        parseable as ISO 8601 or is not in the future.
+    """
+    try:
+        expiration = datetime.fromisoformat(val)
+    except (ValueError, TypeError):
+        raise RequestParameterInvalidException(
+            f"Invalid Crypt4GH keypair expiration date '{val}': expected ISO 8601 format."
+        )
+    if expiration.tzinfo is not None:
+        now = datetime.now(expiration.tzinfo)
+    else:
+        now = datetime.now()
+    if expiration <= now:
+        raise RequestParameterInvalidException(
+            "Crypt4GH keypair expiration date must be in the future."
+        )
+
+
+# --- Job readiness guard (job-level) ---------------------------------------
+
+
+def assert_crypt4gh_job_readiness(job: Job) -> list[str]:
+    """Validate that every Crypt4GH input dataset is ready for compute.
+
+    Returns a list of human-readable error messages (empty if all
+    Crypt4GH inputs are ready).  Each error message is actionable and
+    tells the user to use the recrypt action to fix the problem.
+
+    This function does **not** raise; the caller is responsible for
+    failing the job when errors are returned.
+    """
+    input_associations = [
+        *list(job.input_datasets or []),
+        *list(job.input_library_datasets or []),
+    ]
+    if not input_associations:
+        return []
+
+    errors: list[str] = []
+    for assoc in input_associations:
+        dataset = getattr(assoc, "dataset", None)
+        if dataset is None:
+            continue
+        ext = getattr(dataset, "ext", "") or ""
+        if not is_crypt4gh_file_ext(ext):
+            continue
+
+        input_name = getattr(assoc, "name", "") or "<unnamed>"
+        errors.extend(_validate_single_crypt4gh_input(input_name, dataset))
+
+    return errors
+
+
+def _validate_single_crypt4gh_input(input_name: str, dataset: DatasetInstance) -> list[str]:
+    """Validate one Crypt4GH input dataset and return a list of errors."""
+    metadata = dataset.metadata
+    compute_header = getattr(metadata, "crypt4gh_compute_header", None)
+    keypair_id = getattr(metadata, "crypt4gh_compute_keypair_id", None)
+    expiration_str = getattr(metadata, "crypt4gh_compute_keypair_expiration_date", None)
+
+    if not compute_header:
+        return [
+            f"Input '{input_name}': missing crypt4gh_compute_header metadata. "
+            f"Use the recrypt action to prepare this dataset for compute."
+        ]
+    if not keypair_id:
+        return [
+            f"Input '{input_name}': missing crypt4gh_compute_keypair_id metadata. "
+            f"Use the recrypt action to prepare this dataset for compute."
+        ]
+    if not expiration_str:
+        return [
+            f"Input '{input_name}': missing crypt4gh_compute_keypair_expiration_date metadata. "
+            f"Use the recrypt action to prepare this dataset for compute."
+        ]
+
+    return _validate_keypair_not_expired(input_name, str(expiration_str))
+
+
+def _validate_keypair_not_expired(input_name: str, expiration_str: str) -> list[str]:
+    """Validate that the keypair expiration date is valid and not expired."""
+    try:
+        expiration = datetime.fromisoformat(expiration_str)
+    except (ValueError, TypeError):
+        return [
+            f"Input '{input_name}': invalid crypt4gh_compute_keypair_expiration_date "
+            f"'{expiration_str}': expected ISO 8601 format."
+        ]
+
+    if expiration.tzinfo is not None:
+        now = datetime.now(expiration.tzinfo)
+    else:
+        now = datetime.now()
+
+    if expiration <= now:
+        return [
+            f"Input '{input_name}': Crypt4GH keypair has expired "
+            f"(expiration: {expiration_str}). Use the recrypt action to renew."
+        ]
+
+    return []

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -19,8 +19,10 @@ Security invariants
 
 from __future__ import annotations
 
+import shutil
 import struct
 from datetime import datetime
+from pathlib import Path
 from re import fullmatch
 from typing import (
     IO,
@@ -41,6 +43,10 @@ CRYPT4GH_MAGIC = b"crypt4gh"
 CRYPT4GH_VERSION = 1
 CRYPT4GH_FILE_EXT = "c4gh"
 CRYPT4GH_SUFFIX = f".{CRYPT4GH_FILE_EXT}"
+
+#: Sentinel emitted to stderr by the compute-side shell wrapper when
+#: plaintext cleanup fails.  Scanned by the host-side job finisher.
+CRYPT4GH_CLEANUP_FAILED_MARKER = "CRYPT4GH_PLAINTEXT_CLEANUP_FAILED"
 
 # Struct format for the 16-byte prelude: magic (8s) + version (I) + packet_count (I)
 _PRELUDE_FORMAT = "<8sII"
@@ -204,9 +210,23 @@ def check_crypt4gh(file_path: str) -> bool:
         return False
 
 
+def cleanup_crypt4gh_plaintext_artifacts(*, working_directory: str) -> None:
+    """Delete staged Crypt4GH plaintext input and output directories.
+
+    Removes ``_crypt/inputs`` and ``_crypt/outputs`` under *working_directory*.
+    """
+    crypt_root = Path(working_directory) / "_crypt"
+    for child_name in ("inputs", "outputs"):
+        child_path = crypt_root / child_name
+        if child_path.exists():
+            shutil.rmtree(child_path)
+
+
 __all__ = (
     "assert_crypt4gh_job_readiness",
     "check_crypt4gh",
+    "cleanup_crypt4gh_plaintext_artifacts",
+    "CRYPT4GH_CLEANUP_FAILED_MARKER",
     "CRYPT4GH_COMPUTE_METADATA_KEYS",
     "CRYPT4GH_FILE_EXT",
     "CRYPT4GH_MAGIC",

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -19,6 +19,7 @@ Security invariants
 
 from __future__ import annotations
 
+import os
 import shutil
 import struct
 from datetime import datetime
@@ -30,6 +31,7 @@ from typing import (
 )
 
 from galaxy.exceptions import RequestParameterInvalidException
+from galaxy.job_execution.compute_environment import dataset_path_to_extra_path
 
 if TYPE_CHECKING:
     from galaxy.model import (
@@ -222,10 +224,54 @@ def cleanup_crypt4gh_plaintext_artifacts(*, working_directory: str) -> None:
             shutil.rmtree(child_path)
 
 
+def cleanup_crypt4gh_plaintext_outputs(*, output_paths: list[str]) -> None:
+    """Remove plaintext (un-encrypted) output files left by a failed postrun.
+
+    For each path in *output_paths*, if the file exists and does **not** begin
+    with the Crypt4GH magic bytes, it is deleted.  If a sibling ``_files``
+    directory exists (extra-files), its non-``.c4gh`` contents are also removed.
+
+    This ensures that no unencrypted dataset remains on the compute node when
+    the tool or postrun script fails.
+    """
+    for output_path_str in output_paths:
+        output_path = Path(output_path_str)
+        if not output_path.exists():
+            continue
+
+        # Remove the primary output file if it is not encrypted.
+        if output_path.is_file():
+            try:
+                with output_path.open("rb") as fh:
+                    magic = fh.read(len(CRYPT4GH_MAGIC))
+                if magic != CRYPT4GH_MAGIC:
+                    output_path.unlink()
+            except OSError:
+                pass
+
+        # Remove plaintext files in the sibling extra-files directory.
+        extra_files_path = Path(dataset_path_to_extra_path(str(output_path)))
+        if extra_files_path.exists() and extra_files_path.is_dir():
+            for root, _dirs, files in os.walk(extra_files_path):
+                root_path = Path(root)
+                for file_name in files:
+                    if file_name.endswith(CRYPT4GH_SUFFIX):
+                        continue
+                    file_path = root_path / file_name
+                    try:
+                        with file_path.open("rb") as fh:
+                            magic = fh.read(len(CRYPT4GH_MAGIC))
+                        if magic != CRYPT4GH_MAGIC:
+                            file_path.unlink()
+                    except OSError:
+                        pass
+
+
 __all__ = (
     "assert_crypt4gh_job_readiness",
     "check_crypt4gh",
     "cleanup_crypt4gh_plaintext_artifacts",
+    "cleanup_crypt4gh_plaintext_outputs",
     "CRYPT4GH_CLEANUP_FAILED_MARKER",
     "CRYPT4GH_COMPUTE_METADATA_KEYS",
     "CRYPT4GH_FILE_EXT",

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -1,0 +1,202 @@
+"""Crypt4GH header parsing and file-extension helpers.
+
+This module provides strict, dependency-free utilities for detecting
+Crypt4GH files, validating their binary headers, and managing the
+``inner_ext.c4gh`` wrapper-extension convention used by the Galaxy
+datatype registry.
+
+Security invariants
+-------------------
+* Functions in this module **never** decrypt payload data or handle
+  private keys.  They only read and validate the *public* header
+  portion of a Crypt4GH file.
+* Header bytes returned by :func:`read_crypt4gh_header` are the raw
+  public header; callers are responsible for redacting them before
+  logging.
+"""
+
+import struct
+from re import fullmatch
+from typing import IO
+
+# --- Constants -------------------------------------------------------------
+
+CRYPT4GH_MAGIC = b"crypt4gh"
+CRYPT4GH_VERSION = 1
+CRYPT4GH_FILE_EXT = "c4gh"
+CRYPT4GH_SUFFIX = f".{CRYPT4GH_FILE_EXT}"
+
+# Struct format for the 16-byte prelude: magic (8s) + version (I) + packet_count (I)
+_PRELUDE_FORMAT = "<8sII"
+_PRELUDE_SIZE = struct.calcsize(_PRELUDE_FORMAT)
+
+
+# --- Extension helpers ------------------------------------------------------
+
+def _is_generic_crypt4gh_file_ext(file_ext: str) -> bool:
+    """Return True for bare wrapper extensions like ``c4gh``, ``crypt4gh``."""
+    return fullmatch(r"c[^.]*4gh", file_ext) is not None
+
+
+def _unwrap_crypt4gh_suffix(value: str) -> str | None:
+    """Strip a trailing ``.c4gh`` (or similar) suffix and return the inner stem."""
+    if not value:
+        return None
+    stem, sep, suffix = value.rpartition(".")
+    if not sep:
+        return None
+    if _is_generic_crypt4gh_file_ext(suffix):
+        return stem
+    return None
+
+
+def is_crypt4gh_file_ext(file_ext: str) -> bool:
+    """Return True if *file_ext* is a Crypt4GH wrapper (generic or typed)."""
+    return _is_generic_crypt4gh_file_ext(file_ext) or _unwrap_crypt4gh_suffix(file_ext) is not None
+
+
+def wrap_crypt4gh_file_ext(file_ext: str) -> str:
+    """Append the Crypt4GH suffix to *file_ext* unless it is already wrapped."""
+    if is_crypt4gh_file_ext(file_ext):
+        return file_ext
+    return f"{file_ext}{CRYPT4GH_SUFFIX}"
+
+
+def unwrap_crypt4gh_file_ext(file_ext: str) -> str | None:
+    """Return the inner extension of a typed wrapper, or None for generic/invalid."""
+    if _is_generic_crypt4gh_file_ext(file_ext):
+        return None
+    return _unwrap_crypt4gh_suffix(file_ext)
+
+
+def infer_crypt4gh_inner_file_ext(filename: str, registry) -> str | None:
+    """Try to infer the inner datatype extension from *filename* via the registry."""
+    inner_filename = _unwrap_crypt4gh_suffix(filename) or filename
+    datatype = registry.get_datatype_from_filename(inner_filename)
+    if datatype and datatype.file_ext not in ("data", "binary", "txt", "auto"):
+        return datatype.file_ext
+    return None
+
+
+def infer_crypt4gh_file_ext(filename: str, registry, requested_ext: str = "auto") -> str:
+    """Determine the best Crypt4GH wrapper extension for *filename*.
+
+    Priority:
+    1. Inner type inferred from filename via the registry.
+    2. Wrap the user-requested extension (if not ``auto``).
+    3. Fall back to the generic ``c4gh``.
+    """
+    inner_file_ext = infer_crypt4gh_inner_file_ext(filename, registry)
+    if inner_file_ext is not None:
+        return wrap_crypt4gh_file_ext(inner_file_ext)
+    if requested_ext != "auto":
+        return wrap_crypt4gh_file_ext(requested_ext)
+    return CRYPT4GH_FILE_EXT
+
+
+def preserve_crypt4gh_inner_file_ext(
+    guessed_ext: str,
+    current_ext: str | None = None,
+    metadata_inner_ext: str | None = None,
+) -> str:
+    """Preserve a known wrapper extension during datatype re-detection.
+
+    Re-detection from object-store paths often loses the original filename
+    suffix and can only sniff a generic ``c*4gh`` wrapper.  When that
+    happens, keep the more specific wrapper if we already know it from the
+    dataset extension or from computed ``crypt4gh_inner_ext`` metadata.
+    """
+    if not _is_generic_crypt4gh_file_ext(guessed_ext):
+        return guessed_ext
+
+    if current_ext and not _is_generic_crypt4gh_file_ext(current_ext) and is_crypt4gh_file_ext(current_ext):
+        return current_ext
+
+    if (
+        metadata_inner_ext
+        and metadata_inner_ext
+        not in (
+            "auto",
+            "data",
+            "binary",
+            "txt",
+        )
+        and not _is_generic_crypt4gh_file_ext(metadata_inner_ext)
+    ):
+        return wrap_crypt4gh_file_ext(metadata_inner_ext)
+
+    return guessed_ext
+
+
+# --- Header reading / validation -------------------------------------------
+
+def read_crypt4gh_header(stream_or_path: str | IO[bytes]) -> bytes:
+    """Read and validate the Crypt4GH header from a file path or stream.
+
+    Returns the raw header bytes (prelude + all header packets).
+
+    Raises :class:`ValueError` if the file is not a valid Crypt4GH file
+    or if the header is truncated.
+    """
+    close_stream = False
+    stream: IO[bytes]
+    if isinstance(stream_or_path, str):
+        stream = open(stream_or_path, "rb")
+        close_stream = True
+    else:
+        stream = stream_or_path
+
+    try:
+        prelude = stream.read(_PRELUDE_SIZE)
+        if len(prelude) != _PRELUDE_SIZE:
+            raise ValueError("Header too small")
+
+        magic, version, packet_count = struct.unpack(_PRELUDE_FORMAT, prelude)
+        if magic != CRYPT4GH_MAGIC:
+            raise ValueError("Not a Crypt4GH file")
+        if version != CRYPT4GH_VERSION:
+            raise ValueError(f"Unsupported Crypt4GH version {version}")
+
+        header = bytearray(prelude)
+        for _ in range(packet_count):
+            packet_len_bytes = stream.read(4)
+            if len(packet_len_bytes) != 4:
+                raise ValueError("Truncated header packet length")
+            packet_len = int.from_bytes(packet_len_bytes, byteorder="little")
+            if packet_len < 4:
+                raise ValueError(f"Invalid packet length {packet_len}")
+            packet_data = stream.read(packet_len - 4)
+            if len(packet_data) != packet_len - 4:
+                raise ValueError("Truncated header packet data")
+            header.extend(packet_len_bytes)
+            header.extend(packet_data)
+
+        return bytes(header)
+    finally:
+        if close_stream:
+            stream.close()
+
+
+def check_crypt4gh(file_path: str) -> bool:
+    """Return True if *file_path* is a valid Crypt4GH file (header check only)."""
+    try:
+        read_crypt4gh_header(file_path)
+        return True
+    except Exception:
+        return False
+
+
+__all__ = (
+    "check_crypt4gh",
+    "CRYPT4GH_FILE_EXT",
+    "CRYPT4GH_MAGIC",
+    "CRYPT4GH_SUFFIX",
+    "CRYPT4GH_VERSION",
+    "infer_crypt4gh_file_ext",
+    "infer_crypt4gh_inner_file_ext",
+    "is_crypt4gh_file_ext",
+    "preserve_crypt4gh_inner_file_ext",
+    "read_crypt4gh_header",
+    "unwrap_crypt4gh_file_ext",
+    "wrap_crypt4gh_file_ext",
+)

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -49,6 +49,7 @@ _PRELUDE_SIZE = struct.calcsize(_PRELUDE_FORMAT)
 
 # --- Extension helpers ------------------------------------------------------
 
+
 def _is_generic_crypt4gh_file_ext(file_ext: str) -> bool:
     """Return True for bare wrapper extensions like ``c4gh``, ``crypt4gh``."""
     return fullmatch(r"c[^.]*4gh", file_ext) is not None
@@ -89,7 +90,7 @@ def infer_crypt4gh_inner_file_ext(filename: str, registry) -> str | None:
     """Try to infer the inner datatype extension from *filename* via the registry."""
     inner_filename = _unwrap_crypt4gh_suffix(filename) or filename
     datatype = registry.get_datatype_from_filename(inner_filename)
-    if datatype and datatype.file_ext not in ("data", "binary", "txt", "auto"):
+    if datatype and datatype.file_ext not in ("data", "auto"):
         return datatype.file_ext
     return None
 
@@ -145,6 +146,7 @@ def preserve_crypt4gh_inner_file_ext(
 
 
 # --- Header reading / validation -------------------------------------------
+
 
 def read_crypt4gh_header(stream_or_path: str | IO[bytes]) -> bytes:
     """Read and validate the Crypt4GH header from a file path or stream.
@@ -287,9 +289,7 @@ def validate_crypt4gh_keypair_expiration(val: str) -> None:
     else:
         now = datetime.now()
     if expiration <= now:
-        raise RequestParameterInvalidException(
-            "Crypt4GH keypair expiration date must be in the future."
-        )
+        raise RequestParameterInvalidException("Crypt4GH keypair expiration date must be in the future.")
 
 
 # --- Job readiness guard (job-level) ---------------------------------------
@@ -336,18 +336,18 @@ def _validate_single_crypt4gh_input(input_name: str, dataset: DatasetInstance) -
 
     if not compute_header:
         return [
-            f"Input '{input_name}': missing crypt4gh_compute_header metadata. "
-            f"Use the recrypt action to prepare this dataset for compute."
+            f"Input '{input_name}': missing crypt4gh_compute_header metadata. ",
+            "Use the recrypt action to prepare this dataset for compute.",
         ]
     if not keypair_id:
         return [
-            f"Input '{input_name}': missing crypt4gh_compute_keypair_id metadata. "
-            f"Use the recrypt action to prepare this dataset for compute."
+            f"Input '{input_name}': missing crypt4gh_compute_keypair_id metadata. ",
+            "Use the recrypt action to prepare this dataset for compute.",
         ]
     if not expiration_str:
         return [
-            f"Input '{input_name}': missing crypt4gh_compute_keypair_expiration_date metadata. "
-            f"Use the recrypt action to prepare this dataset for compute."
+            f"Input '{input_name}': missing crypt4gh_compute_keypair_expiration_date metadata. ",
+            "Use the recrypt action to prepare this dataset for compute.",
         ]
 
     return _validate_keypair_not_expired(input_name, str(expiration_str))
@@ -359,8 +359,8 @@ def _validate_keypair_not_expired(input_name: str, expiration_str: str) -> list[
         expiration = datetime.fromisoformat(expiration_str)
     except (ValueError, TypeError):
         return [
-            f"Input '{input_name}': invalid crypt4gh_compute_keypair_expiration_date "
-            f"'{expiration_str}': expected ISO 8601 format."
+            f"Input '{input_name}': invalid crypt4gh_compute_keypair_expiration_date ",
+            f"'{expiration_str}': expected ISO 8601 format.",
         ]
 
     if expiration.tzinfo is not None:
@@ -370,8 +370,8 @@ def _validate_keypair_not_expired(input_name: str, expiration_str: str) -> list[
 
     if expiration <= now:
         return [
-            f"Input '{input_name}': Crypt4GH keypair has expired "
-            f"(expiration: {expiration_str}). Use the recrypt action to renew."
+            f"Input '{input_name}': Crypt4GH keypair has expired ",
+            f"(expiration: {expiration_str}). Use the recrypt action to renew.",
         ]
 
     return []

--- a/lib/galaxy/util/crypt4gh.py
+++ b/lib/galaxy/util/crypt4gh.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from galaxy.exceptions import RequestParameterInvalidException
-from galaxy.job_execution.compute_environment import dataset_path_to_extra_path
+from galaxy.util import dataset_path_to_extra_path
 
 if TYPE_CHECKING:
     from galaxy.model import (

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -39,7 +39,10 @@ from galaxy.model.item_attrs import (
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.util import sanitize_text
-from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
+from galaxy.util.crypt4gh import (
+    preserve_crypt4gh_inner_file_ext,
+    validate_crypt4gh_compute_metadata,
+)
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.util.zipstream import ZipstreamWrapper
 from galaxy.web import form_builder
@@ -354,7 +357,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 # The following for loop will save all metadata_spec items
                 for name, spec in data.datatype.metadata_spec.items():
                     if not spec.get("readonly"):
-                        setattr(data.metadata, name, spec.unwrap(payload.get(name) or None))
+                        val = payload.get(name) or None
+                        if val is not None:
+                            validate_crypt4gh_compute_metadata(data, name, spec.unwrap(val))
+                        setattr(data.metadata, name, spec.unwrap(val))
                 data.datatype.after_setting_metadata(data)
                 # Sanitize annotation before adding it.
                 if payload.get("annotation"):

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -39,6 +39,7 @@ from galaxy.model.item_attrs import (
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.util import sanitize_text
+from galaxy.util.crypt4gh import preserve_crypt4gh_inner_file_ext
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.util.zipstream import ZipstreamWrapper
 from galaxy.web import form_builder
@@ -385,6 +386,11 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                     self.hda_manager.ensure_dataset_on_disk(trans, data)
                     path = data.dataset.get_file_name()
                     datatype = guess_ext(path, trans.app.datatypes_registry.sniff_order)
+                    datatype = preserve_crypt4gh_inner_file_ext(
+                        datatype,
+                        current_ext=data.extension,
+                        metadata_inner_ext=getattr(data.metadata, "crypt4gh_inner_ext", None),
+                    )
                     trans.app.datatypes_registry.change_datatype(data, datatype)
                     trans.sa_session.commit()
                     job, *_ = trans.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -20,8 +20,6 @@ from typing import (
 import requests
 import yaml
 from requests.models import Response
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
 
 from galaxy.selenium import driver_factory
 from galaxy.selenium.axe_results import assert_baseline_accessible
@@ -70,6 +68,8 @@ from galaxy_test.base.populators import (
     stage_inputs,
 )
 from galaxy_test.base.testcase import FunctionalTestCase
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 try:
     from galaxy_test.driver.driver_util import GalaxyTestDriver

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -20,6 +20,8 @@ from typing import (
 import requests
 import yaml
 from requests.models import Response
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 from galaxy.selenium import driver_factory
 from galaxy.selenium.axe_results import assert_baseline_accessible
@@ -68,8 +70,6 @@ from galaxy_test.base.populators import (
     stage_inputs,
 )
 from galaxy_test.base.testcase import FunctionalTestCase
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
 
 try:
     from galaxy_test.driver.driver_util import GalaxyTestDriver

--- a/lib/galaxy_test/selenium/integration/crypt4gh/conftest.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/conftest.py
@@ -1,0 +1,52 @@
+"""Pytest configuration for Crypt4GH Selenium tests.
+
+Overrides the parent ``real_driver`` fixture to start Galaxy with crypt4gh
+configuration.  The mock recryptor server and test keys are created as
+session-scoped fixtures and injected into the test class before the Galaxy
+server starts.
+"""
+
+import os
+
+import pytest
+
+from .crypt4gh_test_utils import generate_test_keys
+from .framework import Crypt4ghIntegrationSeleniumTestCase
+from .mock_recryptor import MockRecryptorServer
+
+
+@pytest.fixture(scope="session")
+def crypt4gh_test_keys():
+    return generate_test_keys()
+
+
+@pytest.fixture(scope="session")
+def mock_recryptor_server(crypt4gh_test_keys):
+    server = MockRecryptorServer(crypt4gh_test_keys)
+    server.start()
+    yield server
+    server.shutdown()
+
+
+@pytest.fixture(scope="session")
+def real_driver(mock_recryptor_server, crypt4gh_test_keys):
+    if not os.environ.get("GALAXY_TEST_ENVIRONMENT_CONFIGURED"):
+        from galaxy_test.driver.driver_util import GalaxyTestDriver
+
+        # Inject crypt4gh config into the test class before Galaxy starts
+        Crypt4ghIntegrationSeleniumTestCase.mock_recryptor_url = mock_recryptor_server.base_url
+        Crypt4ghIntegrationSeleniumTestCase.crypt4gh_keys = crypt4gh_test_keys
+
+        driver = GalaxyTestDriver()
+        driver.setup(Crypt4ghIntegrationSeleniumTestCase)
+        try:
+            yield driver
+        finally:
+            driver.tear_down()
+    else:
+        yield None
+
+
+@pytest.fixture(scope="class")
+def embedded_driver(real_driver, request):
+    request.cls._test_driver = real_driver

--- a/lib/galaxy_test/selenium/integration/crypt4gh/crypt4gh_test_utils.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/crypt4gh_test_utils.py
@@ -13,13 +13,12 @@ from datetime import (
     timezone,
 )
 
+import crypt4gh.header
+import crypt4gh.lib
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey,
 )
-
-import crypt4gh.header
-import crypt4gh.lib
 
 DEFAULT_KEYPAIR_ID = "test-compute-keypair-1"
 DEFAULT_EXPIRATION_DAYS = 7

--- a/lib/galaxy_test/selenium/integration/crypt4gh/crypt4gh_test_utils.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/crypt4gh_test_utils.py
@@ -1,0 +1,171 @@
+"""Utilities for Crypt4GH Selenium tests.
+
+Provides key generation, file encryption/decryption, and header manipulation
+helpers used by the mock recryptor server and the test framework.
+"""
+
+import base64
+import io
+from dataclasses import dataclass
+from datetime import (
+    datetime,
+    timedelta,
+    timezone,
+)
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+)
+
+import crypt4gh.header
+import crypt4gh.lib
+
+DEFAULT_KEYPAIR_ID = "test-compute-keypair-1"
+DEFAULT_EXPIRATION_DAYS = 7
+
+
+@dataclass(frozen=True)
+class Crypt4ghTestKeys:
+    """Keypairs and metadata for a complete crypt4gh test scenario."""
+
+    # User keypair (encrypts/decrypts the original .c4gh files)
+    user_private_key: bytes  # raw X25519 private key bytes
+    user_public_key: bytes  # raw X25519 public key bytes
+
+    # Compute keypair (held by the mock recryptor / Service B)
+    compute_private_key: bytes
+    compute_public_key: bytes
+    compute_keypair_id: str
+    compute_keypair_expiration_date: str  # ISO 8601
+
+
+def _generate_x25519_keypair() -> tuple[bytes, bytes]:
+    """Generate an X25519 keypair, returning (private_raw_bytes, public_raw_bytes)."""
+    private_key = X25519PrivateKey.generate()
+    private_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private_bytes, public_bytes
+
+
+def generate_test_keys(
+    keypair_id: str = DEFAULT_KEYPAIR_ID,
+    expiration_days: int = DEFAULT_EXPIRATION_DAYS,
+) -> Crypt4ghTestKeys:
+    """Generate all keypairs needed for a crypt4gh test scenario."""
+    user_priv, user_pub = _generate_x25519_keypair()
+    compute_priv, compute_pub = _generate_x25519_keypair()
+    expiration = datetime.now(timezone.utc) + timedelta(days=expiration_days)
+    return Crypt4ghTestKeys(
+        user_private_key=user_priv,
+        user_public_key=user_pub,
+        compute_private_key=compute_priv,
+        compute_public_key=compute_pub,
+        compute_keypair_id=keypair_id,
+        compute_keypair_expiration_date=expiration.isoformat(),
+    )
+
+
+def format_public_key_pem(public_key_bytes: bytes) -> str:
+    """Format raw public key bytes as a PEM-like crypt4gh public key string.
+
+    This matches the format used by Galaxy's ``_format_crypt4gh_public_key``.
+    """
+    encoded = base64.b64encode(public_key_bytes).decode("ascii")
+    return "\n".join(
+        [
+            "-----BEGIN CRYPT4GH PUBLIC KEY-----",
+            encoded,
+            "-----END CRYPT4GH PUBLIC KEY-----",
+        ]
+    )
+
+
+def parse_public_key_pem(pem_str: str) -> bytes:
+    """Parse a PEM-like crypt4gh public key string back to raw bytes."""
+    lines = pem_str.strip().splitlines()
+    # Strip BEGIN/END markers, base64-decode the middle
+    encoded = "".join(line.strip() for line in lines if not line.startswith("-----"))
+    return base64.b64decode(encoded)
+
+
+def encrypt_bytes(
+    plaintext: bytes,
+    recipient_public_keys: list[bytes],
+) -> bytes:
+    """Encrypt plaintext bytes and return the encrypted .c4gh bytes."""
+    ephemeral_priv = X25519PrivateKey.generate()
+    ephemeral_priv_bytes = ephemeral_priv.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    keys = [(0, ephemeral_priv_bytes, recipient_pub) for recipient_pub in recipient_public_keys]
+    infile = io.BytesIO(plaintext)
+    outfile = io.BytesIO()
+    crypt4gh.lib.encrypt(keys, infile, outfile)
+    return outfile.getvalue()
+
+
+def extract_header_bytes(encrypted_bytes: bytes) -> bytes:
+    """Read and return the crypt4gh header bytes from encrypted bytes."""
+    stream = io.BytesIO(encrypted_bytes)
+    list(crypt4gh.header.parse(stream))
+    header_length = stream.tell()
+    stream.seek(0)
+    return stream.read(header_length)
+
+
+def reencrypt_header(
+    header_bytes: bytes,
+    decryptor_private_key: bytes,
+    recipient_public_keys: list[bytes],
+) -> bytes:
+    """Re-encrypt a crypt4gh header for new recipient public keys.
+
+    Uses ``crypt4gh.header.reencrypt`` to decrypt with the holder's private key
+    and re-encrypt for the new recipients.
+    """
+    stream = io.BytesIO(header_bytes)
+    packets = list(crypt4gh.header.parse(stream))
+    # Decryptor keys: (method, private_key, sender_pubkey)
+    keys = [(0, decryptor_private_key, None)]
+    # Recipient keys: (method, sender_private_key, recipient_public_key)
+    # Generate an ephemeral sender key for each recipient
+    recipient_keys = []
+    for recipient_pub in recipient_public_keys:
+        ephemeral_priv = X25519PrivateKey.generate()
+        ephemeral_priv_bytes = ephemeral_priv.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        recipient_keys.append((0, ephemeral_priv_bytes, recipient_pub))
+    new_packets = crypt4gh.header.reencrypt(packets, keys, recipient_keys)
+    return crypt4gh.header.serialize(new_packets)
+
+
+def decrypt_bytes(encrypted_bytes: bytes, private_key: bytes) -> bytes:
+    """Decrypt encrypted bytes and return the plaintext."""
+    keys = [(0, private_key, None)]
+    infile = io.BytesIO(encrypted_bytes)
+    outfile = io.BytesIO()
+    crypt4gh.lib.decrypt(keys, infile, outfile)
+    return outfile.getvalue()
+
+
+def encode_header_b64(header_bytes: bytes) -> str:
+    """Base64-encode header bytes for API payloads."""
+    return base64.b64encode(header_bytes).decode("ascii")
+
+
+def decode_header_b64(encoded: str) -> bytes:
+    """Base64-decode a header string from API payloads."""
+    return base64.b64decode(encoded)

--- a/lib/galaxy_test/selenium/integration/crypt4gh/framework.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/framework.py
@@ -1,0 +1,177 @@
+"""Base class for Crypt4GH Selenium tests.
+
+Provides a ``SeleniumTestCase`` subclass that configures Galaxy with crypt4gh
+settings and helper methods for uploading encrypted datasets and verifying
+encrypted outputs.
+"""
+
+import io
+from pathlib import Path
+from typing import Any
+
+from galaxy_test.selenium.framework import (
+    SeleniumTestCase,
+    UsesHistoryItemAssertions,
+)
+from .crypt4gh_test_utils import (
+    Crypt4ghTestKeys,
+    decrypt_bytes,
+    encode_header_b64,
+    encrypt_bytes,
+    extract_header_bytes,
+    reencrypt_header,
+)
+
+
+class Crypt4ghIntegrationSeleniumTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+    """Selenium integration test case with crypt4gh transparent staging enabled.
+
+    This is an integration test because it modifies the default Galaxy
+    configuration via ``handle_galaxy_config_kwds``.
+
+    The ``mock_recryptor_url`` and ``crypt4gh_keys`` class attributes are set
+    by the ``real_driver`` fixture in ``conftest.py`` before the Galaxy server
+    starts.
+    """
+
+    isolate_galaxy_config = True
+    mock_recryptor_url: str = ""
+    crypt4gh_keys: Crypt4ghTestKeys
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config: dict[str, Any]) -> None:
+        super().handle_galaxy_config_kwds(config)
+        config["enable_crypt4gh_transparent_staging"] = True
+        config["crypt4gh_reencryption_service_url"] = cls.mock_recryptor_url
+        config["outputs_to_working_directory"] = True
+        config["crypt4gh_cleanup_failure_is_job_failure"] = True
+        # Metadata must be embedded in the job script.
+        config["metadata_strategy"] = "extended"
+        # Tool command line must be built on the job side for crypt4gh staging.
+        config["tool_evaluation_strategy"] = "remote"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def upload_crypt4gh_dataset(
+        self,
+        plaintext_filename: str,
+        set_compute_metadata: bool = True,
+    ) -> dict[str, Any]:
+        """Upload a test-data file as a crypt4gh-encrypted dataset.
+
+        1. Reads the plaintext test-data file.
+        2. Encrypts it for the user's public key.
+        3. Uploads via the API with ``file_type="auto"`` so the registry
+           detects magic bytes and infers the inner type from the filename
+           (e.g. ``1.txt.c4gh`` → inner type ``txt`` → ext ``txt.c4gh``).
+        4. If ``set_compute_metadata`` is True, sets compute metadata
+           (compute header, keypair id, expiration date) via
+           ``PUT /api/datasets/{id}`` with a nested ``metadata`` dict,
+           matching the API path that the UI's recrypt flow uses.
+        5. Waits for the dataset to reach the ``ok`` state.
+
+        Returns the dataset details dict.
+        """
+        keys = self.crypt4gh_keys
+        history_id = self.current_history_id()
+
+        # Read plaintext test data
+        plaintext_path = Path(self.get_filename(plaintext_filename))
+        plaintext = plaintext_path.read_bytes()
+
+        # Encrypt for the user's public key
+        encrypted_bytes = encrypt_bytes(plaintext, [keys.user_public_key])
+
+        # Upload from an in-memory stream so the filename still drives the
+        # inferred inner type, without creating a temp file in the test harness.
+        encrypted_filename = f"{plaintext_filename}.c4gh"
+        dataset = self.dataset_populator.new_dataset(
+            history_id,
+            content=io.BytesIO(encrypted_bytes),
+            file_type="auto",
+            wait=True,
+            name=encrypted_filename,
+        )
+
+        if set_compute_metadata:
+            # Re-encrypt header for compute keypair (simulates Service A recrypt)
+            header_bytes = extract_header_bytes(encrypted_bytes)
+            compute_header = reencrypt_header(
+                header_bytes,
+                keys.user_private_key,
+                [keys.compute_public_key],
+            )
+
+            self.dataset_populator.update_dataset(
+                dataset["id"],
+                {
+                    "metadata": {
+                        "crypt4gh_compute_header": encode_header_b64(compute_header),
+                        "crypt4gh_compute_keypair_id": keys.compute_keypair_id,
+                        "crypt4gh_compute_keypair_expiration_date": keys.compute_keypair_expiration_date,
+                    }
+                },
+            )
+
+            # Wait for dataset to be ok after metadata update
+            self.dataset_populator.wait_for_history(history_id)
+
+        # Return fresh details
+        details = self.dataset_populator.get_history_dataset_details(
+            history_id,
+            dataset_id=dataset["id"],
+        )
+        return details
+
+    def upload_plain_dataset(
+        self,
+        plaintext_filename: str,
+        file_ext: str = "txt",
+    ) -> dict[str, Any]:
+        """Upload a plain (non-encrypted) test-data file via the API."""
+        history_id = self.current_history_id()
+        plaintext_path = Path(self.get_filename(plaintext_filename))
+        with open(plaintext_path, "rb") as f:
+            dataset = self.dataset_populator.new_dataset(
+                history_id,
+                content=f,
+                file_type=file_ext,
+                wait=True,
+                name=plaintext_filename,
+            )
+        return self.dataset_populator.get_history_dataset_details(
+            history_id,
+            dataset_id=dataset["id"],
+        )
+
+    def assert_crypt4gh_output_extension(self, hid: int, expected_extension: str) -> None:
+        """Wait for a Crypt4GH output to finish, expand its history item, and assert the wrapped type."""
+        self.history_panel_wait_for_hid_ok(hid)
+        self.history_panel_ensure_showing_item_details(hid)
+        self.assert_item_extension(hid, expected_extension)
+
+    def verify_crypt4gh_output(
+        self,
+        dataset_id: str,
+        expected_content: bytes,
+    ) -> None:
+        """Download an encrypted output dataset, decrypt it, and verify content."""
+        history_id = self.current_history_id()
+        content_bytes = self.dataset_populator.get_history_dataset_content(
+            history_id,
+            dataset_id=dataset_id,
+            type="bytes",
+        )
+        assert isinstance(content_bytes, bytes), "Expected encrypted dataset content as bytes."
+        plaintext = decrypt_bytes(content_bytes, self.crypt4gh_keys.user_private_key)
+        assert plaintext == expected_content, (
+            f"Decrypted content does not match expected.\n"
+            f"Expected: {expected_content!r}\n"
+            f"Got:      {plaintext!r}"
+        )
+
+    def get_test_file_content(self, filename: str) -> bytes:
+        """Read a test-data file and return its content as bytes."""
+        return Path(self.get_filename(filename)).read_bytes()

--- a/lib/galaxy_test/selenium/integration/crypt4gh/mock_recryptor.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/mock_recryptor.py
@@ -1,0 +1,139 @@
+"""Mock Service B (recryptor) for Crypt4GH Selenium tests.
+
+A small HTTP server that performs real crypt4gh header re-encryption using the
+``crypt4gh`` library.  Galaxy sends reencryption requests to two endpoints:
+
+- ``POST /recrypt_header_to_job_key`` — input staging: re-encrypts the compute
+  header for a job's ephemeral public key.
+- ``POST /recrypt_header_to_user_key`` — output finalization: re-encrypts the
+  compute-encrypted header back for the user's public key.
+
+The server uses ``ThreadingHTTPServer`` because Galaxy sends reencryption
+requests in parallel via ``asyncio.gather``.
+"""
+
+import json
+import logging
+from http.server import (
+    BaseHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
+from typing import Any
+
+from .crypt4gh_test_utils import (
+    Crypt4ghTestKeys,
+    decode_header_b64,
+    encode_header_b64,
+    format_public_key_pem,
+    parse_public_key_pem,
+    reencrypt_header,
+)
+
+log = logging.getLogger(__name__)
+
+
+class _RecryptorHandler(BaseHTTPRequestHandler):
+    """Request handler for the mock recryptor server."""
+
+    # Set by MockRecryptorServer before serving requests.
+    keys: Crypt4ghTestKeys
+
+    def do_POST(self) -> None:
+        if self.path == "/recrypt_header_to_job_key":
+            self._handle_recrypt_to_job_key()
+        elif self.path == "/recrypt_header_to_user_key":
+            self._handle_recrypt_to_user_key()
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def _read_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        return json.loads(raw)
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _handle_recrypt_to_job_key(self) -> None:
+        """Re-encrypt the compute header for the job's ephemeral public key."""
+        try:
+            req = self._read_body()
+            header_bytes = decode_header_b64(req["crypt4gh_header"])
+            job_public_key_pem = req["crypt4gh_job_public_key"]
+            job_public_key = parse_public_key_pem(job_public_key_pem)
+
+            # Re-encrypt header: decrypt with compute private key, encrypt for job key
+            recrypted = reencrypt_header(
+                header_bytes,
+                self.keys.compute_private_key,
+                [job_public_key],
+            )
+
+            response = {
+                "crypt4gh_header": encode_header_b64(recrypted),
+                "crypt4gh_compute_public_key": format_public_key_pem(self.keys.compute_public_key),
+                "crypt4gh_compute_keypair_id": self.keys.compute_keypair_id,
+                "crypt4gh_compute_keypair_expiration_date": self.keys.compute_keypair_expiration_date,
+            }
+            self._send_json(200, response)
+        except Exception as exc:
+            log.exception("Error in /recrypt_header_to_job_key")
+            self._send_json(500, {"error": str(exc)})
+
+    def _handle_recrypt_to_user_key(self) -> None:
+        """Re-encrypt the compute-encrypted header back for the user's public key."""
+        try:
+            req = self._read_body()
+            header_bytes = decode_header_b64(req["crypt4gh_header"])
+
+            # Re-encrypt header: decrypt with compute private key, encrypt for user key
+            recrypted = reencrypt_header(
+                header_bytes,
+                self.keys.compute_private_key,
+                [self.keys.user_public_key],
+            )
+
+            response = {
+                "crypt4gh_header": encode_header_b64(recrypted),
+            }
+            self._send_json(200, response)
+        except Exception as exc:
+            log.exception("Error in /recrypt_header_to_user_key")
+            self._send_json(500, {"error": str(exc)})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        log.debug("Mock recryptor: %s - %s", self.address_string(), format % args)
+
+
+class MockRecryptorServer:
+    """A threaded HTTP server that performs real crypt4gh header re-encryption."""
+
+    def __init__(self, keys: Crypt4ghTestKeys, host: str = "127.0.0.1", port: int = 0) -> None:
+        self.keys = keys
+        # Attach keys to the handler class so all instances can access them
+        _RecryptorHandler.keys = keys
+        self._server = ThreadingHTTPServer((host, port), _RecryptorHandler)
+        self._server.daemon_threads = True
+
+    @property
+    def base_url(self) -> str:
+        host, port = self._server.server_address[:2]
+        if isinstance(host, bytes):
+            host = host.decode("ascii")
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        # ThreadingHTTPServer.serve_forever in a background thread
+        import threading
+
+        thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        thread.start()
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()

--- a/lib/galaxy_test/selenium/integration/crypt4gh/test_crypt4gh_tool_execution.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/test_crypt4gh_tool_execution.py
@@ -1,0 +1,124 @@
+"""Selenium tests for Crypt4GH tool execution.
+
+Tests verify the decrypt→run→encrypt flow by running the ``cat1`` tool with
+crypt4gh-encrypted inputs through the browser, then decrypting outputs to
+verify content.
+"""
+
+from galaxy_test.selenium.framework import (
+    managed_history,
+    selenium_test,
+    UsesHistoryItemAssertions,
+)
+from .framework import Crypt4ghIntegrationSeleniumTestCase
+
+
+class TestCrypt4ghToolExecutionIntegration(Crypt4ghIntegrationSeleniumTestCase, UsesHistoryItemAssertions):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_run_cat_with_single_crypt4gh_input(self):
+        """Run cat1 with a single crypt4gh-encrypted input and verify output."""
+        # Upload encrypted dataset
+        input_details = self.upload_crypt4gh_dataset("1.txt")
+        input_hid = input_details["hid"]
+
+        # Open cat1 tool and select the encrypted input
+        self.tool_open("cat1")
+        self.tool_set_value("input1", f"{input_hid}: ", expected_type="data")
+        self.tool_form_execute()
+
+        # Wait for output and verify the wrapped extension once the history item is expanded.
+        output_hid = input_hid + 1
+        self.assert_crypt4gh_output_extension(output_hid, expected_extension="txt.c4gh")
+
+        # Download, decrypt, and verify content
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        expected_content = self.get_test_file_content("1.txt")
+        self.verify_crypt4gh_output(output_details["id"], expected_content)
+
+    @selenium_test
+    @managed_history
+    def test_run_cat_with_multiple_crypt4gh_inputs(self):
+        """Run cat1 with two crypt4gh-encrypted inputs and verify concatenation."""
+        # Upload two encrypted datasets
+        input1_details = self.upload_crypt4gh_dataset("1.txt")
+        input1_hid = input1_details["hid"]
+
+        input2_details = self.upload_crypt4gh_dataset("1.fasta")
+        input2_hid = input2_details["hid"]
+
+        # Open cat1 tool, select both inputs
+        self.tool_open("cat1")
+        self.tool_set_value("input1", f"{input1_hid}: ", expected_type="data")
+        # Add a repeat for the second input
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        self.tool_set_value("queries_0|input2", f"{input2_hid}: ", expected_type="data")
+        self.tool_form_execute()
+
+        # Wait for output and verify the wrapped extension once the history item is expanded.
+        output_hid = input2_hid + 1
+        self.assert_crypt4gh_output_extension(output_hid, expected_extension="txt.c4gh")
+
+        # Download, decrypt, and verify content is concatenation
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        expected_content = self.get_test_file_content("1.txt") + self.get_test_file_content("1.fasta")
+        self.verify_crypt4gh_output(output_details["id"], expected_content)
+
+    @selenium_test
+    @managed_history
+    def test_run_cat_with_mixed_inputs(self):
+        """Run cat1 with one crypt4gh-encrypted and one plain input."""
+        # Upload one encrypted and one plain dataset
+        enc_details = self.upload_crypt4gh_dataset("1.txt")
+        enc_hid = enc_details["hid"]
+
+        plain_details = self.upload_plain_dataset("1.fasta", file_ext="fasta")
+        plain_hid = plain_details["hid"]
+
+        # Open cat1 tool, select both inputs
+        self.tool_open("cat1")
+        self.tool_set_value("input1", f"{enc_hid}: ", expected_type="data")
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        self.tool_set_value("queries_0|input2", f"{plain_hid}: ", expected_type="data")
+        self.tool_form_execute()
+
+        # Wait for output
+        output_hid = plain_hid + 1
+        self.history_panel_wait_for_hid_ok(output_hid)
+
+        # Download, decrypt, and verify content
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        expected_content = self.get_test_file_content("1.txt") + self.get_test_file_content("1.fasta")
+        self.verify_crypt4gh_output(output_details["id"], expected_content)
+
+    @selenium_test
+    @managed_history
+    def test_run_cat_without_compute_metadata_fails(self):
+        """Run cat1 with a crypt4gh input that has no compute metadata.
+
+        The pre-queue readiness guard should fail the job with an actionable
+        error message instead of allowing it to run.
+        """
+        # Upload encrypted dataset WITHOUT compute metadata
+        input_details = self.upload_crypt4gh_dataset("1.txt", set_compute_metadata=False)
+        input_hid = input_details["hid"]
+
+        # Open cat1 tool and select the encrypted input
+        self.tool_open("cat1")
+        self.tool_set_value("input1", f"{input_hid}: ", expected_type="data")
+        self.tool_form_execute()
+
+        # The job should fail (not ok) because compute metadata is missing
+        output_hid = input_hid + 1
+        self.history_panel_wait_for_hid_state(output_hid, "error")

--- a/lib/galaxy_test/selenium/integration/crypt4gh/test_crypt4gh_workflow_execution.py
+++ b/lib/galaxy_test/selenium/integration/crypt4gh/test_crypt4gh_workflow_execution.py
@@ -1,0 +1,162 @@
+"""Selenium tests for Crypt4GH workflow execution.
+
+Tests verify the decrypt→run→encrypt flow through multi-step workflows with
+crypt4gh-encrypted inputs, then decrypting outputs to verify content.
+"""
+
+from galaxy_test.selenium.framework import (
+    managed_history,
+    RunsWorkflows,
+    selenium_test,
+    UsesHistoryItemAssertions,
+)
+from .framework import Crypt4ghIntegrationSeleniumTestCase
+
+# Workflow with a single cat1 step that concatenates the input with itself.
+# (WORKFLOW_SIMPLE_CAT_TWICE from workflow_fixtures.py is this exact pattern.)
+WORKFLOW_SIMPLE_CAT_TWICE = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+      queries_0|input2: input1
+"""
+
+# Two-step workflow: first cat1 concatenates input1 + input2, second cat1
+# concatenates the result with input1 again.
+WORKFLOW_TWO_STEP_CAT = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+  input2: data
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+      queries_0|input2: input2
+  second_cat:
+    tool_id: cat1
+    in:
+      input1: first_cat/out_file1
+      queries_0|input2: input1
+"""
+
+
+class TestCrypt4ghWorkflowExecutionIntegration(
+    Crypt4ghIntegrationSeleniumTestCase, RunsWorkflows, UsesHistoryItemAssertions
+):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_simple_cat_workflow(self):
+        """Run a single-step cat1 workflow with one crypt4gh-encrypted input.
+
+        The workflow concatenates the input with itself, so the output should
+        be the input content doubled.
+        """
+        input_details = self.upload_crypt4gh_dataset("1.txt")
+        input_hid = input_details["hid"]
+
+        # Open and run the workflow
+        self.workflow_run_open_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # Wait for output (input_hid + 1 since there's one input and one output)
+        output_hid = input_hid + 1
+        self.workflow_run_wait_for_ok(output_hid, expand=True)
+        self.assert_crypt4gh_output_extension(output_hid, expected_extension="txt.c4gh")
+
+        # Download, decrypt, and verify content (doubled input)
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        expected_content = self.get_test_file_content("1.txt") * 2
+        self.verify_crypt4gh_output(output_details["id"], expected_content)
+
+    @selenium_test
+    @managed_history
+    def test_multi_step_workflow_with_multiple_inputs(self):
+        """Run a two-step cat1 workflow with two crypt4gh-encrypted inputs.
+
+        Step 1: cat1(input1, input2) → intermediate
+        Step 2: cat1(intermediate, input1) → final output
+        """
+        input1_details = self.upload_crypt4gh_dataset("1.txt")
+        input1_hid = input1_details["hid"]
+
+        input2_details = self.upload_crypt4gh_dataset("1.fasta")
+        input2_hid = input2_details["hid"]
+
+        # Open and run the workflow, specifying inputs
+        self.workflow_run_open_workflow(WORKFLOW_TWO_STEP_CAT)
+        self.workflow_run_specify_inputs(
+            {
+                "input1": {"hid": input1_hid},
+                "input2": {"hid": input2_hid},
+            }
+        )
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # Wait for output (two inputs + two steps → output is last hid)
+        output_hid = input2_hid + 2
+        self.workflow_run_wait_for_ok(output_hid, expand=True)
+        self.assert_crypt4gh_output_extension(output_hid, expected_extension="txt.c4gh")
+
+        # Download, decrypt, and verify content
+        # Step 1: 1.txt + 1.fasta
+        # Step 2: (1.txt + 1.fasta) + 1.txt
+        content_1_txt = self.get_test_file_content("1.txt")
+        content_1_fasta = self.get_test_file_content("1.fasta")
+        expected_content = content_1_txt + content_1_fasta + content_1_txt
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        self.verify_crypt4gh_output(output_details["id"], expected_content)
+
+    @selenium_test
+    @managed_history
+    def test_workflow_with_mixed_inputs(self):
+        """Run a two-step cat1 workflow with one crypt4gh and one plain input."""
+        enc_details = self.upload_crypt4gh_dataset("1.txt")
+        enc_hid = enc_details["hid"]
+
+        plain_details = self.upload_plain_dataset("1.fasta", file_ext="fasta")
+        plain_hid = plain_details["hid"]
+
+        # Open and run the workflow, specifying inputs
+        self.workflow_run_open_workflow(WORKFLOW_TWO_STEP_CAT)
+        self.workflow_run_specify_inputs(
+            {
+                "input1": {"hid": enc_hid},
+                "input2": {"hid": plain_hid},
+            }
+        )
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # Wait for output
+        output_hid = plain_hid + 2
+        self.workflow_run_wait_for_ok(output_hid, expand=True)
+        self.assert_crypt4gh_output_extension(output_hid, expected_extension="txt.c4gh")
+
+        # Download, decrypt, and verify content
+        # Step 1: 1.txt + 1.fasta
+        # Step 2: (1.txt + 1.fasta) + 1.txt
+        content_1_txt = self.get_test_file_content("1.txt")
+        content_1_fasta = self.get_test_file_content("1.fasta")
+        expected_content = content_1_txt + content_1_fasta + content_1_txt
+        output_details = self.dataset_populator.get_history_dataset_details(
+            self.current_history_id(),
+            hid=output_hid,
+        )
+        self.verify_crypt4gh_output(output_details["id"], expected_content)

--- a/packages/app/pyproject.toml
+++ b/packages/app/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "galaxy-job-execution",
     "galaxy-job-metrics",
     "galaxy-objectstore",
-    "galaxy-tool-util[cwl,edam]",
+    "galaxy-tool-util[cwl,edam,crypt4gh]",
     "galaxy-tool-shed-schema",
     "galaxy-tours",
     "galaxy-util[image-util,jstree]",

--- a/packages/tool_util/pyproject.toml
+++ b/packages/tool_util/pyproject.toml
@@ -45,6 +45,10 @@ classifiers = [
 keywords = ["Galaxy"]
 
 [project.optional-dependencies]
+crypt4gh = [
+    "crypt4gh",
+    "aiohttp",
+]
 cwl = [
     "cwl-utils",
     "cwltool>=3.1.20230624081518",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.rst"
 requires-python = ">=3.10"
 dependencies = [
     "a2wsgi",
+    "aiohttp",
     "aiofiles",
     "alembic",
     "apispec",
@@ -28,6 +29,7 @@ dependencies = [
     "cloudauthz==0.6.0",
     "circus",
     "conda-package-streaming",
+    "crypt4gh",
     "CT3>=3.3.3",  # Python 3.13 support
     "cwl-utils>=0.13",
     "cwltool>=3.1.20230624081518",  # save time, minimum needed by cwl-1.0 branch


### PR DESCRIPTION
## Summary

This PR introduces first-class Crypt4GH support in Galaxy, enabling transparent decryption of encrypted inputs on the compute side, execution of tools and workflows on decrypted data, and re-encryption of outputs — all without Galaxy ever handling private keys or unencrypted payload bytes.

The implementation spans the datatype layer (sniffing, dynamic wrapper types, transparent input matching), a remote execution pipeline (decrypt → run → encrypt), a user-triggered recrypt action in the UI, pre-queue job readiness guards, and fail-closed output verification with decrypted data cleanup.

### Architecture overview

```mermaid
flowchart TB
    subgraph UserMachine["User's local machine"]
        subgraph Browser
            UI[Dataset Recrypt Button]
        end
        A[Service A<br/>User-mode Recryptor]
    end
    subgraph GalaxyServer["Galaxy server"]
        JOB[Job Enqueue<br/>Readiness Guard]
        RTE[remote_tool_eval.py]
        CRE[crypt4gh_remote_execution.py]
        FIN[Job Finisher<br/>Verification & Cleanup]
    end
    subgraph ComputeNode["Compute node"]
        B[Service B<br/>Compute-mode Recryptor]
        subgraph JobExecution["Job execution"]
            DECRYPT[Decrypt Inputs]
            TOOL[Tool Runs on Decrypted Data]
            ENCRYPT[Encrypt Outputs]
            CLEANUP[Cleanup Decrypted Artifacts]
        end
    end

    UI -->|POST /recrypt_header| A
    UI -.->|"stores compute metadata<br/>(pre-step, enables tool runs)"| GalaxyServer
    JOB --> RTE
    RTE --> CRE
    CRE -->|POST /recrypt_header_to_job_key| B
    CRE --> DECRYPT
    DECRYPT --> TOOL
    TOOL --> ENCRYPT
    ENCRYPT -->|POST /recrypt_header_to_user_key| B
    ENCRYPT --> CLEANUP
    CLEANUP --> FIN
```

### Key design principles

- **Galaxy never sees private keys or unencrypted data.** All private-key operations are delegated to the recryptor services. Galaxy only handles public headers and metadata.
- **Fail-closed throughout.** Any error in the decrypt/run/encrypt pipeline causes the job to fail rather than risking unencrypted data leakage.
- **Tools run unchanged.** The compute environment rewrites input paths to staged decrypted data, so tools operate on decrypted files without modification.
- **Dynamic wrapper datatypes.** Crypt4GH wrappers (`fastqsanger.c4gh`, `txt.c4gh`, etc.) are generated dynamically by the registry and transparently match tool inputs that accept the inner format.
- **Workflows, not just tools.** The remote execution pipeline operates transparently at the job level, so multi-step workflows run end-to-end with Crypt4GH inputs and outputs. Intermediate datasets between workflow steps are automatically re-encrypted, meaning users can compose arbitrarily complex pipelines without per-step recrypt actions or manual intervention.

## What's included

### Datatype layer

- **New** `lib/galaxy/datatypes/crypt4gh.py` — `Crypt4GH` datatype class with `sniff()`, `set_meta()` (header parsing only), `matches_any()` (transparent inner-type matching), and archive download support for extra files.
- **New** `lib/galaxy/util/crypt4gh.py` — Header parsing, file-extension helpers (`wrap_crypt4gh_file_ext`, `unwrap_crypt4gh_file_ext`, `is_crypt4gh_file_ext`), compute metadata validation, and job readiness checks.
- **Modified** `lib/galaxy/datatypes/registry.py` — Dynamic `inner_ext.c4gh` datatype generation and registration.
- **Modified** `lib/galaxy/datatypes/sniff.py` — Crypt4GH magic-byte sniffing, extension retention during re-detection.
- **Modified** `lib/galaxy/datatypes/upload_util.py` — Crypt4GH detection for non-auto user declarations.

### Remote execution pipeline

- **New** `lib/galaxy/tools/crypt4gh_remote_execution.py` (~3,000 lines) — Full decrypt/run/encrypt orchestration: per-job keypair generation, Service B integration, input staging/decryption, output encryption, galaxy.json metadata emission, verification, and cleanup.
- **Modified** `lib/galaxy/tools/remote_tool_eval.py` — Crypt4GH gate: conditionally builds a `Crypt4GHRemoteComputeEnvironment` and wraps the tool command with a postrun script.
- **Modified** `lib/galaxy/job_execution/setup.py` — Passes Crypt4GH runtime config to the job context via `JobIO`.

### Job lifecycle

- **Modified** `lib/galaxy/jobs/__init__.py` — Pre-queue readiness guard (`_assert_crypt4gh_job_readiness`), post-execution output verification, and cleanup failure handling.
- **Modified** `lib/galaxy/jobs/runners/__init__.py` — Surfaces remote tool eval failures as job errors.

### User-triggered recrypt (Service A)

- **Modified** `client/src/components/History/Content/Dataset/DatasetActions.vue` — Recrypt button visible for writable Crypt4GH datasets.
- **New** `client/src/composables/useCrypt4ghRecrypt.ts` — Composable handling the recrypt flow: fetch dataset metadata → POST header to Service A → PUT compute metadata back to Galaxy.
- **Modified** `lib/galaxy/managers/datasets.py` — Validation for Crypt4GH compute metadata fields on dataset update.
- **Modified** `lib/galaxy/webapps/galaxy/controllers/dataset.py` — Exposes Crypt4GH metadata fields.

### Configuration

- **Modified** `lib/galaxy/config/schemas/config_schema.yml` — Three new config keys:
    - `enable_crypt4gh_transparent_staging` (bool, default `false`)
    - `crypt4gh_reencryption_service_url` (str, default `null`) — Service B URL
    - `crypt4gh_cleanup_failure_is_job_failure` (bool, default `false`)
- **Modified** `lib/galaxy/managers/configuration.py` — Frontend-exposed config keys.
- **Modified** `lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample` — `crypt4gh_recrypt_service` preference (Service A port).
- **Modified** `lib/galaxy/config/sample/galaxy.yml.sample` — Sample config entries.
- **Modified** `doc/source/admin/galaxy_options.rst` — Documentation for new config keys.

### Dependencies

- **Modified** `lib/galaxy/dependencies/pinned-requirements.txt` — Added `crypt4gh` and `aiohttp`.
- **Modified** `pyproject.toml`, `packages/app/pyproject.toml`, `packages/tool_util/pyproject.toml` — Project dependencies.

## Testing status

### Manually tested and working

- **General workflow compatibility** — Tools run correctly with Crypt4GH inputs in standard workflows.
- **Implicit conversion** — Crypt4GH-wrapped inputs transparently match tools and converters that accept the inner datatype (e.g., `fastqsanger.c4gh` matches a tool expecting `fastqsanger`).
- **Multiple inputs** — Jobs with multiple Crypt4GH-encrypted inputs decrypt and run correctly.
- **Explicitly handled (non-mapped-over) collection input** — Crypt4GH inputs in non-map-over collection parameters work correctly.
- **Multiple mixed (encrypted and unencrypted) inputs** — Jobs with a mix of Crypt4GH-encrypted and unencrypted inputs run correctly.
- **Multiple declared outputs** — All declared outputs are encrypted and have correct Crypt4GH metadata.
- **Discovered regular dataset outputs** — Discovered (non-collection) outputs are correctly encrypted and registered.
- **Job failure on unencrypted data cleanup problems** (config flag-dependent) — When `crypt4gh_cleanup_failure_is_job_failure: true`, cleanup failures cause the job to fail, preventing unencrypted data leakage.

### Not working yet

- **`from_work_dir` outputs** — Currently cause job failure. Example tool: `qualimap_bamqc`.
- **Discovered collection elements** — Discovered collection elements are currently returned **unencrypted**. Example tool: `bgruening/split_file_to_collection`.
- **Legacy metadata tools** — Tools that use legacy metadata trigger a job failure with a descriptive error message pointing to the cause. Example tool: **Collapse Collection**.

### Likely not working (not yet tested)

- **Pulsar** — The remote execution pipeline has not been tested with Pulsar job runners.

## Manual testing setup

### Prerequisites

1. **Install mkcert** (for local HTTPS certificates):

    ```bash
    # Ubuntu/Debian
    sudo apt install libnss3-tools
    brew install mkcert
    mkcert -install
    ```

2. **Install the recryptor service** (not yet on PyPI — install from source):
    ```bash
    git clone https://github.com/elixir-europe/crypt4gh-recryptor-service.git
    cd crypt4gh-recryptor-service
    pip install -e .
    ```

### Start the recryptor services

The Crypt4GH flow requires two services:

| Service       | Mode    | Default Port | Purpose                                                                       |
| ------------- | ------- | ------------ | ----------------------------------------------------------------------------- |
| **Service A** | User    | `61357`      | Browser-facing; recrypts headers for the user's dataset recrypt action        |
| **Service B** | Compute | `61358`      | Runner-facing; recrypts headers for job input staging and output finalization |

#### Service B (Compute mode — runner-side)

```bash
cd <recryptor-service-dir>/c4gh_recryptor_compute
# Start the service
crypt4gh-recryptor-service compute
```

This listens on `https://localhost:61358` and exposes:

- `POST /get_compute_key_info`
- `POST /recrypt_header_to_job_key`
- `POST /recrypt_header_to_user_key`

#### Service A (User mode — browser-facing)

```bash
cd <recryptor-service-dir>/c4gh_recryptor_user
# Start the service
crypt4gh-recryptor-service user
```

This listens on `https://localhost:61357` and exposes `POST /recrypt_header` for the browser-based recrypt action.

### Configure Galaxy

Add the following to `config/galaxy.yml`:

```yaml
# Crypt4GH support configuration
enable_crypt4gh_transparent_staging: true
crypt4gh_reencryption_service_url: https://localhost:61358
crypt4gh_cleanup_failure_is_job_failure: true
metadata_strategy: extended
outputs_to_working_directory: true
tool_evaluation_strategy: remote
```

Add the recrypt service user preference to `config/user_preferences_extra_conf.yml` (see `user_preferences_extra_conf.yml.sample`):

```yaml
crypt4gh_recrypt_service:
    description: Crypt4GH recryption service running on your machine
    inputs:
        - name: port
          label: Port number of your local Service instance
          type: text
          required: False
          value: "61357"
```

### Start Galaxy

```bash
./run.sh
```

### Testing

1. **Upload an encrypted file** — Upload a `.c4gh` file (e.g., `fastqsanger.c4gh`) encrypted with Crypt4GH and your private key. Galaxy should detect it as a Crypt4GH-wrapped datatype via magic-byte sniffing.

2. **Recrypt the dataset** — Click the key icon (🔑) on the dataset in the history panel. This calls Service A to recrypt the header and stores compute metadata on the dataset. The dataset is now ready for job execution.

3. **Run a tool** — Select the recrypted dataset as input to any tool. The job will:
    - Pass the pre-queue readiness guard (validates compute metadata and key expiration).
    - On the compute side: generate a job keypair, call Service B to recrypt the header to the job key, decrypt inputs to a staging area.
    - Run the tool on decrypted data.
    - Encrypt outputs to the compute key, then recrypt headers back to the user key via Service B.
    - Clean up all decrypted artifacts.
    - Verify outputs have valid Crypt4GH framing before marking the job as successful.

4. **Verify outputs** — Output datasets should have `.c4gh` extensions and valid Crypt4GH headers. Download and decrypt them with the user's private key to confirm correctness.

## Future work

### Automated testing

- [ ] **Unit tests for `lib/galaxy/util/crypt4gh.py`** — Header parsing, extension wrapping/unwrapping, magic-byte detection, compute metadata validation, and job readiness checks.
- [ ] **Unit tests for `lib/galaxy/datatypes/crypt4gh.py`** — `sniff()`, `set_meta()`, `matches_any()`, archive download behavior, and dynamic wrapper datatype generation via the registry.
- [ ] **Integration tests for the remote execution pipeline** — Mock Service B endpoints and test `crypt4gh_remote_execution.py` end-to-end: input staging/decryption, output encryption, galaxy.json metadata emission, verification, and cleanup.
- [ ] **Integration tests for `remote_tool_eval.py`** — Verify the Crypt4GH gate correctly activates/deactivates based on config flags and input types.
- [ ] **Job lifecycle tests** — Pre-queue readiness guard (`_assert_crypt4gh_job_readiness`), post-execution verification, and cleanup failure handling in `jobs/__init__.py`.
- [ ] **Frontend tests** — Recrypt button visibility logic, `useCrypt4ghRecrypt` composable flow (mock Service A + Galaxy API), and error handling.
- [ ] **End-to-end tests** — Full workflow with a running recryptor service: upload → recrypt → run tool → verify encrypted outputs.
- [ ] **Regression tests for known limitations** — `from_work_dir` outputs, discovered collection elements, and legacy metadata tools.

### Code cleanup and architecture

- [ ] **Reduce `crypt4gh_remote_execution.py` size** — The module is ~3,000 lines. Consider splitting into focused submodules (e.g., input staging, output encryption, verification, cleanup, service client).
- [ ] **Generalize the encryption framework** — The current implementation is Crypt4GH-specific. Abstract the decrypt/run/encrypt lifecycle behind a generic interface so alternative encryption schemes can be plugged in without modifying the job execution pipeline.
- [ ] **Decouple service communication** — Extract the Service B HTTP client into a reusable abstraction with configurable timeouts, retry logic, and connection pooling.
- [ ] **Per-destination recryptor service B URL** — Remove (or deprecate) the general `crypt4gh_reencryption_service_url` and allow setting a different URL for each remote destination that works with crypt4gh, producing actionable error messages when misconfigured.
- [ ] **Pulsar support** — Test and adapt the remote execution pipeline for Pulsar job runners, which have different file staging semantics.
- [ ] **`from_work_dir` output support** — Investigate why `from_work_dir` outputs cause job failure and implement proper encryption handling for this output pattern.
- [ ] **Discovered collection element encryption** — Fix the issue where discovered collection elements are returned unencrypted; ensure the postrun encryption flow covers all discovery output paths.
- [ ] **Legacy metadata compatibility** — Evaluate whether legacy metadata tools can be supported or whether the fail-closed error message is the correct long-term behavior.



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
