### PR TITLE
[26.1] Fix `WorkflowGraph` exposed methods being called without defined ref

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1350,7 +1350,7 @@ export default {
                 await until(() => this.datatypesMapperLoading).toBe(false);
                 await nextTick();
 
-                if (fitGraph) {
+                if (fitGraph && this.workflowGraph) {
                     this.workflowGraph.fitWorkflow();
                 } else {
                     // If we are not fitting the graph, adjust for coordinate shifts so the nodes appear in the same position
@@ -1366,15 +1366,17 @@ export default {
          * @param boundsBefore The bounding box min coordinates we had before refetching the workflow
          */
         adjustForCoordinateShift(transformBefore, boundsBefore) {
-            const adjustedTransform = this.calculateAdjustedTransform(transformBefore, boundsBefore);
+            if (this.workflowGraph) {
+                const adjustedTransform = this.calculateAdjustedTransform(transformBefore, boundsBefore);
 
-            // TODO: Once we migrate to Composition API we can probably handle this within the workflowBoundingBox
-            // and d3Zoom composables
-            this.workflowGraph.setTransform(adjustedTransform);
+                // TODO: Once we migrate to Composition API we can probably handle this within the workflowBoundingBox
+                // and d3Zoom composables
+                this.workflowGraph.setTransform(adjustedTransform);
 
-            // TODO: Verify if setting scale is still needed after setting full transform
-            //       I still needed to set scale separately otherwise it would reset to 1
-            this.stateStore.scale = adjustedTransform.k;
+                // TODO: Verify if setting scale is still needed after setting full transform
+                //       I still needed to set scale separately otherwise it would reset to 1
+                this.stateStore.scale = adjustedTransform.k;
+            }
         },
         onLicense(license) {
             if (this.license != license) {


### PR DESCRIPTION
In workflow editor's `Index.vue`, we call methods from the child `WorkflowGraph` component, when its ref is undefined (we are say, on the report editor view, with the graph not rendered in the DOM). This is a minor fix that just checks for that ref being defined.

Fixes https://github.com/galaxyproject/galaxy/issues/23270

For `dev`, we need to make sure that the `adjustForCoordinateShift` or `fitWorkflow` methods of `WorkflowGraph` that are being called while it is not rendered in the DOM yet, are called when the component DOES render? Or maybe we just reset graph.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In the workflow editor, go to the Report view (click `Report` activity)
  2. Make changes to the report, then DO NOT EXIT the report view, and instead save workflow using the save activity
  3. Note workflow is saved without an error alert being shown (without this fix an error alert shows up saying `Cannot read properties of null (reading 'setTransform')`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
