### PR TITLE
Add reusable `ChangesIndicator` component that indicates unsaved changes in editors

### DIFF
--- a/client/src/components/Common/ChangesIndicator.test.ts
+++ b/client/src/components/Common/ChangesIndicator.test.ts
@@ -1,0 +1,78 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount, type Wrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type Vue from "vue";
+import { nextTick } from "vue";
+
+import ChangesIndicator from "./ChangesIndicator.vue";
+
+const localVue = getLocalVue();
+
+const SELECTORS = {
+    SAVED: "[data-description='item saved indicator']",
+    UNSAVED: "[data-description='item unsaved indicator']",
+} as const;
+
+type ChangesIndicatorInstance = Vue & {
+    flashSavedIndicator: () => Promise<void>;
+};
+
+function mountIndicator(hasChanges = false): Wrapper<ChangesIndicatorInstance> {
+    return mount(ChangesIndicator as object, {
+        localVue,
+        propsData: { hasChanges },
+    }) as Wrapper<ChangesIndicatorInstance>;
+}
+
+describe("ChangesIndicator", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("renders unsaved changes in a live status region", () => {
+        const wrapper = mountIndicator(true);
+
+        expect(wrapper.attributes("role")).toBe("status");
+        expect(wrapper.attributes("aria-live")).toBe("polite");
+        expect(wrapper.attributes("aria-atomic")).toBe("true");
+        expect(wrapper.find(SELECTORS.UNSAVED).text()).toBe("Unsaved");
+        expect(wrapper.find(SELECTORS.SAVED).exists()).toBe(false);
+    });
+
+    it("shows the saved indicator for 1.5 seconds", async () => {
+        const wrapper = mountIndicator();
+
+        await wrapper.vm.flashSavedIndicator();
+        expect(wrapper.find(SELECTORS.SAVED).isVisible()).toBe(true);
+
+        vi.advanceTimersByTime(1500);
+        await nextTick();
+
+        expect(wrapper.find(SELECTORS.SAVED).isVisible()).toBe(false);
+    });
+
+    it("dismisses saved feedback when new changes arrive", async () => {
+        const wrapper = mountIndicator();
+
+        await wrapper.vm.flashSavedIndicator();
+        await wrapper.setProps({ hasChanges: true });
+
+        expect(wrapper.find(SELECTORS.UNSAVED).isVisible()).toBe(true);
+        expect(wrapper.find(SELECTORS.SAVED).exists()).toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("does not schedule saved feedback after unmount", async () => {
+        const wrapper = mountIndicator();
+
+        const flashPromise = wrapper.vm.flashSavedIndicator();
+        wrapper.destroy();
+        await flashPromise;
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/client/src/components/Common/ChangesIndicator.vue
+++ b/client/src/components/Common/ChangesIndicator.vue
@@ -3,6 +3,8 @@ import { faCheck, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { nextTick, onUnmounted, ref, watch } from "vue";
 
+import localize from "@/utils/localization";
+
 interface Props {
     /** If the object has unsaved changes */
     hasChanges: boolean;
@@ -17,22 +19,34 @@ const props = withDefaults(defineProps<Props>(), {
     objectNamespace: "item",
 });
 
-/** Briefly shown after a successful save (independent of `props.hasChanges`) when the exposed `flashSavedIndicator` method is called. */
+/** Briefly shown after a successful save when the exposed `flashSavedIndicator` method is called. */
 const showSavedIndicator = ref(false);
 
 let savedIndicatorTimeout: ReturnType<typeof setTimeout> | undefined;
-onUnmounted(() => clearTimeout(savedIndicatorTimeout));
+let flashGeneration = 0;
+let unmounted = false;
+
+onUnmounted(() => {
+    unmounted = true;
+    flashGeneration++;
+    clearTimeout(savedIndicatorTimeout);
+});
 
 /** Flashes a "Saved" indicator when called, given `props.hasChanges` is `false`. */
 async function flashSavedIndicator() {
+    const generation = ++flashGeneration;
     clearTimeout(savedIndicatorTimeout);
 
-    // If `props.hasChanges` becoming false and this call happen at the same time, wait a tick
-    // so the "Saved" indicator doesn't flash in and out immediately.
+    // Let a simultaneous `hasChanges` update settle before deciding whether the feedback is still valid.
     await nextTick();
+    if (unmounted || generation !== flashGeneration || props.hasChanges) {
+        return;
+    }
     showSavedIndicator.value = true;
     savedIndicatorTimeout = setTimeout(() => {
-        showSavedIndicator.value = false;
+        if (!unmounted && generation === flashGeneration) {
+            showSavedIndicator.value = false;
+        }
     }, 1500);
 }
 
@@ -42,6 +56,7 @@ watch(
     () => props.hasChanges,
     (hasChanges) => {
         if (hasChanges) {
+            flashGeneration++;
             clearTimeout(savedIndicatorTimeout);
             showSavedIndicator.value = false;
         }
@@ -54,36 +69,39 @@ defineExpose({
 </script>
 
 <template>
-    <div class="changes-indicator small text-muted unselectable">
+    <span class="changes-indicator small text-muted unselectable" role="status" aria-live="polite" aria-atomic="true">
         <span
             v-if="props.hasChanges"
             class="changes-unsaved-indicator"
             :data-description="`${props.objectNamespace} unsaved indicator`">
-            <FontAwesomeIcon :icon="faInfoCircle" size="lg" />
-            Unsaved
+            <FontAwesomeIcon :icon="faInfoCircle" size="lg" aria-hidden="true" />
+            {{ localize("Unsaved") }}
         </span>
 
         <transition v-if="!props.hasChanges" name="saved-indicator">
-            <span v-show="showSavedIndicator" class="changes-saved-indicator">
-                <FontAwesomeIcon :icon="faCheck" fixed-width />
-                Saved
+            <span
+                v-show="showSavedIndicator"
+                class="changes-saved-indicator"
+                :data-description="`${props.objectNamespace} saved indicator`">
+                <FontAwesomeIcon :icon="faCheck" fixed-width aria-hidden="true" />
+                {{ localize("Saved") }}
             </span>
         </transition>
-    </div>
+    </span>
 </template>
 
 <style scoped lang="scss">
 .changes-indicator {
-    display: flex;
+    display: inline-flex;
     gap: 0.5rem;
     align-items: center;
 
     .changes-unsaved-indicator {
-        color: var(--color-orange-600);
+        color: var(--color-orange-700);
     }
 
     .changes-saved-indicator {
-        color: var(--color-green-500);
+        color: var(--color-green-700);
     }
 
     .saved-indicator-enter-active,
@@ -98,6 +116,18 @@ defineExpose({
     .saved-indicator-leave-to {
         opacity: 0;
         transform: translateY(-2px);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .saved-indicator-enter-active,
+        .saved-indicator-leave-active {
+            transition: none;
+        }
+
+        .saved-indicator-enter,
+        .saved-indicator-leave-to {
+            transform: none;
+        }
     }
 }
 </style>

--- a/client/src/components/Common/ChangesIndicator.vue
+++ b/client/src/components/Common/ChangesIndicator.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { faCheck, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { nextTick, onUnmounted, ref, watch } from "vue";
+
+interface Props {
+    /** If the object has unsaved changes */
+    hasChanges: boolean;
+    /**
+     * Optional namespace for the object being saved
+     * @default "item"
+     */
+    objectNamespace?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    objectNamespace: "item",
+});
+
+/** Briefly shown after a successful save (independent of `props.hasChanges`) when the exposed `flashSavedIndicator` method is called. */
+const showSavedIndicator = ref(false);
+
+let savedIndicatorTimeout: ReturnType<typeof setTimeout> | undefined;
+onUnmounted(() => clearTimeout(savedIndicatorTimeout));
+
+/** Flashes a "Saved" indicator when called, given `props.hasChanges` is `false`. */
+async function flashSavedIndicator() {
+    clearTimeout(savedIndicatorTimeout);
+
+    // If `props.hasChanges` becoming false and this call happen at the same time, wait a tick
+    // so the "Saved" indicator doesn't flash in and out immediately.
+    await nextTick();
+    showSavedIndicator.value = true;
+    savedIndicatorTimeout = setTimeout(() => {
+        showSavedIndicator.value = false;
+    }, 1500);
+}
+
+// If changes come back in while the "Saved" indicator is showing, dismiss it right
+// away and cancel the pending timeout, so it can't flash back in once hasChanges clears again.
+watch(
+    () => props.hasChanges,
+    (hasChanges) => {
+        if (hasChanges) {
+            clearTimeout(savedIndicatorTimeout);
+            showSavedIndicator.value = false;
+        }
+    },
+);
+
+defineExpose({
+    flashSavedIndicator,
+});
+</script>
+
+<template>
+    <div class="changes-indicator small text-muted unselectable">
+        <span
+            v-if="props.hasChanges"
+            class="changes-unsaved-indicator"
+            :data-description="`${props.objectNamespace} unsaved indicator`">
+            <FontAwesomeIcon :icon="faInfoCircle" size="lg" />
+            Unsaved
+        </span>
+
+        <transition v-if="!props.hasChanges" name="saved-indicator">
+            <span v-show="showSavedIndicator" class="changes-saved-indicator">
+                <FontAwesomeIcon :icon="faCheck" fixed-width />
+                Saved
+            </span>
+        </transition>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.changes-indicator {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+
+    .changes-unsaved-indicator {
+        color: var(--color-orange-600);
+    }
+
+    .changes-saved-indicator {
+        color: var(--color-green-500);
+    }
+
+    .saved-indicator-enter-active,
+    .saved-indicator-leave-active {
+        transition:
+            opacity 0.2s ease,
+            transform 0.2s ease;
+    }
+
+    // TODO(vue3): rename .saved-indicator-enter to .saved-indicator-enter-from
+    .saved-indicator-enter,
+    .saved-indicator-leave-to {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+}
+</style>

--- a/client/src/components/PageEditor/PageDisplayToolbar.test.ts
+++ b/client/src/components/PageEditor/PageDisplayToolbar.test.ts
@@ -11,8 +11,10 @@ import { usePageEditorStore } from "@/stores/pageEditorStore";
 import { PAGE_LABELS } from "../Page/constants.js";
 
 import PageDisplayToolbar from "./PageDisplayToolbar.vue";
+import ChangesIndicator from "@/components/Common/ChangesIndicator.vue";
 
 const localVue = getLocalVue();
+(ChangesIndicator as unknown as { name?: string }).name = "ChangesIndicator";
 
 const HISTORY_ID = "history-1";
 const PAGE_ID = "page-1";
@@ -34,14 +36,18 @@ const SELECTORS = {
 
 let pinia: Pinia;
 
-function mountComponent(propsData: {
-    labels: (typeof PAGE_LABELS)[keyof typeof PAGE_LABELS];
-    mode: "editor" | "display";
-}) {
+function mountComponent(
+    propsData: {
+        labels: (typeof PAGE_LABELS)[keyof typeof PAGE_LABELS];
+        mode: "editor" | "display";
+    },
+    stubs: Record<string, object> = {},
+) {
     return mount(PageDisplayToolbar as object, {
         localVue,
         propsData,
         pinia,
+        stubs,
     });
 }
 
@@ -78,6 +84,7 @@ describe("PageDisplayToolbar", () => {
     });
 
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
@@ -172,6 +179,45 @@ describe("PageDisplayToolbar", () => {
             await flushPromises();
 
             expect(store.savePage).toHaveBeenCalled();
+        });
+
+        it("shows saved feedback after a successful save", async () => {
+            const flashSavedIndicator = vi.fn();
+            const saveWrapper = mountComponent(
+                { labels: PAGE_LABELS.history, mode: "editor" },
+                {
+                    ChangesIndicator: {
+                        template: "<div />",
+                        methods: { flashSavedIndicator },
+                    },
+                },
+            );
+
+            await saveWrapper.find(SELECTORS.SAVE_BUTTON).trigger("click");
+            await flushPromises();
+
+            expect(flashSavedIndicator).toHaveBeenCalledOnce();
+            saveWrapper.destroy();
+        });
+
+        it("does not show saved feedback after a failed save", async () => {
+            const flashSavedIndicator = vi.fn();
+            const saveWrapper = mountComponent(
+                { labels: PAGE_LABELS.history, mode: "editor" },
+                {
+                    ChangesIndicator: {
+                        template: "<div />",
+                        methods: { flashSavedIndicator },
+                    },
+                },
+            );
+            vi.mocked(store.savePage).mockRejectedValue(new Error("save failed"));
+
+            await saveWrapper.find(SELECTORS.SAVE_BUTTON).trigger("click");
+            await flushPromises();
+
+            expect(flashSavedIndicator).not.toHaveBeenCalled();
+            saveWrapper.destroy();
         });
 
         it("back button text says whatever the label back button value is", () => {

--- a/client/src/components/PageEditor/PageDisplayToolbar.vue
+++ b/client/src/components/PageEditor/PageDisplayToolbar.vue
@@ -1,14 +1,5 @@
 <script setup lang="ts">
-import {
-    faArrowLeft,
-    faEdit,
-    faEye,
-    faHistory,
-    faInfo,
-    faPen,
-    faSave,
-    faSpinner,
-} from "@fortawesome/free-solid-svg-icons";
+import { faArrowLeft, faEdit, faEye, faHistory, faPen, faSave, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -20,6 +11,7 @@ import { usePageEditorStore } from "@/stores/pageEditorStore.js";
 import GButton from "../BaseComponents/GButton.vue";
 import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
 import RenameModal from "../Common/RenameModal.vue";
+import ChangesIndicator from "@/components/Common/ChangesIndicator.vue";
 
 const props = defineProps<{
     labels: (typeof PAGE_LABELS)[keyof typeof PAGE_LABELS];
@@ -37,6 +29,9 @@ const emit = defineEmits<{
 }>();
 
 const showRename = ref(false);
+
+/** Ref for the `ChangesIndicator` component from which we call the `flashSavedIndicator` method. */
+const changesIndicator = ref<InstanceType<typeof ChangesIndicator> | null>(null);
 
 const currentEntity = computed(() => {
     return props.labels.entityName.toLowerCase();
@@ -56,7 +51,12 @@ const saveDisabledTitle = computed(() => {
 });
 
 async function handleSave() {
-    await pageEditorStore.savePage();
+    try {
+        await pageEditorStore.savePage();
+        changesIndicator.value?.flashSavedIndicator();
+    } catch (error) {
+        // Error is already handled in the store and displayed in parent(s)
+    }
 }
 
 function handleTitleChange(newTitle: string): Promise<void> {
@@ -86,15 +86,7 @@ function handleTitleChange(newTitle: string): Promise<void> {
         </div>
 
         <div class="d-flex align-items-center flex-gapx-1 flex-shrink-0">
-            <span
-                v-if="isDirty"
-                class="d-flex align-items-center flex-gapx-1 text-warning small"
-                data-description="page unsaved indicator">
-                <BBadge variant="warning" class="text-light">
-                    <FontAwesomeIcon :icon="faInfo" />
-                </BBadge>
-                Unsaved
-            </span>
+            <ChangesIndicator ref="changesIndicator" class="pr-2" :has-changes="isDirty" object-namespace="page" />
 
             <GButton color="blue" transparent size="small" data-description="page back button" @click="emit('back')">
                 <FontAwesomeIcon :icon="faArrowLeft" />

--- a/client/src/components/Workflow/Editor/Index.test.ts
+++ b/client/src/components/Workflow/Editor/Index.test.ts
@@ -24,6 +24,7 @@ import SaveChangesModal from "./SaveChangesModal.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import GFormInput from "@/components/BaseComponents/Form/GFormInput.vue";
 import GAlert from "@/components/BaseComponents/GAlert.vue";
+import ChangesIndicator from "@/components/Common/ChangesIndicator.vue";
 import ReadmeEditor from "@/components/Workflow/Editor/ReadmeEditor.vue";
 import WorkflowAttributes from "@/components/Workflow/Editor/WorkflowAttributes.vue";
 import WorkflowGraph from "@/components/Workflow/Editor/WorkflowGraph.vue";
@@ -43,6 +44,7 @@ const SELECTORS = {
 // ourselves on the shared imported component object before mounting.
 (ActivityBar as unknown as { name?: string }).name = "ActivityBar";
 (WorkflowGraph as unknown as { name?: string }).name = "WorkflowGraph";
+(ChangesIndicator as unknown as { name?: string }).name = "ChangesIndicator";
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
@@ -78,6 +80,14 @@ function editorStubs() {
             methods: {
                 fitWorkflow() {},
                 setTransform() {},
+            },
+        },
+        // `Index.vue` calls `changesIndicator.value?.flashSavedIndicator()` directly after a
+        // successful save; the default auto-stub doesn't expose it, so `onSave` would throw.
+        ChangesIndicator: {
+            template: "<div />",
+            methods: {
+                flashSavedIndicator() {},
             },
         },
     };

--- a/client/src/components/Workflow/Editor/Index.test.ts
+++ b/client/src/components/Workflow/Editor/Index.test.ts
@@ -49,6 +49,8 @@ const SELECTORS = {
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
 
+const mockFlashSavedIndicator = vi.fn();
+
 /**
  * Stub for `ActivityBar`, a component `Index.vue` calls methods on directly
  * (`activityBar.value?.isActiveSideBar/setActiveSideBar`). Renders its
@@ -87,7 +89,7 @@ function editorStubs() {
         ChangesIndicator: {
             template: "<div />",
             methods: {
-                flashSavedIndicator() {},
+                flashSavedIndicator: mockFlashSavedIndicator,
             },
         },
     };
@@ -121,6 +123,7 @@ describe("Index", () => {
 
         mockPush.mockClear();
         mockReplace.mockClear();
+        mockFlashSavedIndicator.mockClear();
         mockRoute = { query: {}, fullPath: "/" };
 
         // `useMagicKeys` (undo/redo shortcuts) always wraps a `Set` in `reactive()`
@@ -365,6 +368,36 @@ describe("Index", () => {
 
             expect(mockSaveWorkflow).toHaveBeenCalled();
             expect(stateStore.hasChanges).toBeFalsy();
+            expect(mockFlashSavedIndicator).toHaveBeenCalledOnce();
+        });
+
+        it("keeps edits made during a save dirty and does not show saved feedback", async () => {
+            let resolveSave: (value: { version: number }) => void = () => {};
+            mockSaveWorkflow.mockImplementation(
+                () =>
+                    new Promise<{ version: number }>((resolve) => {
+                        resolveSave = resolve;
+                    }),
+            );
+            await flushPromises();
+
+            const workflowAttributes = wrapper.findComponent(WorkflowAttributes);
+            workflowAttributes.vm.$emit("update:annotationCurrent", "submitted annotation");
+            await nextTick();
+
+            wrapper.find("#workflow-save-button").vm!.$emit("click");
+            await nextTick();
+            wrapper.findComponent(WorkflowAttributes).vm.$emit("update:annotationCurrent", "newer annotation");
+            await nextTick();
+            resolveSave({ version: 2 });
+            await flushPromises();
+
+            expect(mockSaveWorkflow).toHaveBeenCalledWith(
+                expect.objectContaining({ annotation: "submitted annotation" }),
+            );
+            expect(wrapper.findComponent(WorkflowAttributes).props("annotation")).toBe("newer annotation");
+            expect(stateStore.hasChanges).toBeTruthy();
+            expect(mockFlashSavedIndicator).not.toHaveBeenCalled();
         });
 
         it("save as calls createWorkflow with the provided name and annotation", async () => {
@@ -465,6 +498,7 @@ describe("Index", () => {
                 // Rule out a stale/leftover title from a previous state, so this is
                 // actually checking the error from *this* failed save.
                 expect(modal.props("title")).not.toBe("Workflow Editor Error");
+                expect(mockFlashSavedIndicator).not.toHaveBeenCalled();
 
                 // dismissing the modal (as a user closing it would) should clear the message
                 modal.vm.$emit("close");
@@ -652,6 +686,7 @@ describe("Index", () => {
             // once the workflow has a real id, so saveWorkflow is expected to run after create.
             expect(createWorkflowSpy).toHaveBeenCalled();
             expect(mockPush).toHaveBeenCalledWith("/workflows/list");
+            expect(mockFlashSavedIndicator).toHaveBeenCalledOnce();
         });
 
         it("emits forceReload instead of pushing when navigating to the exact current route", async () => {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -63,6 +63,7 @@ import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
+import ChangesIndicator from "@/components/Common/ChangesIndicator.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import MarkdownEditor from "@/components/Markdown/MarkdownEditor.vue";
 import InputPanel from "@/components/Panels/InputPanel.vue";
@@ -487,6 +488,9 @@ const graphOffset = ref({
     y: 0,
     update: () => {},
 });
+
+/** Ref for the `ChangesIndicator` component from which we call the `flashSavedIndicator` method. */
+const changesIndicator = ref<InstanceType<typeof ChangesIndicator> | null>(null);
 
 // Several watchers ----------------------------------------------------------
 
@@ -1063,8 +1067,6 @@ async function onSave(): Promise<boolean> {
 
         hideErrorModal();
 
-        // TODO: Should we add a Toast here?
-
         // If version is not defined, set it to the latest version
         const latestVersion = versions.value[versions.value.length - 1]?.version;
         if ((version.value === undefined || version.value === null) && latestVersion !== undefined) {
@@ -1073,6 +1075,9 @@ async function onSave(): Promise<boolean> {
 
         await loadCurrent(id.value, version.value);
         syncVersionToRoute(version.value ?? undefined, true);
+
+        // `loadCurrent` settles `hasChanges` back to false; flash the indicator now that it will actually be visible.
+        changesIndicator.value?.flashSavedIndicator();
     } catch (response) {
         onWorkflowError("Saving workflow failed...", errorMessageAsString(response));
         return false;
@@ -1453,13 +1458,16 @@ initializeWorkflowEditor();
                     <span>
                         <span class="sr-only">Workflow Editor</span>
                         <LoadingSpan v-if="initialLoading" message="Loading Editor" />
-                        <span v-else class="editor-title" :title="name">
-                            {{ name }}
-                            <i v-if="hasChanges" class="text-muted"> (unsaved changes) </i>
-                        </span>
+                        <span v-else class="editor-title" :title="name">{{ name }}</span>
                     </span>
 
                     <div class="d-flex align-items-center flex-gapx-1">
+                        <ChangesIndicator
+                            ref="changesIndicator"
+                            class="pr-2"
+                            :has-changes="hasChanges"
+                            object-namespace="workflow" />
+
                         <BDropdown
                             v-if="credentialSteps.length > 0"
                             no-caret

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -900,6 +900,7 @@ async function onCreate(): Promise<boolean> {
         return false;
     }
 
+    loadingWorkflow.value = true;
     try {
         const { id: createdId, name: createdName, number_of_steps } = await services.createWorkflow(workflowData.value);
         const message = `Created new workflow '${createdName}' with ${number_of_steps} steps.`;
@@ -909,10 +910,13 @@ async function onCreate(): Promise<boolean> {
 
         await routeToWorkflow(createdId);
 
+        changesIndicator.value?.flashSavedIndicator();
         Toast.success(message);
     } catch (e) {
         onWorkflowError("Creating workflow failed", errorMessageAsString(e, "Please contact an administrator."));
         return false;
+    } finally {
+        loadingWorkflow.value = false;
     }
     return true;
 }
@@ -1049,19 +1053,23 @@ async function onSave(): Promise<boolean> {
     const lastActiveNodeId = activeNodeId.value;
 
     try {
-        const data = await saveWorkflow(workflowData.value);
+        const serializedWorkflowData = JSON.stringify(workflowData.value);
+        const workflowToSave = JSON.parse(serializedWorkflowData) as Workflow;
+        const data = await saveWorkflow(workflowToSave);
 
         versions.value = await getVersions(id.value);
 
+        const hasNewerChanges = JSON.stringify(workflowData.value) !== serializedWorkflowData;
+
         // Mirror loadEditorData and only take fields the response actually carries,
         // otherwise a partial response blanks out the in-memory workflow.
-        if (data.name !== undefined) {
+        if (!hasNewerChanges && data.name !== undefined) {
             name.value = data.name;
         }
         if (data.version !== undefined) {
             version.value = data.version as number;
         }
-        if (data.annotation !== undefined) {
+        if (!hasNewerChanges && data.annotation !== undefined) {
             annotation.value = data.annotation;
         }
 
@@ -1071,6 +1079,12 @@ async function onSave(): Promise<boolean> {
         const latestVersion = versions.value[versions.value.length - 1]?.version;
         if ((version.value === undefined || version.value === null) && latestVersion !== undefined) {
             version.value = latestVersion;
+        }
+
+        if (hasNewerChanges) {
+            hasChanges.value = true;
+            syncVersionToRoute(version.value ?? undefined, true);
+            return true;
         }
 
         await loadCurrent(id.value, version.value);
@@ -1340,6 +1354,7 @@ initializeWorkflowEditor();
 
         <ActivityBar
             ref="activityBar"
+            :inert="loadingWorkflow ? '' : undefined"
             data-description="workflow editor activity bar"
             :default-activities="workflowActivities"
             :special-activities="specialActivities"
@@ -1427,6 +1442,12 @@ initializeWorkflowEditor();
                 :steps="steps"
                 @update="onReportUpdate">
                 <template v-slot:buttons>
+                    <ChangesIndicator
+                        ref="changesIndicator"
+                        class="pr-2"
+                        :has-changes="hasChanges"
+                        object-namespace="workflow" />
+
                     <GButton
                         tooltip
                         title="Generate AI GalaxyAI report based on the workflow and its expected results"
@@ -1453,7 +1474,7 @@ initializeWorkflowEditor();
             </MarkdownEditor>
         </template>
         <template v-else>
-            <div id="center" class="workflow-center">
+            <div id="center" class="workflow-center" :inert="loadingWorkflow ? '' : undefined">
                 <div class="editor-top-bar" unselectable="on">
                     <span>
                         <span class="sr-only">Workflow Editor</span>

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1354,7 +1354,6 @@ initializeWorkflowEditor();
 
         <ActivityBar
             ref="activityBar"
-            :inert="loadingWorkflow ? '' : undefined"
             data-description="workflow editor activity bar"
             :default-activities="workflowActivities"
             :special-activities="specialActivities"
@@ -1474,7 +1473,7 @@ initializeWorkflowEditor();
             </MarkdownEditor>
         </template>
         <template v-else>
-            <div id="center" class="workflow-center" :inert="loadingWorkflow ? '' : undefined">
+            <div id="center" class="workflow-center">
                 <div class="editor-top-bar" unselectable="on">
                     <span>
                         <span class="sr-only">Workflow Editor</span>

--- a/client/src/nls/de/locale.js
+++ b/client/src/nls/de/locale.js
@@ -33,6 +33,8 @@ export default {
     "Saved Histories": "Gespeicherte Verläufe",
     "Saved Datasets": "Gespeicherte Datensätze",
     "Saved Pages": "Gespeicherte Seiten",
+    Saved: "Gespeichert",
+    Unsaved: "Nicht gespeichert",
     //Tooltip
     "Account and saved data": "Nutzerkonto und gespeicherte Daten",
     "Account registration or login": "Registrierung oder Anmeldung",

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -81,6 +81,10 @@ export default {
 
     "Saved Pages": "Páginas Guardadas",
 
+    Saved: "Guardado",
+
+    Unsaved: "Sin guardar",
+
     "Using ": "Utilizando ",
 
     //Tooltip

--- a/client/src/nls/fr/locale.js
+++ b/client/src/nls/fr/locale.js
@@ -32,6 +32,8 @@ export default {
     "Saved Histories": "Historiques sauvegardés",
     "Saved Datasets": "Jeux de données sauvegardés",
     "Saved Pages": "Pages sauvegardées",
+    Saved: "Enregistré",
+    Unsaved: "Non enregistré",
     //Tooltip
     "Account and saved data": "Compte et données sauvegardées",
     "Account registration or login": "Enregistrement ou authentification",

--- a/client/src/nls/ja/locale.js
+++ b/client/src/nls/ja/locale.js
@@ -33,6 +33,8 @@ export default {
     "Saved Histories": "保存されたヒストリー",
     "Saved Datasets": "保存されたデータセット",
     "Saved Pages": "保存されたページ",
+    Saved: "保存済み",
+    Unsaved: "未保存",
     //Tooltip
     "Account and saved data": "アカウントと保存されたデータ",
     "Account registration or login": "アカウントの登録またはログイン",

--- a/client/src/nls/locale.js
+++ b/client/src/nls/locale.js
@@ -32,6 +32,8 @@ export const root = {
     "Saved Histories": false,
     "Saved Datasets": false,
     "Saved Reports": false,
+    Saved: false,
+    Unsaved: false,
 
     //Tooltip
     "Account and saved data": false,

--- a/client/src/nls/zh/locale.js
+++ b/client/src/nls/zh/locale.js
@@ -33,6 +33,8 @@ export default {
     "Saved Histories": "保存的历史",
     "Saved Datasets": "保存的数据集",
     "Saved Pages": "保存的页面",
+    Saved: "已保存",
+    Unsaved: "未保存",
 
     //Tooltip
     "Account and saved data": "账户与已保存数据",

--- a/client/src/stores/pageEditorStore.test.ts
+++ b/client/src/stores/pageEditorStore.test.ts
@@ -381,6 +381,39 @@ describe("usePageEditorStore", () => {
             expect(store.isDirty).toBe(false);
         });
 
+        it("keeps edits made during a save dirty", async () => {
+            let releaseSave: () => void = () => {};
+            const saveCanFinish = new Promise<void>((resolve) => {
+                releaseSave = resolve;
+            });
+            const updatedDetails: HistoryPageDetails = {
+                ...TEST_PAGE_DETAILS,
+                content: "submitted content",
+                update_time: "2025-06-16T09:00:00Z",
+            };
+            server.use(
+                http.get("/api/pages/{id}", ({ response }: any) => {
+                    return response(200).json(TEST_PAGE_DETAILS);
+                }) as any,
+                http.put("/api/pages/{id}", async ({ response }: any) => {
+                    await saveCanFinish;
+                    return response(200).json(updatedDetails);
+                }) as any,
+            );
+            const store = usePageEditorStore();
+            store.setCurrentContext(TEST_HISTORY_ID);
+            await store.loadPageById(TEST_PAGE_ID);
+            store.updateContent("submitted content");
+
+            const savePromise = store.savePage();
+            store.updateContent("newer content");
+            releaseSave();
+            await savePromise;
+
+            expect(store.currentContent).toBe("newer content");
+            expect(store.isDirty).toBe(true);
+        });
+
         it("sets isSaving during save", async () => {
             server.use(
                 http.get("/api/pages/{id}", ({ response }: any) => {

--- a/client/src/stores/pageEditorStore.ts
+++ b/client/src/stores/pageEditorStore.ts
@@ -172,24 +172,26 @@ export const usePageEditorStore = defineStore("pageEditor", () => {
         isSaving.value = true;
         error.value = null;
         try {
+            const savedContent = currentContent.value;
+            const savedTitle = currentTitle.value;
             const payload: UpdateHistoryPagePayload = {
-                content: currentContent.value,
+                content: savedContent,
                 content_format: "markdown",
-                title: currentTitle.value || undefined,
+                title: savedTitle || undefined,
                 edit_source: editSource,
             };
             const data = await updateHistoryPage(currentPage.value.id, payload);
             currentPage.value = data;
-            // Use current values (what the user typed) as the baseline, not data values
+            // Use the submitted values as the baseline, not response values
             // which may be transformed by rewrite_content_for_export for rendering.
-            originalContent.value = currentContent.value;
-            originalTitle.value = currentTitle.value;
+            originalContent.value = savedContent;
+            originalTitle.value = savedTitle;
             // Sync the pages list so handleSelect reads the updated title
             const idx = pages.value.findIndex((n) => n.id === data.id);
             if (idx !== -1) {
                 pages.value[idx] = {
                     ...pages.value[idx]!,
-                    title: currentTitle.value,
+                    title: savedTitle,
                     update_time: data.update_time,
                 };
             }


### PR DESCRIPTION
Used in the Workflow and Page editors for now. Displays an unsaved indicator, and then flashes a saved indicator for a couple seconds:

## In workflow editor
<img width="1056" height="330" alt="Screen Recording 2026-08-13 at 6 26 05 PM" src="https://github.com/user-attachments/assets/308fc5a5-3ff1-4b71-9fdc-822a2c968403" />

## In page editor
<img width="1168" height="330" alt="Screen Recording 2026-08-13 at 6 28 30 PM" src="https://github.com/user-attachments/assets/d065eb1b-e7ec-4399-9a4c-2a7ae7f57435" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In either the workflow or page editor, make some changes
  2. Note the orange-shade Unsaved indicator in the top bar
  3. Then click Save and note that a green Saved indicator appears, for 1.5 seconds and then fades out

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
