### PR TITLE
[26.1] Do not render the rerun workflow button for unowned history

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faArchive, faBurn } from "@fortawesome/free-solid-svg-icons";
+import { faArchive, faBurn, faUsers } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
 import { computed } from "vue";
@@ -131,6 +131,13 @@ const linkClass = computed(() => {
 
             <FontAwesomeIcon v-if="history.purged" :icon="faBurn" fixed-width />
             <FontAwesomeIcon v-else-if="history.archived" :icon="faArchive" fixed-width />
+
+            <FontAwesomeIcon
+                v-if="!userOwnsHistory(userStore.currentUser, history)"
+                v-g-tooltip.hover
+                title="You do not own this history"
+                :icon="faUsers"
+                fixed-width />
         </component>
     </component>
 </template>

--- a/client/src/components/Workflow/Run/WorkflowRerun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRerun.vue
@@ -4,8 +4,10 @@ import { computed, ref, watch } from "vue";
 import { Toast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useInvocationStore } from "@/stores/invocationStore";
+import { errorMessageAsString } from "@/utils/simple-error.js";
 
 import WorkflowRun from "./WorkflowRun.vue";
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 
 const props = defineProps<{
     invocationId: string;
@@ -17,6 +19,7 @@ const invocationStore = useInvocationStore();
 const ready = ref(false);
 
 const requestData = computed(() => invocationStore.getInvocationRequestById(props.invocationId));
+const requestError = computed(() => invocationStore.getInvocationRequestByIdError(props.invocationId));
 
 watch(
     requestData,
@@ -37,8 +40,11 @@ watch(
 </script>
 
 <template>
+    <GAlert v-if="requestError" variant="danger">
+        Unable to load workflow rerun data: {{ errorMessageAsString(requestError) }}
+    </GAlert>
     <WorkflowRun
-        v-if="ready && requestData"
+        v-else-if="ready && requestData"
         :workflow-id="requestData.workflow_id"
         :instance="requestData.instance"
         :request-state="requestData.inputs"

--- a/client/src/components/Workflow/WorkflowNavigationTitle.test.ts
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.test.ts
@@ -5,7 +5,9 @@ import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 
+import type { AnyHistory } from "@/api";
 import sampleInvocation from "@/components/Workflow/test/json/invocation.json";
+import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
 import WorkflowNavigationTitle from "./WorkflowNavigationTitle.vue";
@@ -22,6 +24,17 @@ const SAMPLE_WORKFLOW = {
     version: 1,
 };
 const IMPORT_ERROR_MESSAGE = "Failed to import workflow";
+
+// `getFakeRegisteredUser` always defaults to this id
+const CURRENT_USER_ID = "fake_user_id";
+const OTHER_USER_ID = "other-user-id";
+const UNOWNED_HISTORY_ID = "unowned-history-id";
+// Matches `sampleInvocation.history_id` so the component resolves it as the invocation's history
+const SAMPLE_HISTORY = {
+    id: sampleInvocation.history_id,
+    name: "history-name",
+    user_id: CURRENT_USER_ID,
+} as AnyHistory;
 
 const SELECTORS = {
     WORKFLOW_HEADING: "[data-description='workflow heading']",
@@ -67,12 +80,14 @@ const localVue = getLocalVue();
  * @param version The version of the component to mount (`run_form` or `invocation` view)
  * @param ownsWorkflow Whether the user owns the workflow associated with the invocation
  * @param unimportableWorkflow Whether the workflow import should fail
+ * @param ownsHistory Whether the current user owns the history associated with the invocation
  * @returns The wrapper object
  */
 async function mountWorkflowNavigationTitle(
     version: "run_form" | "invocation",
     ownsWorkflow = true,
     unimportableWorkflow = false,
+    ownsHistory = true,
 ) {
     let workflowId: string;
     let invocation;
@@ -87,17 +102,28 @@ async function mountWorkflowNavigationTitle(
         invocation = undefined;
     }
 
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+
+    const historyStore = useHistoryStore(pinia);
+    historyStore.setHistory(
+        ownsHistory ? SAMPLE_HISTORY : { ...SAMPLE_HISTORY, id: UNOWNED_HISTORY_ID, user_id: OTHER_USER_ID },
+    );
+    if (!ownsHistory && invocation) {
+        invocation = { ...invocation, history_id: UNOWNED_HISTORY_ID };
+    }
+
     const wrapper = shallowMount(WorkflowNavigationTitle as object, {
         propsData: {
             invocation,
             workflowId,
         },
         localVue,
-        pinia: createTestingPinia({ createSpy: vi.fn }),
+        pinia,
     });
 
     const userStore = useUserStore();
     userStore.currentUser = getFakeRegisteredUser({
+        id: CURRENT_USER_ID,
         username: ownsWorkflow ? WORKFLOW_OWNER : OTHER_USER,
     });
 
@@ -114,6 +140,13 @@ describe("WorkflowNavigationTitle renders", () => {
 
         const rerunButton = wrapper.find(SELECTORS.ROUTE_TO_RERUN_BUTTON);
         expect(rerunButton.attributes("title")).toContain("Rerun");
+    });
+
+    it("hides the rerun button if the user does not own the invocation's history", async () => {
+        const { wrapper } = await mountWorkflowNavigationTitle("invocation", true, false, false);
+
+        const rerunButton = wrapper.find(SELECTORS.ROUTE_TO_RERUN_BUTTON);
+        expect(rerunButton.exists()).toBe(false);
     });
 
     it("the workflow name in header and run button in actions; run form version", async () => {

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -7,6 +7,7 @@ import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 import { useRouter } from "vue-router/composables";
 
+import { userOwnsHistory } from "@/api";
 import type { WorkflowInvocationElementView } from "@/api/invocations";
 import type { WorkflowSummary } from "@/api/workflows";
 import { useConfirmDialog } from "@/composables/confirmDialog";
@@ -45,7 +46,13 @@ const emit = defineEmits<{
 
 const { workflow, loading, error, owned } = useWorkflowInstance(props.workflowId);
 
-const { isAnonymous } = storeToRefs(useUserStore());
+const { isAnonymous, currentUser } = storeToRefs(useUserStore());
+
+const historyStore = useHistoryStore();
+const history = computed(() =>
+    props.invocation?.history_id ? historyStore.getHistoryById(props.invocation.history_id) : null,
+);
+const historyIsOwned = computed(() => (history.value ? userOwnsHistory(currentUser.value, history.value) : false));
 
 const importErrorMessage = ref<string | null>(null);
 const importedWorkflow = ref<WorkflowSummary | null>(null);
@@ -103,6 +110,12 @@ async function rerunWorkflow() {
         router.push(`/workflows/rerun?invocation_id=${props.invocation.id}`);
         return;
     }
+
+    if (!historyIsOwned.value) {
+        console.error("The running user is not the owner of the history with the original inputs for this workflow.");
+        return;
+    }
+
     const confirmed = await confirm(
         localize(
             "Rerunning this workflow requires changing the history to the one with the original inputs. Do you want to continue?",
@@ -196,6 +209,7 @@ async function rerunWorkflow() {
                             <span v-localize>Run</span>
                         </GButton>
                         <GButton
+                            v-if="historyIsOwned"
                             :title="localize('Rerun Workflow with same inputs')"
                             disabled-title="This workflow has been deleted."
                             data-button-rerun

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
@@ -14,6 +14,9 @@ import GModal from "@/components/BaseComponents/GModal.vue";
 // Constants
 const WORKFLOW_OWNER = "test-user";
 const OTHER_USER = "other-user";
+// `getFakeRegisteredUser` always defaults to this id, regardless of `username`
+const CURRENT_USER_ID = "fake_user_id";
+const OTHER_USER_ID = "other-user-id";
 const TEST_WORKFLOW = {
     id: "workflow-id",
     name: "workflow-name",
@@ -25,10 +28,12 @@ const TEST_WORKFLOW = {
     title: "workflow-title",
 };
 const SHARED_WORKFLOW_ID = "shared-workflow-id";
+const UNOWNED_HISTORY_ID = "unowned-history-id";
 const TEST_HISTORY = {
     id: "test-history-id",
     name: "test-history-name",
     archived: false,
+    user_id: CURRENT_USER_ID,
 };
 const TEST_HISTORY_POST_SHARE = {
     ...TEST_HISTORY,
@@ -101,6 +106,7 @@ vi.mock("@/stores/historyStore", async () => {
                     ...TEST_HISTORY,
                     id: historyId,
                     importable: historyId === `${TEST_HISTORY.id}-importable`,
+                    user_id: historyId === UNOWNED_HISTORY_ID ? OTHER_USER_ID : CURRENT_USER_ID,
                 };
             }),
             getHistoryNameById: vi.fn().mockImplementation(() => {
@@ -118,9 +124,10 @@ const localVue = getLocalVue();
  * Mounts the WorkflowInvocationShare component with props/stores adjusted given the parameters
  * @param ownsWorkflow Whether the user owns the workflow associated with the invocation
  * @param bothShareable Whether the workflow and history are already shareable
+ * @param ownsHistory Whether the user owns the history associated with the invocation
  * @returns The wrapper object
  */
-async function mountWorkflowInvocationShare(ownsWorkflow = true, bothShareable = false) {
+async function mountWorkflowInvocationShare(ownsWorkflow = true, bothShareable = false, ownsHistory = true) {
     server.use(
         http.put("/api/workflows/{workflow_id}/enable_link_access", ({ response }) => {
             return response(200).json({
@@ -138,7 +145,11 @@ async function mountWorkflowInvocationShare(ownsWorkflow = true, bothShareable =
         propsData: {
             invocationId: "invocation-id",
             workflowId: bothShareable ? SHARED_WORKFLOW_ID : TEST_WORKFLOW.id,
-            historyId: bothShareable ? `${TEST_HISTORY.id}-importable` : TEST_HISTORY.id,
+            historyId: bothShareable
+                ? `${TEST_HISTORY.id}-importable`
+                : !ownsHistory
+                  ? UNOWNED_HISTORY_ID
+                  : TEST_HISTORY.id,
         },
         stubs: {
             FontAwesomeIcon: true,
@@ -204,6 +215,18 @@ describe("WorkflowInvocationShare", () => {
 
     it("renders nothing when the user does not own the workflow", async () => {
         const { wrapper } = await mountWorkflowInvocationShare(false);
+        expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
+        expect(wrapper.findComponent(GModal).exists()).toBeFalsy();
+    });
+
+    it("renders nothing when the user owns the workflow but not the history", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare(true, false, false);
+        expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
+        expect(wrapper.findComponent(GModal).exists()).toBeFalsy();
+    });
+
+    it("renders nothing when the user owns the history but not the workflow", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare(false, false, true);
         expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
         expect(wrapper.findComponent(GModal).exists()).toBeFalsy();
     });

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -4,12 +4,13 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
-import { GalaxyApi } from "@/api";
+import { GalaxyApi, userOwnsHistory } from "@/api";
 import { hasImportable } from "@/api/histories";
 import { getFullAppUrl } from "@/app/utils";
 import { Toast } from "@/composables/toast";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore.js";
 import { copy } from "@/utils/clipboard";
 import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -28,10 +29,17 @@ const props = defineProps<{
 
 const modalToggle = ref(false);
 
+const userStore = useUserStore();
+
 // Workflow and History refs
-const { workflow, loading, error, owned } = useWorkflowInstance(props.workflowId);
+const { workflow, loading, error, owned: workflowOwned } = useWorkflowInstance(props.workflowId);
 const historyStore = useHistoryStore();
 const history = computed(() => historyStore.getHistoryById(props.historyId));
+
+/** Whether the current user owns both the workflow and history. */
+const owned = computed(
+    () => workflowOwned.value && history.value && userOwnsHistory(userStore.currentUser, history.value),
+);
 
 /** The link to the invocation. */
 const invocationLink = computed(() => getFullAppUrl(`workflows/invocations/${props.invocationId}`));

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -130,7 +130,8 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         isLoadingItem: isLoadingInvocationStep,
     } = useKeyedCache<InvocationStep>(fetchInvocationStep);
 
-    const { getItemById: getInvocationRequestById } = useKeyedCache<WorkflowInvocationRequest>(fetchInvocationRequest);
+    const { getItemById: getInvocationRequestById, getItemLoadError: getInvocationRequestByIdError } =
+        useKeyedCache<WorkflowInvocationRequest>(fetchInvocationRequest);
 
     const { getItemById: getInvocationCountByWorkflowId } = useKeyedCache<number>(fetchInvocationCount);
 
@@ -154,6 +155,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         getInvocationLoadError,
         getInvocationStepById,
         getInvocationRequestById,
+        getInvocationRequestByIdError,
         getInvocationCountByWorkflowId,
         isLoadingInvocation,
         isLoadingInvocationStep,


### PR DESCRIPTION
The rerun option for workflows requires switching to the history linked to the original run. This prevents rendering that button if the current user does not own that original history (since we do not want them to be able to switch to it).

The rerun method also guards against this internally. Note we do not render the rerun button anymore on that invocation:

<img width="335" height="150" alt="Screenshot 2026-08-12 at 2 32 06 PM" src="https://github.com/user-attachments/assets/7ad71c76-c88a-4944-9e86-e29c1ab25c41" />

**Some additional changes are:**

## Show alert on rerun page for unowned history
If the user does manually route to the rerun, we show this alert instead of a blank page as we had before this fix:

<img width="1103" height="387" alt="Screenshot 2026-08-12 at 2 30 40 PM" src="https://github.com/user-attachments/assets/8936a239-2fdf-4e40-abcd-8e9f611a2474" />

## Do not render share invocation button either for unowned workflow OR history
For a workflow run where the workflow is yours but run by another user, if you have access to the running user's history, you can still have access to the invocation. However, you should not see the share button since the sharing button allows you to share both the history and workflow, and one of those is not accessible for you.

In the existing implementation, we were only looking at the workflow ownership, not the history ownership. This fixes that.

## Show badge for unowned history next to the `TargetHistoryLink`
<img width="335" height="96" alt="Screenshot 2026-08-12 at 2 39 18 PM" src="https://github.com/user-attachments/assets/ed74b897-3b4d-4ff7-8e8e-8667ebf4aabf" />



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
