### PR TITLE
[26.1] Fix workflow SVG image generation crashing on inactive conditional inputs

### DIFF
--- a/lib/galaxy/workflow/render.py
+++ b/lib/galaxy/workflow/render.py
@@ -17,6 +17,7 @@ class WorkflowCanvas:
         self.text = []
         self.in_pos = {}
         self.out_pos = {}
+        self.out_box_pos = {}
         self.widths = {}
         self.max_x = 0
         self.max_y = 0
@@ -62,6 +63,7 @@ class WorkflowCanvas:
         left, top = step.position["left"], step.position["top"]
         x, y = left, top
         order_index = step.order_index
+        self.out_box_pos[order_index] = (x, y)
         max_len = len(module_name) * 1.5
         self.text.append(svgwrite.text.Text(module_name, (x, y + 20), style="font-size:14px"))
         y += 45
@@ -97,22 +99,27 @@ class WorkflowCanvas:
         out_pos_index = output_dict["id"]
         # out_pos_name will be a string like 'o', 'o2', etc.
         out_pos_name = output_dict["output_name"]
+        out_conn_pos = None
         if out_pos_index in self.out_pos:
             # out_conn_index_dict will be something like:
             # 7: {'o': (824.5, 618)}
             out_conn_index_dict = self.out_pos[out_pos_index]
             if out_pos_name in out_conn_index_dict:
                 out_conn_pos = out_conn_index_dict[out_pos_name]
-            else:
+            elif out_conn_index_dict:
                 # Take any key / value pair available in out_conn_index_dict.
