### PR TITLE
Generalize runner-level default_<param> seeding of destination params

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -102,6 +102,15 @@ class BaseJobRunner:
     start_methods = ["_init_monitor_thread", "_init_worker_threads"]
     DEFAULT_SPECS = dict(recheck_missing_job_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=0))
 
+    # Destination params that may be seeded from a runner-level ``default_<param>``
+    # setting. This lets a value be configured once at the runner level in
+    # ``job_conf.yml`` instead of repeated on every destination that targets the
+    # runner, while any destination may still override it. Subclasses that want
+    # this behavior list the destination param names here (without the
+    # ``default_`` prefix) and register the corresponding ``default_<param>``
+    # entries in their runner param specs.
+    runner_default_destination_params: list[str] = []
+
     def __init__(self, app: "GalaxyManagerApplication", nworkers: int, **kwargs) -> None:
         """Start the job runner"""
         self.app = app
@@ -271,6 +280,28 @@ class BaseJobRunner:
     def parse_destination_params(self, params: dict[str, Any]):
         """Parse the JobDestination ``params`` dict and return the runner's native representation of those params."""
         raise NotImplementedError()
+
+    def _apply_runner_default_destination_params(self, job_destination: JobDestination) -> bool:
+        """Seed unset destination params from runner-level ``default_<param>`` values.
+
+        For each ``<param>`` in :attr:`runner_default_destination_params`, if the
+        destination has not set ``<param>`` and the runner defines a truthy
+        ``default_<param>`` value, copy that value onto the destination. The
+        destination value always wins over the runner-level default.
+
+        Returns ``True`` if any destination param was populated.
+        """
+        params = job_destination.params
+        updated = False
+        for name in self.runner_default_destination_params:
+            if name in params:
+                # Destination overrides the runner-level default.
+                continue
+            runner_value = self.runner_params.get(f"default_{name}")
+            if runner_value:
+                params[name] = runner_value
+                updated = True
+        return updated
 
     def prepare_job(
         self,

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -220,6 +220,13 @@ PULSAR_PARAM_SPECS = dict(
         map=specs.to_str_or_none,
         default=None,
     ),
+    # Runner-level default for the ``custom_vm_image`` destination param. See
+    # ``BaseJobRunner.runner_default_destination_params``; lets the image be set
+    # once on the runner instead of on every GCP Batch destination.
+    default_custom_vm_image=dict(
+        map=specs.to_str_or_none,
+        default=None,
+    ),
 )
 
 
@@ -1192,17 +1199,14 @@ class PulsarGcpBatchJobRunner(PulsarCoexecutionJobRunner):
     client_manager_kwargs = GCP_BATCH_CLIENT_MANAGER_KWARGS
     destination_defaults = GCP_DESTINATION_DEFAULTS
 
-    # Runner-level params that should be passed through to the Pulsar client
-    # as destination params (destination overrides runner).
-    PASSTHROUGH_PARAMS = ["custom_vm_image"]
+    # Destination params seeded from runner-level ``default_<param>`` settings
+    # (e.g. ``default_custom_vm_image``). Destination values override the
+    # runner-level default. See ``BaseJobRunner._apply_runner_default_destination_params``.
+    runner_default_destination_params = ["custom_vm_image"]
 
     def _populate_parameter_defaults(self, job_destination):
         updated = super()._populate_parameter_defaults(job_destination)
-        params = job_destination.params
-        for key in self.PASSTHROUGH_PARAMS:
-            if key not in params and self.runner_params.get(key):
-                params[key] = self.runner_params[key]
-                updated = True
+        updated = self._apply_runner_default_destination_params(job_destination) or updated
         return updated
 
 

--- a/test/unit/app/jobs/test_runner_default_destination_params.py
+++ b/test/unit/app/jobs/test_runner_default_destination_params.py
@@ -1,0 +1,72 @@
+"""Unit tests for the runner-level ``default_<param>`` destination-seeding mechanism.
+
+See ``BaseJobRunner._apply_runner_default_destination_params``.
+"""
+
+from galaxy.jobs.job_destination import JobDestination
+from galaxy.jobs.runners import BaseJobRunner
+
+
+class _StubRunner(BaseJobRunner):
+    """Minimal runner that bypasses ``BaseJobRunner.__init__`` for the helper under test."""
+
+    def __init__(self, runner_params, defaultable):
+        self.runner_params = runner_params
+        self.runner_default_destination_params = defaultable
+
+
+def _apply(runner_params, defaultable, dest_params):
+    runner = _StubRunner(runner_params, defaultable)
+    destination = JobDestination(params=dict(dest_params))
+    updated = runner._apply_runner_default_destination_params(destination)
+    return updated, destination.params
+
+
+def test_runner_default_seeds_unset_destination_param():
+    updated, params = _apply(
+        runner_params={"default_custom_vm_image": "projects/p/global/images/cvmfs"},
+        defaultable=["custom_vm_image"],
+        dest_params={},
+    )
+    assert updated is True
+    assert params["custom_vm_image"] == "projects/p/global/images/cvmfs"
+
+
+def test_destination_value_overrides_runner_default():
+    updated, params = _apply(
+        runner_params={"default_custom_vm_image": "runner-image"},
+        defaultable=["custom_vm_image"],
+        dest_params={"custom_vm_image": "destination-image"},
+    )
+    assert updated is False
+    assert params["custom_vm_image"] == "destination-image"
+
+
+def test_no_runner_default_leaves_destination_untouched():
+    updated, params = _apply(
+        runner_params={},
+        defaultable=["custom_vm_image"],
+        dest_params={},
+    )
+    assert updated is False
+    assert "custom_vm_image" not in params
+
+
+def test_falsy_runner_default_is_ignored():
+    updated, params = _apply(
+        runner_params={"default_custom_vm_image": ""},
+        defaultable=["custom_vm_image"],
+        dest_params={},
+    )
+    assert updated is False
+    assert "custom_vm_image" not in params
+
+
+def test_only_listed_params_are_seeded():
+    updated, params = _apply(
+        runner_params={"default_other_param": "value"},
+        defaultable=["custom_vm_image"],
+        dest_params={},
+    )
+    assert updated is False
+    assert "other_param" not in params


