### PR TITLE
[26.1] Fix bulk storage move for user-defined storage

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -2005,6 +2005,8 @@ class DeviceSourceMap:
             device_map = self.backends.get(object_store_id)
             if device_map:
                 return device_map.get_device_id(object_store_id)
+        elif is_user_object_store(object_store_id):
+            return object_store_id
 
         return self.default_device_id
 

--- a/test/integration/objectstore/test_bulk_storage_operations.py
+++ b/test/integration/objectstore/test_bulk_storage_operations.py
@@ -1712,3 +1712,69 @@ class TestBulkStorageOperationsIntegration(BaseObjectStoreIntegrationTestCase):
             self._prune_expired_bulk_storage_operations()
             assert self._snapshot_has_been_pruned(preview["snapshot_id"])
             assert self._run_has_been_pruned(history_id, run_id)
+
+
+USER_OBJECT_STORE_CATALOG = """
+- id: general_disk
+  name: General Disk
+  description: General Disk Bound to You
+  configuration:
+    type: disk
+    files_dir: '/data/general/{{ user.username }}'
+"""
+
+
+class TestBulkStorageOperationsUserObjectStoreIntegration(TestBulkStorageOperationsIntegration):
+    """Bulk storage operations with a user-defined object store as the move target."""
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        cls._configure_object_store_template_catalog(USER_OBJECT_STORE_CATALOG, config)
+
+    def test_preview_eligible_with_user_object_store_target(self):
+        """A user-defined object store is a valid move target."""
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content="test", wait=True)
+
+            user_store_id = self._create_user_object_store()
+            preview = self._preview_move(history_id, user_store_id, [self._item(hda["id"])])
+
+            self._assert_eligibility(preview, eligible=1, ineligible=0)
+
+    @requires_celery
+    def test_move_to_user_object_store_completes(self):
+        """A full move to a user-defined object store succeeds and the dataset ends up in that store."""
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content="move-to-user-store", wait=True)
+            before = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=hda["id"])
+            assert before["object_store_id"] == DEFAULT_OBJECT_STORE_ID
+
+            user_store_id = self._create_user_object_store()
+            _, _, final = self._run_move(
+                history_id,
+                user_store_id,
+                [self._item(hda["id"])],
+                include_items_on_terminal=True,
+            )
+
+            self._assert_run_counts(final["run"], succeeded=1, failed=0, skipped=0)
+            assert final["items"][0]["state"] == "succeeded"
+            assert final["items"][0]["bytes_processed"] > 0
+            self._assert_dataset_store_and_content(
+                history_id,
+                hda["id"],
+                user_store_id,
+                "move-to-user-store\n",
+            )
+
+    def _create_user_object_store(self) -> str:
+        body = {
+            "name": "My User Disk",
+            "template_id": "general_disk",
+            "template_version": 0,
+            "secrets": {},
+            "variables": {},
+        }
+        object_store_json = self.dataset_populator.create_object_store(body)
+        return object_store_json["object_store_id"]

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -16,7 +16,10 @@ import pytest
 from requests import get
 
 from galaxy.exceptions import ObjectInvalid
-from galaxy.objectstore import persist_extra_files_for_dataset
+from galaxy.objectstore import (
+    DeviceSourceMap,
+    persist_extra_files_for_dataset,
+)
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -502,6 +505,16 @@ def test_distributed_store():
             assert device_source_map
             assert device_source_map.get_device_id("files1") == "primary_disk"
             assert device_source_map.get_device_id("files2") == "primary_disk"
+
+
+def test_device_source_map_user_object_store():
+    """User-defined object stores return their own ID as the device ID."""
+
+    device_map = DeviceSourceMap()
+    user_store_id = "user_objects://abc123"
+    assert device_map.get_device_id(user_store_id) == user_store_id
+    # A non-existent, non-user store still falls back to the default (None).
+    assert device_map.get_device_id("does_not_exist") is None
 
 
 def test_distributed_store_empty_cache_targets():


### PR DESCRIPTION
Resolves #23287, in which user-defined object stores were incorrectly treated as invalid targets during bulk storage move operations. Updates the device source mapping logic to correctly resolve user object store identifiers, preventing incorrect fallback to default devices. 

Includes integration tests and manual verification with a Backblaze-backed user-defined object store.

<img width="897" height="424" alt="image" src="https://github.com/user-attachments/assets/bebb5434-a4a6-47f9-b224-b9ee8974d4ef" />


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