-                # A problem will result if the dictionary is empty.
-                if out_conn_index_dict:
-                    key = next(iter(out_conn_index_dict.keys()))
-                    out_conn_pos = self.out_pos[out_pos_index][key]
-        adjusted = (out_conn_pos[0] + self.widths[output_dict["id"]], out_conn_pos[1])
+                key = next(iter(out_conn_index_dict.keys()))
+                out_conn_pos = self.out_pos[out_pos_index][key]
+        if out_conn_pos is None:
+            # The output isn't among the upstream module's introspected outputs
+            # (e.g. it moved to a different conditional branch). Anchor to the
+            # upstream step's box instead of dropping the connection.
+            out_conn_pos = self.out_box_pos.get(out_pos_index, (0, 0))
+        out_width = self.widths.get(output_dict["id"], 0)
+        adjusted = (out_conn_pos[0] + out_width, out_conn_pos[1])
         self.text.append(
             svgwrite.shapes.Circle(
-                center=(out_conn_pos[0] + self.widths[output_dict["id"]] - MARGIN, out_conn_pos[1] - MARGIN),
+                center=(out_conn_pos[0] + out_width - MARGIN, out_conn_pos[1] - MARGIN),
                 r=5,
                 fill="#ffffff",
                 stroke="#000000",
@@ -150,9 +157,12 @@ class WorkflowCanvas:
             self.add_boxes(step_dict, width, fill)
             for conn, output_dict in step_dict["input_connections"].items():
                 if conn not in self.in_pos.get(step_dict["id"], {}):
-                    # input isn't part of the module's introspected inputs (e.g. a
-                    # conditional branch that's no longer active) - nothing to draw to.
-                    continue
+                    # Input isn't part of the module's introspected inputs (e.g. a
+                    # conditional branch that's no longer active), so it has no
+                    # labeled row to point to. Anchor the connection to the box's
+                    # top-left corner instead of dropping it.
+                    left, top = step_dict["position"]["left"], step_dict["position"]["top"]
+                    self.in_pos.setdefault(step_dict["id"], {})[conn] = (left, top + MARGIN)
                 self.add_connection(step_dict, conn, output_dict)
 
     def populate_data_for_step(self, step, module_name, module_data_inputs, module_data_outputs, tool_errors=None):

--- a/lib/galaxy/workflow/render.py
+++ b/lib/galaxy/workflow/render.py
@@ -17,7 +17,6 @@ class WorkflowCanvas:
         self.text = []
         self.in_pos = {}
         self.out_pos = {}
-        self.out_box_pos = {}
         self.widths = {}
         self.max_x = 0
         self.max_y = 0
@@ -63,7 +62,6 @@ class WorkflowCanvas:
         left, top = step.position["left"], step.position["top"]
         x, y = left, top
         order_index = step.order_index
-        self.out_box_pos[order_index] = (x, y)
         max_len = len(module_name) * 1.5
         self.text.append(svgwrite.text.Text(module_name, (x, y + 20), style="font-size:14px"))
         y += 45
@@ -93,8 +91,8 @@ class WorkflowCanvas:
         self.max_y = max(self.max_y, top)
         self.max_width = max(self.max_width, self.widths[order_index])
 
-    def add_connection(self, step_dict, conn, output_dict):
-        in_coords = self.in_pos[step_dict["id"]][conn]
+    def add_connection(self, step_dict, conn, output_dict, in_fallback_pos, out_fallback_pos):
+        in_coords = self.in_pos.get(step_dict["id"], {}).get(conn, in_fallback_pos)
         # out_pos_index will be a step number like 1, 2, 3...
         out_pos_index = output_dict["id"]
         # out_pos_name will be a string like 'o', 'o2', etc.
@@ -114,7 +112,7 @@ class WorkflowCanvas:
             # The output isn't among the upstream module's introspected outputs
             # (e.g. it moved to a different conditional branch). Anchor to the
             # upstream step's box instead of dropping the connection.
-            out_conn_pos = self.out_box_pos.get(out_pos_index, (0, 0))
+            out_conn_pos = out_fallback_pos
         out_width = self.widths.get(output_dict["id"], 0)
         adjusted = (out_conn_pos[0] + out_width, out_conn_pos[1])
         self.text.append(
@@ -147,6 +145,7 @@ class WorkflowCanvas:
 
     def add_steps(self, highlight_errors=False):
         # Only highlight missing tools if displaying in the tool shed.
+        positions_by_id = {step_dict["id"]: step_dict["position"] for step_dict in self.data}
         for step_dict in self.data:
             tool_unavailable = step_dict.get("tool_errors", False)
             if highlight_errors and tool_unavailable:
@@ -155,15 +154,16 @@ class WorkflowCanvas:
                 fill = "#EBD9B2"
             width = self.widths[step_dict["id"]]
             self.add_boxes(step_dict, width, fill)
+            position = step_dict["position"]
+            # Fallback anchors used when a stored connection references an
+            # input/output name the module no longer introspects (e.g. a
+            # conditional branch that's no longer active) - draw the
+            # connection to the step's box instead of dropping it.
+            in_fallback_pos = (position["left"], position["top"] + MARGIN)
             for conn, output_dict in step_dict["input_connections"].items():
-                if conn not in self.in_pos.get(step_dict["id"], {}):
-                    # Input isn't part of the module's introspected inputs (e.g. a
-                    # conditional branch that's no longer active), so it has no
-                    # labeled row to point to. Anchor the connection to the box's
-                    # top-left corner instead of dropping it.
-                    left, top = step_dict["position"]["left"], step_dict["position"]["top"]
-                    self.in_pos.setdefault(step_dict["id"], {})[conn] = (left, top + MARGIN)
-                self.add_connection(step_dict, conn, output_dict)
+                out_position = positions_by_id.get(output_dict["id"], position)
+                out_fallback_pos = (out_position["left"], out_position["top"])
+                self.add_connection(step_dict, conn, output_dict, in_fallback_pos, out_fallback_pos)
 
     def populate_data_for_step(self, step, module_name, module_data_inputs, module_data_outputs, tool_errors=None):
         step_dict = {

--- a/lib/galaxy/workflow/render.py
+++ b/lib/galaxy/workflow/render.py
@@ -149,6 +149,10 @@ class WorkflowCanvas:
             width = self.widths[step_dict["id"]]
             self.add_boxes(step_dict, width, fill)
             for conn, output_dict in step_dict["input_connections"].items():
+                if conn not in self.in_pos.get(step_dict["id"], {}):
+                    # input isn't part of the module's introspected inputs (e.g. a
+                    # conditional branch that's no longer active) - nothing to draw to.
+                    continue
                 self.add_connection(step_dict, conn, output_dict)
 
     def populate_data_for_step(self, step, module_name, module_data_inputs, module_data_outputs, tool_errors=None):

--- a/test/unit/workflows/test_render.py
+++ b/test/unit/workflows/test_render.py
@@ -1,5 +1,25 @@
+from dataclasses import (
+    dataclass,
+    field,
+)
+
 from galaxy.workflow import render
 from .workflow_support import yaml_to_model
+
+
+@dataclass
+class FakeConnection:
+    input_name: str
+    output_name: str
+    output_step: "FakeStep"
+
+
+@dataclass
+class FakeStep:
+    order_index: int
+    position: dict
+    input_connections: list = field(default_factory=list)
+
 
 TEST_WORKFLOW_YAML = """
 steps:
@@ -61,3 +81,63 @@ def test_render():
     workflow_canvas.add_steps()
     workflow_canvas.finish()
     assert workflow_canvas.canvas.tostring()
+
+
+def test_render_connection_to_uninspected_input():
+    # Regression test: a stored WorkflowStepConnection can reference an input
+    # name (e.g. one nested inside a Conditional) that the module's current
+    # state no longer introspects as a data input - for example after a tool
+    # version bump changes which conditional branch is active. This used to
+    # raise a KeyError in add_connection() and abort SVG generation entirely.
+    workflow_canvas = render.WorkflowCanvas()
+
+    step_0 = FakeStep(order_index=0, position={"top": 3, "left": 3})
+    step_1 = FakeStep(order_index=1, position={"top": 13, "left": 10})
+    step_1.input_connections = [
+        FakeConnection(input_name="input_option|amrfinder_db_select", output_name="di1", output_step=step_0)
+    ]
+
+    workflow_canvas.populate_data_for_step(
+        step_0,
+        "input1",
+        [],
+        [{"name": "di1"}],
+    )
+    # module_data_inputs deliberately omits "input_option|amrfinder_db_select",
+    # simulating get_data_inputs() skipping an inactive conditional branch.
+    workflow_canvas.populate_data_for_step(step_1, "amrfinder wrapper", [], [{"name": "out1"}])
+    workflow_canvas.add_steps()
+    workflow_canvas.finish()
+    assert workflow_canvas.canvas.tostring()
+    # The connection should still be drawn (anchored to the step box) rather
+    # than silently dropped.
+    assert len(workflow_canvas.connectors) == 1
+
+
+def test_render_connection_to_uninspected_output():
+    # Regression test: a stored WorkflowStepConnection can reference an
+    # upstream output name that the upstream module no longer introspects
+    # (e.g. a collection output that moved to a different conditional
+    # branch). This used to raise an UnboundLocalError in add_connection().
+    workflow_canvas = render.WorkflowCanvas()
+
+    step_0 = FakeStep(order_index=0, position={"top": 3, "left": 3})
+    step_1 = FakeStep(order_index=1, position={"top": 13, "left": 10})
+    step_1.input_connections = [FakeConnection(input_name="input1", output_name="stale_output", output_step=step_0)]
+
+    # module_data_outputs deliberately omits "stale_output".
+    workflow_canvas.populate_data_for_step(
+        step_0,
+        "input1",
+        [],
+        [],
+    )
+    workflow_canvas.populate_data_for_step(
+        step_1, "cat wrapper", [{"name": "input1", "label": "i1"}], [{"name": "out1"}]
+    )
+    workflow_canvas.add_steps()
+    workflow_canvas.finish()
+    assert workflow_canvas.canvas.tostring()
+    # The connection should still be drawn (anchored to the upstream step's
+    # box) rather than silently dropped.
+    assert len(workflow_canvas.connectors) == 1

--- a/test/unit/workflows/test_render.py
+++ b/test/unit/workflows/test_render.py
@@ -83,31 +83,39 @@ def test_render():
     assert workflow_canvas.canvas.tostring()
 
 
+def _render_two_step_canvas(step_0_outputs, step_1_inputs, conn_input_name, conn_output_name):
+    """Populate a two-step canvas where step_1 has a single stored connection
+    from step_0, and return it after add_steps()/finish()."""
+    workflow_canvas = render.WorkflowCanvas()
+
+    step_0 = FakeStep(order_index=0, position={"top": 3, "left": 3})
+    step_1 = FakeStep(order_index=1, position={"top": 13, "left": 10})
+    step_1.input_connections = [
+        FakeConnection(input_name=conn_input_name, output_name=conn_output_name, output_step=step_0)
+    ]
+
+    workflow_canvas.populate_data_for_step(step_0, "input1", [], step_0_outputs)
+    workflow_canvas.populate_data_for_step(step_1, "cat wrapper", step_1_inputs, [{"name": "out1"}])
+    workflow_canvas.add_steps()
+    workflow_canvas.finish()
+    return workflow_canvas
+
+
 def test_render_connection_to_uninspected_input():
     # Regression test: a stored WorkflowStepConnection can reference an input
     # name (e.g. one nested inside a Conditional) that the module's current
     # state no longer introspects as a data input - for example after a tool
     # version bump changes which conditional branch is active. This used to
     # raise a KeyError in add_connection() and abort SVG generation entirely.
-    workflow_canvas = render.WorkflowCanvas()
-
-    step_0 = FakeStep(order_index=0, position={"top": 3, "left": 3})
-    step_1 = FakeStep(order_index=1, position={"top": 13, "left": 10})
-    step_1.input_connections = [
-        FakeConnection(input_name="input_option|amrfinder_db_select", output_name="di1", output_step=step_0)
-    ]
-
-    workflow_canvas.populate_data_for_step(
-        step_0,
-        "input1",
-        [],
-        [{"name": "di1"}],
-    )
-    # module_data_inputs deliberately omits "input_option|amrfinder_db_select",
+    #
+    # step_1_inputs deliberately omits "input_option|amrfinder_db_select",
     # simulating get_data_inputs() skipping an inactive conditional branch.
-    workflow_canvas.populate_data_for_step(step_1, "amrfinder wrapper", [], [{"name": "out1"}])
-    workflow_canvas.add_steps()
-    workflow_canvas.finish()
+    workflow_canvas = _render_two_step_canvas(
+        step_0_outputs=[{"name": "di1"}],
+        step_1_inputs=[],
+        conn_input_name="input_option|amrfinder_db_select",
+        conn_output_name="di1",
+    )
     assert workflow_canvas.canvas.tostring()
     # The connection should still be drawn (anchored to the step box) rather
     # than silently dropped.
@@ -119,24 +127,14 @@ def test_render_connection_to_uninspected_output():
     # upstream output name that the upstream module no longer introspects
     # (e.g. a collection output that moved to a different conditional
     # branch). This used to raise an UnboundLocalError in add_connection().
-    workflow_canvas = render.WorkflowCanvas()
-
-    step_0 = FakeStep(order_index=0, position={"top": 3, "left": 3})
-    step_1 = FakeStep(order_index=1, position={"top": 13, "left": 10})
-    step_1.input_connections = [FakeConnection(input_name="input1", output_name="stale_output", output_step=step_0)]
-
-    # module_data_outputs deliberately omits "stale_output".
-    workflow_canvas.populate_data_for_step(
-        step_0,
-        "input1",
-        [],
-        [],
+    #
+    # step_0_outputs deliberately omits "stale_output".
+    workflow_canvas = _render_two_step_canvas(
+        step_0_outputs=[],
+        step_1_inputs=[{"name": "input1", "label": "i1"}],
+        conn_input_name="input1",
+        conn_output_name="stale_output",
     )
-    workflow_canvas.populate_data_for_step(
-        step_1, "cat wrapper", [{"name": "input1", "label": "i1"}], [{"name": "out1"}]
-    )
-    workflow_canvas.add_steps()
-    workflow_canvas.finish()
     assert workflow_canvas.canvas.tostring()
     # The connection should still be drawn (anchored to the upstream step's
     # box) rather than silently dropped.


### PR DESCRIPTION
`WorkflowCanvas.add_steps()` would raise a `KeyError` and abort SVG generation whenever a step's input_connections referenced an input name that `add_text()` never existed in `in_pos`. This happens when a stored connection targets a parameter inside a `Conditional` whose currently active branch (based on the tool's resolved state) no longer matches the branch the connection was made against, e.g. after a tool version update shifts which conditional branch is the default. `get_data_inputs()` only visits the active branch, so the connection's `input_name` is absent from in_pos even though the raw `WorkflowStepConnection` row still exists. The same could happen on the output side: `add_connection()` could hit an `UnboundLocalError` if the upstream output name wasn't in `out_pos` either.

Rather than dropping these connections, we now anchor them to the relevant step's box position when their specific input/output position can't be found, so the connection is still drawn and the rest of the workflow image still renders correctly.

Fixes https://github.com/galaxyproject/galaxy/issues/23271

Co-authored-by: Claude <noreply@anthropic.com>

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
