### PR TITLE
[26.1] Fix doubled proxy prefix on forced object route push

### DIFF
--- a/client/src/entry/analysis/router-push.js
+++ b/client/src/entry/analysis/router-push.js
@@ -20,7 +20,7 @@ export function patchRouterPush(VueRouter) {
                 location = addSearchParams(location, { __vkey__: Date.now() });
             } else if (typeof location === "object") {
                 // convert to string version addSearchParams can handle
-                let url = this.resolve(location).href;
+                let url = this.resolve(location).route.fullPath;
                 url = addSearchParams(url, { __vkey__: Date.now() });
                 // convert back to object version
                 location = this.resolve(url).route;

--- a/client/src/entry/analysis/router-push.test.js
+++ b/client/src/entry/analysis/router-push.test.js
@@ -72,4 +72,31 @@ describe("router push changes", () => {
         push.call(mockContext, "/test/forceroute", { force: true });
         expect(currentLocation).toMatch(new RegExp(`/test/forceroute?.*vkey.*`));
     });
+
+    it("does not double the router base for forced object routes", () => {
+        const base = "/galaxy";
+        let pushed = null;
+        const mockContext = {
+            confirmation: false,
+            app: { $emit: vi.fn() },
+            resolve(location) {
+                const rel = typeof location === "object" ? location.path : location;
+                return { href: `${base}${rel}`, route: { fullPath: rel } };
+            },
+        };
+        const mockRouter = {
+            prototype: {
+                push: (location) => {
+                    pushed = location;
+                    return { catch: vi.fn() };
+                },
+            },
+        };
+        patchRouterPush(mockRouter);
+
+        mockRouter.prototype.push.call(mockContext, { path: "/collection/new_list?advanced=false" }, { force: true });
+
+        expect(pushed.fullPath).not.toContain(base);
+        expect(pushed.fullPath).toContain("__vkey__");
+    });
 });


### PR DESCRIPTION
Fixes #23238.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