### PR DESCRIPTION
## Summary

Follow-up to #23068. In that PR, `PulsarGcpBatchJobRunner` gained a `PASSTHROUGH_PARAMS` mechanism so `custom_vm_image` could be configured once at the runner level in `job_conf.yml` and merged into each job's destination params, instead of being repeated on every TPV destination.

In review, @jmchilton [asked](https://github.com/galaxyproject/galaxy/pull/23068#issuecomment-4905011977) whether there was an existing `default_<prop>` pattern for this kind of "runner param → destination param" mirroring, said he'd prefer a generalized solution, and suggested starting that pattern here (while keeping the explicit allow-list, which he liked).

This PR does that: it promotes the ad-hoc mechanism into a small, reusable helper on `BaseJobRunner` using a `default_<param>` naming convention, and migrates the Pulsar GCP Batch runner onto it.

## Motivation

The same "seed a destination param from a runner-level default" logic was already
hand-rolled in three separate places, each slightly differently:

- `PulsarGcpBatchJobRunner` — `PASSTHROUGH_PARAMS` list + `_populate_parameter_defaults`
  override (#23068)
- `GoogleCloudBatchJobRunner` (`gcp_batch.py`) — a hardcoded key list doing
  `job_destination.params.get(key, self.runner_params[key])`
- `HTCondorJobRunner` (`htcondor.py`) —
  `params.get("htcondor_collector") or self.runner_params.htcondor_collector` (×3)

There's even a commented-out sketch of the idea in Pulsar's own base
`_populate_parameter_defaults`. A shared mechanism removes the duplication and gives
every runner a consistent, self-documenting way to expose runner-level defaults.

## Changes

1. **`BaseJobRunner`**
   - New class attribute `runner_default_destination_params: list[str]` — destination
     param names a runner will seed from a runner-level default.
   - New helper `_apply_runner_default_destination_params(job_destination)` — for each
     listed `<param>`, if the destination hasn't set it and the runner defines a truthy
     `default_<param>`, copy it onto the destination. **The destination value always
     wins.**

2. **`PulsarGcpBatchJobRunner`**
   - Registered `default_custom_vm_image` in `PULSAR_PARAM_SPECS` (Pulsar reuses these
     specs for runner-level params).
   - Replaced the `PASSTHROUGH_PARAMS` override with
     `runner_default_destination_params = ["custom_vm_image"]` and a call to the shared
     helper.

3. **Unit tests** (`test/unit/app/jobs/test_runner_default_destination_params.py`)
   covering: seeding an unset param, destination override, no-default no-op,
   falsy-default ignored, and only-listed-params seeded.

## Example configuration

`job_conf.yml`:

```yaml
runners:
  pulsar_gcp_batch:
    load: galaxy.jobs.runners.pulsar:PulsarGcpBatchJobRunner
    # runner-level default, applied to every destination that doesn't set custom_vm_image
    default_custom_vm_image: projects/my-project/global/images/galaxy-cvmfs-image
```

A destination may still set `custom_vm_image` to override the runner-level default.

## Note on the config surface

The runner-level knob is renamed from `custom_vm_image` (as introduced in #23068) to
**`default_custom_vm_image`**, matching the new convention and disambiguating it from the
destination param of the same name. Since #23068 only landed on `dev` (unreleased), this
is a clean rename rather than a compatibility break. The destination-level
`custom_vm_image` param is unchanged.

## Follow-ups (the "bonus points" scan)

Other runners hand-roll the same pattern and could migrate onto this helper. They're left
out of this PR because, unlike the just-merged Pulsar knob, they're **released config
surface** and renaming would break existing `job_conf.yml`:

- **HTCondor** — `htcondor_collector`, `htcondor_schedd`, `htcondor_config` (closest fit)
- **GCP Batch** (`GoogleCloudBatchJobRunner`) — its full passthrough list
- **Kubernetes** — `k8s_namespace`, `k8s_pull_policy`, `k8s_walltime_limit`,
  `k8s_pod_priority_class`, `k8s_tolerations`, … (read sites would also need updating)
- **AWS Batch** `region`, **Chronos** `owner`

A backward-compatible migration (accept both the legacy name and `default_<param>`) could
be done per-runner in later PRs.

Separately, @jmchilton noted more type checking at the runner level would be nice — not
addressed here.

## Testing

`pytest test/unit/app/jobs/test_runner_default_destination_params.py` — 5 passed.
