### PR TITLE
Resolve GalaxyAI recommended tool names from the toolbox instead of showing "Unknown"

### DIFF
--- a/lib/galaxy/agents/tools.py
+++ b/lib/galaxy/agents/tools.py
@@ -464,7 +464,7 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
         if recommendation.primary_tools:
             parts.append("**Recommended Tools:**")
             for i, tool in enumerate(recommendation.primary_tools[:3], 1):
-                tool_name = tool.get("name", tool.get("tool_name", "Unknown"))
+                tool_name = self._resolve_tool_name(tool)
                 tool_id = tool.get("id", tool.get("tool_id", "unknown"))
 
                 is_installed = self._verify_tool_exists(tool_id)
@@ -486,13 +486,13 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
         if recommendation.alternative_tools:
             parts.append("\n**Alternative Options:**")
             for tool in recommendation.alternative_tools[:2]:
-                tool_name = tool.get("name", tool.get("tool_name", "Unknown"))
+                tool_name = self._resolve_tool_name(tool)
                 parts.append(f"- **{tool_name}**: {tool.get('description', 'No description')}")
 
         if recommendation.recommended_workflows:
             parts.append("\n**Recommended IWC Workflows:**")
             for i, wf in enumerate(recommendation.recommended_workflows[:3], 1):
-                wf_name = wf.get("name", "Unknown workflow")
+                wf_name = wf.get("name") or wf.get("trsID") or wf.get("trs_id") or "IWC workflow"
                 trs_id = wf.get("trsID") or wf.get("trs_id") or ""
                 parts.append(f"\n{i}. **{wf_name}**")
                 if trs_id:
@@ -526,7 +526,7 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
         if recommendation.primary_tools:
             top_tool = recommendation.primary_tools[0]
             log.debug(f"Creating suggestion for top_tool: {top_tool}")
-            tool_name = top_tool.get("name", top_tool.get("tool_name", "Unknown tool"))
+            tool_name = self._resolve_tool_name(top_tool)
             tool_id = top_tool.get("id", top_tool.get("tool_id", ""))
             log.debug(f"Extracted tool_name={tool_name}, tool_id={tool_id}")
 
@@ -559,6 +559,24 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
                 )
 
         return suggestions
+
+    def _resolve_tool_name(self, tool: dict) -> str:
+        """Human-readable name for a recommended tool.
+
+        The model's structured recommendation frequently carries only the
+        tool_id (no explicit name). Resolve the name from the toolbox by id,
+        and fall back to the id itself -- never render the literal "Unknown"
+        for a tool that is actually installed.
+        """
+        tool_id = tool.get("id") or tool.get("tool_id") or ""
+        if not (tool.get("name") or tool.get("tool_name")) and tool_id and self.deps.toolbox:
+            try:
+                resolved = self.deps.toolbox.get_tool(tool_id)
+                if resolved is not None:
+                    return resolved.name
+            except (AttributeError, KeyError, TypeError) as e:
+                log.debug(f"Error resolving name for tool {tool_id}: {e}")
+        return tool.get("name") or tool.get("tool_name") or tool_id or "Unknown"
 
     def _verify_tool_exists(self, tool_id: str) -> bool:
         if not self.deps.toolbox:


### PR DESCRIPTION
Claude is convinced this is a legitimate problem in Galaxy.  I encountered this problem using Google's `gemini-3.5-flash` on an AnVIL-like Kubernetes instance.

## What

GalaxyAI's tool-recommendation agent renders recommended **tool** and **workflow** cards as "Unknown" even when the tool is installed and valid. The model's structured recommendation carries only `tool_id` (no `name`), and `ToolRecommendationAgent` defaulted straight to "Unknown" instead of resolving the name from the toolbox.

<img width="693" height="489" alt="Screenshot 2026-08-13 at 2 19 18 PM" src="https://github.com/user-attachments/assets/af1f52f3-0224-48a2-842b-cc08848ba16d" />

## Why

Confirmed on a live instance: the agent grounded correctly (called `search_galaxy_tools`, emitted valid installed IDs such as `…/iuc/bcftools_view/bcftools_view/1.24+galaxy0`), yet the cards showed "Unknown". The prose was fine because it's free text; only the structured card/name resolution failed. "Unknown" is generated server-side, not by the model.

**Note — this is model-dependent and can look non-reproducible.** `primary_tools` is typed `list[dict[str, Any]]` and filled from the LLM's structured output, so `name` is present only if the model includes it. A backend whose model fills optional fields renders fine (e.g. usegalaxy.org), while a Gemini backend (gemini-3.5-flash) returns `{"tool_id": "…"}` with no `name` and hits the "Unknown" fallback. The running code is the same in both; resolving the name from the toolbox removes the dependency on model behavior entirely.

## Change

`lib/galaxy/agents/tools.py` — add a `_resolve_tool_name(tool)` helper that:

1. returns an explicit `name`/`tool_name` if present,
2. else resolves the name from the toolbox by id (`self.deps.toolbox.get_tool(tool_id).name`,
   reusing the same access + exception pattern as `_verify_tool_exists`),
3. else falls back to the **tool id** — never the literal "Unknown" for an installed tool.

It replaces the four `"Unknown"` fallbacks:
- `_format_recommendation_response` — primary tools, alternative tools;
- `_create_suggestions` — the `ActionSuggestion` (kills "Open Unknown tool");
- IWC workflows now fall back to `name`/`trsID` (workflows aren't in the toolbox), not
  "Unknown workflow".

Net: `1 file changed, 22 insertions(+), 4 deletions(-)`. Server-side only — no client changes.

## Testing

- `python -m py_compile lib/galaxy/agents/tools.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
