### PR TITLE
Avoid refetch of test inputs

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -838,13 +838,15 @@ class GalaxyInteractorApi:
             parameters = request_schema["parameters"]
 
             def adapt_datasets(test_input: JsonTestDatasetDefDict) -> DataRequestHda | DataRequestUri:
+                # if path is not set it might be a composite file with a path,
+                # e.g. composite_shapefile
+                test_input_path = test_input.get("path", "")
+                if test_input_path in self.uploads:
+                    return DataRequestHda(**self.uploads[test_input_path])
                 location = test_input.get("location")
                 if location:
                     ext = test_input.get("filetype") or "auto"
                     return DataRequestUri(url=location, ext=ext)
-                # if path is not set it might be a composite file with a path,
-                # e.g. composite_shapefile
-                test_input_path = test_input.get("path", "")
                 return DataRequestHda(**self.uploads[test_input_path])
 
             def adapt_collections(test_input: JsonTestCollectionDefDict) -> DataCollectionRequest:


### PR DESCRIPTION
Async tool tests already stage all inputs into the history, including URL inputs. The async path ignored this and passed URLs as DataRequestUri, causing a second server-side fetch. This change makes adapt_datasets prefer staged datasets (DataRequestHda from self.uploads) and fall back to DataRequestUri only if an input was not staged.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
