### PR TITLE
Fix empty pages for file sources with server side pagination

### DIFF
--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -305,7 +305,7 @@ defineExpose({
                     compact
                     hover
                     primary-key="id"
-                    :current-page="currentPage"
+                    :current-page="usingProvider ? undefined : currentPage"
                     :fields="fieldDetails"
                     :filter="filter"
                     :items="tableItems"
@@ -313,7 +313,7 @@ defineExpose({
                     :local-filtering="!usingProvider"
                     :local-sorting="!usingProvider"
                     :indeterminate-items="indeterminateItems"
-                    :per-page="perPage"
+                    :per-page="usingProvider ? undefined : perPage"
                     :selectable="props.selectable"
                     :selected-items="selectedItems"
                     :show-select-all="props.selectable"


### PR DESCRIPTION
When a file source uses server side pagination, only the first page shows entries and the pages after that are empty, although the backend returns the correct data for the requested offset.

As far as i can tell, SelectionDialog passes the entries it received from the items provider to GTable together with `current-page` and `per-page`, and GTable then slices that list again in `paginatedLocalItems`. Since the list already contains only the rows of the requested page, page 2 tries to take the entries 26 to 50 of a list with at most 25 and ends up empty. GTable has `local-filtering` and `local-sorting` props that are set to false when a provider is used, but i could not find an equivalent for the paging. It might come from the switch of SelectionDialog from BTable to GTable.

The change stops passing `current-page` and `per-page` to GTable when the items come from a provider, so GTable renders the list as it is. The pagination bar below keeps using the values of SelectionDialog.

I tested this with Dataverse and with a CKAN file source i am working on in #23116.
Other file sources with server side pagination should be affected in the same way, but i have not tested those.

**Before, page 2 of a Dataverse instance with 105 datasets:**
<img width="1589" height="869" alt="Screenshot 2026-08-17 015418" src="https://github.com/user-attachments/assets/0b985b79-2a7c-4d9e-a675-130679be46bf" />

**After:**
<img width="1584" height="842" alt="Screenshot 2026-08-17 at 02-02-08 Galaxy" src="https://github.com/user-attachments/assets/a30fe301-d318-4f0d-ae9c-0d1bae29bf22" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a Dataverse file source pointing to `https://dataverse.bsc.es`. It has 105 public datasets and no account or token is needed to browse them.
  2. Go to **Import Data → Import History** and choose **Repository** as the source, then browse
   that file source and go to page 2.
<img width="1030" height="575" alt="Screenshot 2026-08-17 at 01-55-27 Galaxy" src="https://github.com/user-attachments/assets/3a686a30-700a-4e97-8888-b99c1e89b0fd" />

  3. Without this change the page is empty, with it the remaining datasets are shown.

   Note: this does not show through *Import Data → Choose remote files*. That browser renders its
   own `GTable` with the full list and is unaffected, so it looks correct either way.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
