### PR TITLE
Typed user account API: display name, email updates, extra preferences, address gating

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -11947,6 +11947,11 @@ export interface components {
              */
             deleted: boolean;
             /**
+             * Display name
+             * @description Free-form name shown in place of the username. Not unique, and never used in URLs, slugs or as an identifier.
+             */
+            display_name?: string | null;
+            /**
              * Email
              * @description Email of the user
              */
@@ -26572,6 +26577,11 @@ export interface components {
              * @description User is active
              */
             active?: boolean | null;
+            /**
+             * Display name
+             * @description Free-form name shown in place of the username. Not unique, and never used in URLs, slugs or as an identifier.
+             */
+            display_name?: string | null;
             /**
              * Preferred Object Store ID
              * @description The ID of the object store that should be used to store new datasets in this history.

--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -26583,6 +26583,11 @@ export interface components {
              */
             display_name?: string | null;
             /**
+             * Email
+             * @description New email address. When `user_activation_on` is set, changing the email deactivates the account and sends an activation link to the new address.
+             */
+            email?: string | null;
+            /**
              * Preferred Object Store ID
              * @description The ID of the object store that should be used to store new datasets in this history.
              */

--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -26624,7 +26624,7 @@ export interface components {
         UserUpdatePayload: {
             /**
              * Active
-             * @description User is active
+             * @description Whether the account is active. Only an administrator can change this.
              */
             active?: boolean | null;
             /**

--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -6211,6 +6211,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users/{user_id}/extra_preferences/inputs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the administrator-defined extra user preferences as form inputs */
+        get: operations["get_extra_preferences_api_users__user_id__extra_preferences_inputs_get"];
+        /** Save values for the administrator-defined extra user preferences */
+        put: operations["set_extra_preferences_api_users__user_id__extra_preferences_inputs_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/users/{user_id}/favorites/order": {
         parameters: {
             query?: never;
@@ -25980,6 +25998,38 @@ export interface components {
              * @example 0123456789ABCDEF
              */
             id: string;
+        };
+        /**
+         * UserExtraPreferencesInputs
+         * @description Form-builder inputs for the admin-defined extra user preferences.
+         *
+         *     The sections come from ``user_preferences_extra_conf.yml``, so their shape is
+         *     whatever an administrator wrote. Modelling it any further would be fiction.
+         */
+        UserExtraPreferencesInputs: {
+            /**
+             * Inputs
+             * @description One form-builder section per configured group of extra preferences.
+             */
+            inputs?: {
+                [key: string]: unknown;
+            }[];
+        };
+        /**
+         * UserExtraPreferencesPayload
+         * @description Flat map of ``<section>|<input>`` to value, as produced by the generic form.
+         * @default {}
+         */
+        UserExtraPreferencesPayload: {
+            [key: string]: unknown;
+        };
+        /** UserExtraPreferencesUpdated */
+        UserExtraPreferencesUpdated: {
+            /**
+             * Message
+             * @description Human readable confirmation that the preferences were saved.
+             */
+            message: string;
         };
         /** UserFileSourceModel */
         UserFileSourceModel: {
@@ -51338,6 +51388,98 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeletedCustomBuild"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    get_extra_preferences_api_users__user_id__extra_preferences_inputs_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the user. */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserExtraPreferencesInputs"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    set_extra_preferences_api_users__user_id__extra_preferences_inputs_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the user. */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UserExtraPreferencesPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserExtraPreferencesUpdated"];
                 };
             };
             /** @description Request Error */

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -477,9 +477,14 @@
     process composes its named store with the default
     (``tool_source_database_connection``) store at runtime, with reads
     tried in declared order and writes always landing on the default.
-    Each entry takes a SQLAlchemy ``url`` and an optional ``read_only:
-    true`` flag. For SQLite connection-level read-only, use a SQLite
-    URI with ``mode=ro&uri=true``.
+    Each entry takes either a normal SQLAlchemy ``url`` or an
+    ``external_store_directory`` containing versioned publisher
+    bundles. Galaxy never consults manifests for a normal URL. For an
+    external directory it reads the sidecars and automatically selects
+    the newest cohort compatible with its store/source/index formats
+    and index schema. External stores are always read-only.
+    For SQLite connection-level read-only, use a SQLite URI with
+    ``mode=ro&uri=true``.
     For details see
     https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
 :Default: ``None``
@@ -2072,6 +2077,21 @@
 :Description:
     Allow users to manage their account data, change passwords or
     delete their accounts.
+:Default: ``true``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_user_addresses``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Allow users to store postal addresses on their account, through
+    the deprecated /api/users/{id}/information/inputs endpoint.
+    This feature is deprecated and the user_address table will be
+    removed in a future release. Galaxy's own interface no longer
+    offers these addresses, so this option only affects that endpoint;
+    set it to false to stop accepting them ahead of the removal.
 :Default: ``true``
 :Type: bool
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1154,6 +1154,9 @@ class GalaxyAppConfiguration(GalaxyAppConfigurationAttributes, BaseAppConfigurat
                     f"Config file ({self.user_preferences_extra_conf_path}) could not be found or is malformed."
                 )
             self.user_preferences_extra = {"preferences": {}}
+        # Lets the client hide the extra preferences entry entirely on instances
+        # that configure none, rather than linking to an empty form.
+        self.has_user_preferences_extra = bool(self.user_preferences_extra.get("preferences"))
 
         # default allow_local_account_creation to false if disable_local_accounts is true
         if "disable_local_accounts" in kwargs and self.disable_local_accounts:

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -159,6 +159,7 @@ class GalaxyAppConfigurationAttributes:
     inactivity_box_content: str
     password_expiration_period: timedelta
     enable_account_interface: bool
+    enable_user_addresses: bool
     session_duration: int
     ga_code: str | None
     plausible_server: str | None

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -620,11 +620,13 @@ galaxy:
   # (``tool_source_database_connection``) store at runtime, with reads
   # tried in declared order and writes always landing on the default.
   # Each entry takes either a normal SQLAlchemy ``url`` or an
-  # ``external_store_directory`` of versioned publisher bundles. Manifests
-  # are ignored for normal URL stores. Galaxy automatically selects the
-  # newest manifest-compatible bundle from an external directory, which is
-  # always read-only. For an explicit SQLite URL, use ``mode=ro&uri=true``
-  # when connection-level read-only behavior is wanted.
+  # ``external_store_directory`` containing versioned publisher bundles.
+  # Galaxy never consults manifests for a normal URL. For an external
+  # directory it reads the sidecars and automatically selects the newest
+  # cohort compatible with its store/source/index formats and index
+  # schema. External stores are always read-only.
+  # For SQLite connection-level read-only, use a SQLite URI with
+  # ``mode=ro&uri=true``.
   # For details see
   # https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
   #tool_source_stores: null
@@ -1399,6 +1401,14 @@ galaxy:
   # Allow users to manage their account data, change passwords or delete
   # their accounts.
   #enable_account_interface: true
+
+  # Allow users to store postal addresses on their account, through the
+  # deprecated /api/users/{id}/information/inputs endpoint.
+  # This feature is deprecated and the user_address table will be
+  # removed in a future release. Galaxy's own interface no longer offers
+  # these addresses, so this option only affects that endpoint; set it
+  # to false to stop accepting them ahead of the removal.
+  #enable_user_addresses: true
 
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this
@@ -3449,3 +3459,4 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1561,6 +1561,19 @@ mapping:
           Allow users to manage their account data, change passwords or delete their
           accounts.
 
+      enable_user_addresses:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Allow users to store postal addresses on their account, through the
+          deprecated /api/users/{id}/information/inputs endpoint.
+
+          This feature is deprecated and the user_address table will be removed in a
+          future release. Galaxy's own interface no longer offers these addresses,
+          so this option only affects that endpoint; set it to false to stop
+          accepting them ahead of the removal.
+
       session_duration:
         type: int
         default: 0

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -176,6 +176,7 @@ class ConfigSerializer(base.ModelSerializer):
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,
             "has_user_tool_filters": _defaults_to(False),
+            "has_user_preferences_extra": _defaults_to(False),
             # TODO: is there no 'correct' way to get an api url? controller='api', action='tools' is a hack
             # at any rate: the following works with path_prefix but is still brittle
             # TODO: change this to (more generic) upload_path and incorporate config.nginx_upload_path into building it

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -343,6 +343,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         # Redact user's email and username
         user.email = email_hash
         user.username = uname_hash
+        # The display name is free text and typically holds a real name, so it is
+        # dropped outright - there is nothing here worth keeping a hash of.
+        user.display_name = None
         # Redact user addresses as well
         if self.app.config.redact_user_address_during_deletion:
             stmt = select(UserAddress).where(UserAddress.user_id == user.id)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -51,6 +51,7 @@ from galaxy.model.db.user import (
 )
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
+    validate_display_name_str,
     validate_email,
     validate_password,
     validate_preferred_object_store_id,
@@ -218,6 +219,25 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if user.username == new_username:
             return
         user.username = new_username
+        session = self.session()
+        session.add(user)
+        if commit:
+            session.commit()
+
+    def update_display_name(self, user: User, new_display_name: str | None, *, commit: bool = True) -> None:
+        """
+        Update a user's display name after validating it. Raises RequestParameterInvalidException on validation errors.
+
+        Unlike the username this needs no transaction: display names are not unique, so there is nothing to look up.
+        Surrounding whitespace is stripped rather than rejected, and a name that is empty once stripped clears the
+        field - an invisible difference is a poor reason to fail a save.
+        """
+        normalized = (new_display_name or "").strip() or None
+        if message := validate_display_name_str(normalized):
+            raise exceptions.RequestParameterInvalidException(message)
+        if user.display_name == normalized:
+            return
+        user.display_name = normalized
         session = self.session()
         session.add(user)
         if commit:
@@ -737,6 +757,7 @@ class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
             [
                 "active",
                 "deleted",
+                "display_name",
                 "is_admin",
                 "nice_total_disk_usage",
                 "preferences",
@@ -816,6 +837,7 @@ class UserDeserializer(base.ModelDeserializer):
         user_deserializers: dict[str, base.Deserializer] = {
             "active": self.default_deserializer,
             "username": self.deserialize_username,
+            "display_name": self.deserialize_display_name,
             "preferred_object_store_id": self.deserialize_preferred_object_store_id,
         }
         self.deserializers.update(user_deserializers)
@@ -830,6 +852,12 @@ class UserDeserializer(base.ModelDeserializer):
         if validation_error:
             raise base.ModelDeserializingError(validation_error)
         return self.default_deserializer(item, key, preferred_object_store_id, **context)
+
+    def deserialize_display_name(self, item, key, display_name, **context):
+        display_name = (display_name or "").strip() or None
+        if validation_error := validate_display_name_str(display_name):
+            raise base.ModelDeserializingError(validation_error)
+        return self.default_deserializer(item, key, display_name, **context)
 
     def deserialize_username(self, item, key, username, trans: ProvidesAppContext | None = None, **context):
         # TODO: validate_publicname requires trans and should(?) raise exceptions

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -842,8 +842,18 @@ class UserDeserializer(base.ModelDeserializer):
             "username": self.deserialize_username,
             "display_name": self.deserialize_display_name,
             "preferred_object_store_id": self.deserialize_preferred_object_store_id,
+            "email": self.deserialize_email,
         }
         self.deserializers.update(user_deserializers)
+
+    def deserialize_email(self, item, key, email, trans: ProvidesAppContext | None = None, **context):
+        if trans is None:
+            raise base.ModelDeserializingError("Email addresses cannot be changed in this context.")
+        # update_email keeps the private role in sync and honours user_activation_on.
+        # commit=False because ModelDeserializer.deserialize commits once at the end,
+        # which is also what lets update_email roll back if the activation mail fails.
+        self.manager.update_email(trans, item, email, commit=False, send_activation_email=True)
+        return email
 
     def deserialize_preferred_object_store_id(
         self, item: Any, key: Any, val: Any, trans: ProvidesUserContext | None = None, **context

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -838,13 +838,21 @@ class UserDeserializer(base.ModelDeserializer):
     def add_deserializers(self):
         super().add_deserializers()
         user_deserializers: dict[str, base.Deserializer] = {
-            "active": self.default_deserializer,
+            "active": self.deserialize_active,
             "username": self.deserialize_username,
             "display_name": self.deserialize_display_name,
             "preferred_object_store_id": self.deserialize_preferred_object_store_id,
             "email": self.deserialize_email,
         }
         self.deserializers.update(user_deserializers)
+
+    def deserialize_active(self, item, key, active, trans: ProvidesUserContext | None = None, **context):
+        # Activation is the email-verification gate under user_activation_on: a user
+        # who could flip it themselves would skip verifying a new address, or the
+        # address they registered with once the grace period ends.
+        if trans is None or not trans.user_is_admin:
+            raise exceptions.AdminRequiredException("Only an administrator can change whether a user is active.")
+        return self.deserialize_bool(item, key, active, **context)
 
     def deserialize_email(self, item, key, email, trans: ProvidesAppContext | None = None, **context):
         if trans is None:

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -867,10 +867,10 @@ class UserDeserializer(base.ModelDeserializer):
         return self.default_deserializer(item, key, preferred_object_store_id, **context)
 
     def deserialize_display_name(self, item, key, display_name, **context):
-        display_name = (display_name or "").strip() or None
-        if validation_error := validate_display_name_str(display_name):
-            raise base.ModelDeserializingError(validation_error)
-        return self.default_deserializer(item, key, display_name, **context)
+        # update_display_name strips, validates and assigns. commit=False because
+        # ModelDeserializer.deserialize commits once at the end.
+        self.manager.update_display_name(item, display_name, commit=False)
+        return item.display_name
 
     def deserialize_username(self, item, key, username, trans: ProvidesAppContext | None = None, **context):
         # TODO: validate_publicname requires trans and should(?) raise exceptions

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -871,6 +871,9 @@ class User(Base, Dictifiable, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     email: Mapped[str] = mapped_column(TrimmedString(255), index=True, unique=True)
     username: Mapped[str | None] = mapped_column(TrimmedString(255), index=True, unique=True)
+    # Free-form name shown in place of the username. Deliberately not unique and
+    # not indexed: nothing resolves a user by it, and it never appears in a URL.
+    display_name: Mapped[str | None] = mapped_column(TrimmedString(255))
     password: Mapped[str] = mapped_column(TrimmedString(255))
     last_password_change: Mapped[datetime | None] = mapped_column(default=now)
     external: Mapped[bool | None] = mapped_column(default=False)
@@ -956,7 +959,7 @@ class User(Base, Dictifiable, RepresentById):
         "preferred_object_store_id",
     ]
 
-    def __init__(self, email=None, password=None, username=None):
+    def __init__(self, email=None, password=None, username=None, display_name=None):
         self.email = email
         self.password = password
         self.external = False
@@ -964,6 +967,7 @@ class User(Base, Dictifiable, RepresentById):
         self.purged = False
         self.active = False
         self.username = username
+        self.display_name = display_name
 
     def get_user_data_tables(self, data_table: str):
         session = required_object_session(self)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/64d49ad328d4_add_display_name_column_to_galaxy_user.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/64d49ad328d4_add_display_name_column_to_galaxy_user.py
@@ -1,0 +1,34 @@
+"""add display_name column to galaxy_user
+
+Revision ID: 64d49ad328d4
+Revises: e96dd6fd5863
+Create Date: 2026-08-13 10:00:00.000000
+
+"""
+
+from sqlalchemy import Column
+
+from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "64d49ad328d4"
+down_revision = "e96dd6fd5863"
+branch_labels = None
+depends_on = None
+
+
+# database object names used in this revision
+table_name = "galaxy_user"
+column_name = "display_name"
+
+
+def upgrade():
+    add_column(table_name, Column(column_name, TrimmedString(255), nullable=True))
+
+
+def downgrade():
+    drop_column(table_name, column_name)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -436,6 +436,34 @@ class UserUpdatePayload(Model):
     ] = None
 
 
+class UserExtraPreferencesInputs(Model):
+    """Form-builder inputs for the admin-defined extra user preferences.
+
+    The sections come from ``user_preferences_extra_conf.yml``, so their shape is
+    whatever an administrator wrote. Modelling it any further would be fiction.
+    """
+
+    inputs: list[dict[str, Any]] = Field(
+        default_factory=list,
+        title="Inputs",
+        description="One form-builder section per configured group of extra preferences.",
+    )
+
+
+class UserExtraPreferencesPayload(RootModel):
+    """Flat map of ``<section>|<input>`` to value, as produced by the generic form."""
+
+    root: dict[str, Any] = {}
+
+
+class UserExtraPreferencesUpdated(Model):
+    message: str = Field(
+        default=...,
+        title="Message",
+        description="Human readable confirmation that the preferences were saved.",
+    )
+
+
 class UserCreationPayload(Model):
     password: str = Field(default=..., title="user_password", description="The password of the user.")
     email: str = UserEmailField

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -421,6 +421,19 @@ class UserUpdatePayload(Model):
     username: Annotated[str | None, Field(title="Username", description="The name of the user.")] = None
     display_name: Annotated[str | None, UserDisplayNameField] = None
     preferred_object_store_id: Annotated[str | None, PreferredObjectStoreIdField]
+    # Declared last so that a payload combining it with `active` ends on the
+    # deactivation, not on a stale activation. The admin gate on `active` is the
+    # real protection; this is belt and braces.
+    email: Annotated[
+        str | None,
+        Field(
+            title="Email",
+            description=(
+                "New email address. When `user_activation_on` is set, changing the email deactivates the account "
+                "and sends an activation link to the new address."
+            ),
+        ),
+    ] = None
 
 
 class UserCreationPayload(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -303,6 +303,14 @@ UserId = Annotated[EncodedDatabaseIdField, Field(title="ID", description="Encode
 UserEmailField = Field(title="Email", description="Email of the user")
 UserDescriptionField = Field(title="Description", description="Description of the user")
 UserNameField = Field(default=..., title="user_name", description="The name of the user.")
+UserDisplayNameField = Field(
+    default=None,
+    title="Display name",
+    description=(
+        "Free-form name shown in place of the username. Not unique, and never used in URLs, slugs or as an identifier."
+    ),
+    max_length=255,
+)
 QuotaPercentField = Field(
     default=None, title="Quota percent", description="Percentage of the storage quota applicable to the user."
 )
@@ -397,6 +405,7 @@ class AnonUserModel(DiskUsageUserModel):
 
 
 class DetailedUserModel(BaseUserModel, AnonUserModel):
+    display_name: str | None = UserDisplayNameField
     is_admin: bool = Field(default=..., title="Is admin", description="User is admin")
     purged: bool = Field(default=..., title="Purged", description="User is purged")
     preferences: dict[Any, Any] = Field(default=..., title="Preferences", description="Preferences of the user")
@@ -410,6 +419,7 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
 class UserUpdatePayload(Model):
     active: Annotated[bool | None, Field(title="Active", description="User is active")] = None
     username: Annotated[str | None, Field(title="Username", description="The name of the user.")] = None
+    display_name: Annotated[str | None, UserDisplayNameField] = None
     preferred_object_store_id: Annotated[str | None, PreferredObjectStoreIdField]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -417,13 +417,16 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
 
 
 class UserUpdatePayload(Model):
-    active: Annotated[bool | None, Field(title="Active", description="User is active")] = None
+    active: Annotated[
+        bool | None,
+        Field(title="Active", description="Whether the account is active. Only an administrator can change this."),
+    ] = None
     username: Annotated[str | None, Field(title="Username", description="The name of the user.")] = None
     display_name: Annotated[str | None, UserDisplayNameField] = None
     preferred_object_store_id: Annotated[str | None, PreferredObjectStoreIdField]
     # Declared last so that a payload combining it with `active` ends on the
-    # deactivation, not on a stale activation. The admin gate on `active` is the
-    # real protection; this is belt and braces.
+    # deactivation, not on a stale activation. UserDeserializer only lets an
+    # administrator set `active`, so this ordering is belt and braces.
     email: Annotated[
         str | None,
         Field(

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -63,6 +63,17 @@ VALID_PUBLICNAME_RE = re.compile(r"^[a-z0-9._\-]+$")
 VALID_PUBLICNAME_SUB = re.compile(r"[^a-z0-9._\-]")
 FILL_CHAR = "-"
 
+# Display name validity parameters
+#
+# Display names are free-form and may contain any script, so the rule is a
+# denylist rather than an allowlist. It covers C0/C1 control characters, the
+# zero-width characters, and the bidirectional formatting characters. The bidi
+# overrides are the reason this check exists: U+202E and friends let a name
+# render as text entirely unrelated to what is stored, which makes a display
+# name a viable impersonation vector wherever it is shown.
+DISPLAY_NAME_MAX_LEN = 255
+INVALID_DISPLAY_NAME_RE = re.compile("[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]")
+
 # Password validity parameters
 PASSWORD_MIN_LEN = 6
 
@@ -97,6 +108,22 @@ def validate_publicname_str(publicname):
         return f"Public name cannot be more than {PUBLICNAME_MAX_LEN} characters in length."
     if not (VALID_PUBLICNAME_RE.match(publicname)):
         return "Public name must contain only lower-case letters, numbers, '.', '_' and '-'."
+    return ""
+
+
+def validate_display_name_str(display_name):
+    """Validates a string containing a user's display name.
+
+    Callers are expected to have stripped the value already; an empty display
+    name means "unset" and is accepted here so that clearing the field is not
+    an error.
+    """
+    if not display_name:
+        return ""
+    if len(display_name) > DISPLAY_NAME_MAX_LEN:
+        return f"Display name cannot be more than {DISPLAY_NAME_MAX_LEN} characters in length."
+    if INVALID_DISPLAY_NAME_RE.search(display_name):
+        return "Display name cannot contain control or text-direction characters."
     return ""
 
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -147,9 +147,10 @@ def validate_email(
         if is_email_banned(email, trans.app.config.email_ban_file, trans.app.config.canonical_email_rules):
             message = "This email address has been banned."
 
-    stmt = select(trans.app.model.User).filter(func.lower(trans.app.model.User.email) == email.lower()).limit(1)
-    if not message and check_dup and trans.sa_session.scalars(stmt).first():
-        message = f"User with email '{email}' already exists."
+    if not message and check_dup:
+        stmt = select(trans.app.model.User).filter(func.lower(trans.app.model.User.email) == email.lower()).limit(1)
+        if trans.sa_session.scalars(stmt).first():
+            message = f"User with email '{email}' already exists."
 
     if not message:
         # If the allowlist is not empty filter out any domain not in the list and ignore blocklist.

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -59,11 +59,6 @@ from galaxy.web import (
     error,
     url_for,
 )
-from galaxy.web.form_builder import (
-    AddressField,
-    CheckboxField,
-    PasswordField,
-)
 from galaxy.workflow.modules import WorkflowModuleInjector
 
 if TYPE_CHECKING:
@@ -699,54 +694,6 @@ class UsesFormDefinitionsMixin:
             return [fdc.latest_form for fdc in fdc_list]
         else:
             return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
-
-    def save_widget_field(self, trans: ProvidesUserContext, field_obj, widget_name, **kwd):
-        # Save a form_builder field object
-        params = util.Params(kwd)
-        if isinstance(field_obj, trans.model.UserAddress):
-            field_obj.desc = util.restore_text(params.get(f"{widget_name}_short_desc", ""))
-            field_obj.name = util.restore_text(params.get(f"{widget_name}_name", ""))
-            field_obj.institution = util.restore_text(params.get(f"{widget_name}_institution", ""))
-            field_obj.address = util.restore_text(params.get(f"{widget_name}_address", ""))
-            field_obj.city = util.restore_text(params.get(f"{widget_name}_city", ""))
-            field_obj.state = util.restore_text(params.get(f"{widget_name}_state", ""))
-            field_obj.postal_code = util.restore_text(params.get(f"{widget_name}_postal_code", ""))
-            field_obj.country = util.restore_text(params.get(f"{widget_name}_country", ""))
-            field_obj.phone = util.restore_text(params.get(f"{widget_name}_phone", ""))
-            trans.sa_session.add(field_obj)
-            trans.sa_session.commit()
-
-    def get_form_values(self, trans: ProvidesUserContext, user, form_definition, **kwd):
-        """
-        Returns the name:value dictionary containing all the form values
-        """
-        params = util.Params(kwd)
-        values = {}
-        for field in form_definition.fields:
-            field_type = field["type"]
-            field_name = field["name"]
-            input_value = params.get(field_name, "")
-            field_value: int | str | bool
-            if field_type == AddressField.__name__:
-                input_text_value = util.restore_text(input_value)
-                if input_text_value == "new":
-                    # Save this new address in the list of this user's addresses
-                    user_address = trans.model.UserAddress(user=user)
-                    self.save_widget_field(trans, user_address, field_name, **kwd)
-                    trans.sa_session.refresh(user)
-                    field_value = int(user_address.id)
-                elif input_text_value in ["", "none", "None", None]:
-                    field_value = ""
-                else:
-                    field_value = int(input_text_value)
-            elif field_type == CheckboxField.__name__:
-                field_value = CheckboxField.is_checked(input_value)
-            elif field_type == PasswordField.__name__:
-                field_value = kwd.get(field_name, "")
-            else:
-                field_value = util.restore_text(input_value)
-            values[field_name] = field_value
-        return values
 
 
 class SharableMixin:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -2,7 +2,6 @@
 API operations on User objects.
 """
 
-import copy
 import json
 import logging
 import re
@@ -64,6 +63,9 @@ from galaxy.schema.schema import (
     UserBeaconSetting,
     UserCreationPayload,
     UserDeletionPayload,
+    UserExtraPreferencesInputs,
+    UserExtraPreferencesPayload,
+    UserExtraPreferencesUpdated,
     UserUpdatePayload,
 )
 from galaxy.security.validate_user_input import (
@@ -71,7 +73,6 @@ from galaxy.security.validate_user_input import (
     validate_password,
     validate_publicname,
 )
-from galaxy.security.vault import UserVaultWrapper
 from galaxy.tool_util.toolbox.filters import FilterFactory
 from galaxy.util import (
     docstring_trim,
@@ -96,6 +97,21 @@ from galaxy.webapps.galaxy.services.users import UsersService
 from galaxy.work.context import SessionRequestContext
 
 log = logging.getLogger(__name__)
+
+_information_inputs_deprecation_warned = False
+
+
+def _warn_information_inputs_deprecated() -> None:
+    """Log once per process, so a busy instance does not fill its log with this."""
+    global _information_inputs_deprecation_warned
+    if not _information_inputs_deprecation_warned:
+        _information_inputs_deprecation_warned = True
+        log.warning(
+            "/api/users/{id}/information/inputs is deprecated and will be removed in a future release. "
+            "Use /api/users/{user_id} for email, username and display name, and "
+            "/api/users/{user_id}/extra_preferences/inputs for administrator-defined extra preferences."
+        )
+
 
 router = Router(tags=["users"])
 
@@ -432,6 +448,35 @@ class FastAPIUsers:
         favorites = self.favorites_manager.add(trans, user, object_type, payload.object_id)
         return FavoriteObjectsSummary.model_validate(favorites)
 
+    @router.get(
+        "/api/users/{user_id}/extra_preferences/inputs",
+        name="get_extra_preferences",
+        summary="Return the administrator-defined extra user preferences as form inputs",
+    )
+    def get_extra_preferences(
+        self,
+        user_id: UserIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> UserExtraPreferencesInputs:
+        user = self.service.get_user(trans, user_id)
+        return UserExtraPreferencesInputs(inputs=self.service.build_extra_preferences_inputs(trans, user))
+
+    @router.put(
+        "/api/users/{user_id}/extra_preferences/inputs",
+        name="set_extra_preferences",
+        summary="Save values for the administrator-defined extra user preferences",
+    )
+    def set_extra_preferences(
+        self,
+        user_id: UserIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+        payload: UserExtraPreferencesPayload = Body(default_factory=UserExtraPreferencesPayload),
+    ) -> UserExtraPreferencesUpdated:
+        user = self.service.get_user(trans, user_id)
+        self.service.save_extra_preferences(trans, user, payload.root)
+        trans.sa_session.commit()
+        return UserExtraPreferencesUpdated(message="Extra preferences have been saved.")
+
     @router.put(
         "/api/users/{user_id}/theme/{theme}",
         name="set_theme",
@@ -750,66 +795,21 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         deleted = util.string_as_bool(deleted)
         return self.service.get_user_full(trans, user_id, deleted)
 
-    def _get_extra_user_preferences(self, trans: ProvidesAppContext):
-        """
-        Reads the file user_preferences_extra_conf.yml to display
-        admin defined user informations
-        """
-        return trans.app.config.user_preferences_extra["preferences"]
-
-    def _build_extra_user_pref_inputs(self, trans: ProvidesAppContext, preferences, user):
-        """
-        Build extra user preferences inputs list.
-        Add values to the fields if present
-        """
-        if not preferences:
-            return []
-        extra_pref_inputs = []
-        # Build sections for different categories of inputs
-        user_vault = UserVaultWrapper(trans.app.vault, user)
-        for item, value in preferences.items():
-            if value is not None:
-                input_fields = copy.deepcopy(value["inputs"])
-                for input in input_fields:
-                    help = input.get("help", "")
-                    required = "Required" if util.string_as_bool(input.get("required")) else ""
-                    if help:
-                        input["help"] = f"{help} {required}"
-                    else:
-                        input["help"] = required
-                    if input.get("store") == "vault":
-                        field = f"{item}/{input['name']}"
-                        input["value"] = user_vault.read_secret(f"preferences/{field}")
-                    else:
-                        field = f"{item}|{input['name']}"
-                        for data_item in user.extra_preferences:
-                            if field in data_item:
-                                input["value"] = user.extra_preferences[data_item]
-                    # regardless of the store, do not send secret type values to client
-                    if input.get("type") == "secret":
-                        input["value"] = "__SECRET_PLACEHOLDER__"
-                        # let the client treat it as a password field
-                        input["type"] = "password"
-                extra_pref_inputs.append(
-                    {
-                        "type": "section",
-                        "title": value["description"],
-                        "name": item,
-                        "expanded": True,
-                        "inputs": input_fields,
-                    }
-                )
-        return extra_pref_inputs
-
     @expose_api
     def get_information(self, trans: GalaxyWebTransaction, id, **kwd):
         """
         GET /api/users/{id}/information/inputs
         Return user details such as username, email, addresses etc.
 
+        .. deprecated::
+            Use ``GET /api/users/{user_id}`` for email, username and display name,
+            and ``GET /api/users/{user_id}/extra_preferences/inputs`` for the
+            administrator-defined extra preferences.
+
         :param id: the encoded id of the user
         :type  id: str
         """
+        _warn_information_inputs_deprecated()
         user = self._get_user(trans, id)
         email = user.email
         username = user.username
@@ -901,8 +901,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                 user_info["addresses"] = [address.to_dict(trans) for address in user.addresses]
 
             # Build input sections for extra user preferences
-            extra_user_pref = self._build_extra_user_pref_inputs(trans, self._get_extra_user_preferences(trans), user)
-            for item in extra_user_pref:
+            for item in self.service.build_extra_preferences_inputs(trans, user):
                 inputs.append(item)
         else:
             if user.active_repositories:
@@ -936,12 +935,18 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         PUT /api/users/{id}/information/inputs
         Save a user's email, username, addresses etc.
 
+        .. deprecated::
+            Use ``PUT /api/users/{user_id}`` for email, username and display name,
+            and ``PUT /api/users/{user_id}/extra_preferences/inputs`` for the
+            administrator-defined extra preferences.
+
         :param id: the encoded id of the user
         :type  id: str
 
         :param payload: data with new settings
         :type  payload: dict
         """
+        _warn_information_inputs_deprecated()
         payload = payload or {}
         user = self._get_user(trans, id)
         # Update email
@@ -971,39 +976,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             user.values = form_values
 
         # Update values for extra user preference items
-        extra_user_pref_data = {}
-        extra_pref_keys = self._get_extra_user_preferences(trans)
-        user_vault = UserVaultWrapper(trans.app.vault, user)
-        current_extra_user_pref_data = json.loads(user.preferences.get("extra_user_preferences", "{}"))
-        if extra_pref_keys is not None:
-            for key in extra_pref_keys:
-                key_prefix = f"{key}|"
-                for item in payload:
-                    if item.startswith(key_prefix):
-                        keys = item.split("|")
-                        section = extra_pref_keys[keys[0]]
-                        matching_input = [input for input in section["inputs"] if input["name"] == keys[1]]
-                        if matching_input:
-                            input = matching_input[0]
-                            if input.get("required") and payload[item] == "":
-                                raise exceptions.ObjectAttributeMissingException("Please fill the required field")
-                            input_type = input.get("type")
-                            is_secret_value_unchanged = (
-                                input_type == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"
-                            )
-                            is_stored_in_vault = input.get("store") == "vault"
-                            if is_secret_value_unchanged:
-                                if not is_stored_in_vault:
-                                    # If the value is unchanged, keep the current value
-                                    extra_user_pref_data[item] = current_extra_user_pref_data.get(item, "")
-                            else:
-                                if is_stored_in_vault:
-                                    user_vault.write_secret(f"preferences/{keys[0]}/{keys[1]}", str(payload[item]))
-                                else:
-                                    extra_user_pref_data[item] = payload[item]
-                        else:
-                            extra_user_pref_data[item] = payload[item]
-            user.preferences["extra_user_preferences"] = json.dumps(extra_user_pref_data)
+        self.service.save_extra_preferences(trans, user, payload)
 
         # Update user addresses
         address_dicts: dict[int, dict[str, Any]] = {}

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -878,7 +878,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                     info_field["cases"].append({"value": info_form["id"], "inputs": info_form["inputs"]})
                 inputs.append(info_field)
 
-            if trans.app.config.enable_account_interface:
+            if trans.app.config.enable_account_interface and trans.app.config.enable_user_addresses:
                 address_inputs = [{"type": "hidden", "name": "id", "hidden": True}]
                 for field in AddressField.fields():
                     address_inputs.append({"type": "text", "name": field[0], "label": field[1], "help": field[2]})
@@ -978,38 +978,41 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         # Update values for extra user preference items
         self.service.save_extra_preferences(trans, user, payload)
 
-        # Update user addresses
-        address_dicts: dict[int, dict[str, Any]] = {}
-        address_count = 0
-        for item in payload:
-            match = re.match(r"^address_(?P<index>\d+)\|(?P<attribute>\S+)", item)
-            if match:
-                groups = match.groupdict()
-                index = int(groups["index"])
-                attribute = groups["attribute"]
-                address_dicts[index] = address_dicts.get(index) or {}
-                address_dicts[index][attribute] = payload[item]
-                address_count = max(address_count, index + 1)
-        user.addresses = []
-        for index in range(0, address_count):
-            d = address_dicts[index]
-            if d.get("id"):
-                try:
-                    user_address = trans.sa_session.get(UserAddress, trans.security.decode_id(d["id"]))
-                except Exception as e:
-                    raise exceptions.ObjectNotFound(f"Failed to access user address ({d['id']}). {e}")
-            else:
-                user_address = UserAddress()
-                trans.log_event("User address added")
-            for field in AddressField.fields():
-                if str(field[2]).lower() == "required" and not d.get(field[0]):
-                    raise exceptions.ObjectAttributeMissingException(
-                        f"Address {index + 1}: {field[1]} ({field[0]}) required."
-                    )
-                setattr(user_address, field[0], str(d.get(field[0], "")))
-            user_address.user = user
-            user.addresses.append(user_address)
-            trans.sa_session.add(user_address)
+        # Update user addresses. The whole block is gated, not just the parsing:
+        # it rebuilds user.addresses from the payload, so running it while the
+        # feature is off would silently discard whatever is stored.
+        if trans.app.config.enable_user_addresses:
+            address_dicts: dict[int, dict[str, Any]] = {}
+            address_count = 0
+            for item in payload:
+                match = re.match(r"^address_(?P<index>\d+)\|(?P<attribute>\S+)", item)
+                if match:
+                    groups = match.groupdict()
+                    index = int(groups["index"])
+                    attribute = groups["attribute"]
+                    address_dicts[index] = address_dicts.get(index) or {}
+                    address_dicts[index][attribute] = payload[item]
+                    address_count = max(address_count, index + 1)
+            user.addresses = []
+            for index in range(0, address_count):
+                d = address_dicts[index]
+                if d.get("id"):
+                    try:
+                        user_address = trans.sa_session.get(UserAddress, trans.security.decode_id(d["id"]))
+                    except Exception as e:
+                        raise exceptions.ObjectNotFound(f"Failed to access user address ({d['id']}). {e}")
+                else:
+                    user_address = UserAddress()
+                    trans.log_event("User address added")
+                for field in AddressField.fields():
+                    if str(field[2]).lower() == "required" and not d.get(field[0]):
+                        raise exceptions.ObjectAttributeMissingException(
+                            f"Address {index + 1}: {field[1]} ({field[0]}) required."
+                        )
+                    setattr(user_address, field[0], str(d.get(field[0], "")))
+                user_address.user = user
+                user.addresses.append(user_address)
+                trans.sa_session.add(user_address)
         trans.sa_session.add(user)
         trans.sa_session.commit()
         trans.log_event("User information added")

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -1,4 +1,7 @@
+import copy
+import json
 from typing import (
+    Any,
     TYPE_CHECKING,
 )
 
@@ -33,6 +36,7 @@ from galaxy.schema.schema import (
     UserModel,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.security.vault import UserVaultWrapper
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.roles import role_to_model
 
@@ -114,6 +118,104 @@ class UsersService(ServiceBase):
             raise glx_exceptions.InsufficientPermissionsException("Access denied.")
         user = self.user_manager.by_id(user_id)
         return user
+
+    def get_extra_preferences(self, trans: ProvidesUserContext) -> dict[str, Any] | None:
+        """The admin-defined sections from ``user_preferences_extra_conf.yml``.
+
+        None when the file declares a ``preferences`` key with nothing under it,
+        which is why callers guard against it rather than assuming a dict.
+        """
+        return trans.app.config.user_preferences_extra["preferences"]
+
+    def build_extra_preferences_inputs(self, trans: ProvidesUserContext, user: User) -> list[dict[str, Any]]:
+        """
+        Build the form-builder input list for the admin-defined extra preferences,
+        filling in the user's stored values.
+
+        The shape is deliberately untyped form JSON: the sections come from admin
+        authored YAML, so there is no fixed schema to model.
+        """
+        preferences = self.get_extra_preferences(trans)
+        if not preferences:
+            return []
+        extra_pref_inputs = []
+        # Build sections for different categories of inputs
+        user_vault = UserVaultWrapper(trans.app.vault, user)
+        for item, value in preferences.items():
+            if value is not None:
+                input_fields = copy.deepcopy(value["inputs"])
+                for input in input_fields:
+                    help = input.get("help", "")
+                    required = "Required" if util.string_as_bool(input.get("required")) else ""
+                    if help:
+                        input["help"] = f"{help} {required}"
+                    else:
+                        input["help"] = required
+                    if input.get("store") == "vault":
+                        field = f"{item}/{input['name']}"
+                        input["value"] = user_vault.read_secret(f"preferences/{field}")
+                    else:
+                        field = f"{item}|{input['name']}"
+                        for data_item in user.extra_preferences:
+                            if field in data_item:
+                                input["value"] = user.extra_preferences[data_item]
+                    # regardless of the store, do not send secret type values to client
+                    if input.get("type") == "secret":
+                        input["value"] = "__SECRET_PLACEHOLDER__"
+                        # let the client treat it as a password field
+                        input["type"] = "password"
+                extra_pref_inputs.append(
+                    {
+                        "type": "section",
+                        "title": value["description"],
+                        "name": item,
+                        "expanded": True,
+                        "inputs": input_fields,
+                    }
+                )
+        return extra_pref_inputs
+
+    def save_extra_preferences(self, trans: ProvidesUserContext, user: User, payload: dict[str, Any]) -> None:
+        """
+        Store values for the admin-defined extra preferences.
+
+        Payload keys are flat ``<section>|<input>`` pairs, as produced by the
+        generic form. Secrets are either written to the user vault or kept in the
+        user's preferences; a secret that comes back as the placeholder means the
+        client never saw it and the stored value must be left alone.
+        """
+        extra_user_pref_data = {}
+        extra_pref_keys = self.get_extra_preferences(trans)
+        if extra_pref_keys is None:
+            return
+        user_vault = UserVaultWrapper(trans.app.vault, user)
+        current_extra_user_pref_data = json.loads(user.preferences.get("extra_user_preferences", "{}"))
+        for key in extra_pref_keys:
+            key_prefix = f"{key}|"
+            for item in payload:
+                if item.startswith(key_prefix):
+                    keys = item.split("|")
+                    section = extra_pref_keys[keys[0]]
+                    matching_input = [input for input in section["inputs"] if input["name"] == keys[1]]
+                    if matching_input:
+                        input = matching_input[0]
+                        if input.get("required") and payload[item] == "":
+                            raise glx_exceptions.ObjectAttributeMissingException("Please fill the required field")
+                        input_type = input.get("type")
+                        is_secret_value_unchanged = input_type == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"
+                        is_stored_in_vault = input.get("store") == "vault"
+                        if is_secret_value_unchanged:
+                            if not is_stored_in_vault:
+                                # If the value is unchanged, keep the current value
+                                extra_user_pref_data[item] = current_extra_user_pref_data.get(item, "")
+                        else:
+                            if is_stored_in_vault:
+                                user_vault.write_secret(f"preferences/{keys[0]}/{keys[1]}", str(payload[item]))
+                            else:
+                                extra_user_pref_data[item] = payload[item]
+                    else:
+                        extra_user_pref_data[item] = payload[item]
+        user.preferences["extra_user_preferences"] = json.dumps(extra_user_pref_data)
 
     def _anon_user_api_value(self, trans: ProvidesHistoryContext):
         """Return data for an anonymous user, truncated to only usage and quota_percent"""

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -112,6 +112,35 @@ class TestUsersApi(ApiTestCase):
             update_response = self._put(update_url, data=payload, json=True)
             assert_object_id_error(update_response)
 
+    @requires_new_user
+    def test_update_display_name(self):
+        # This suite runs with public profile pages disabled, which is the point:
+        # a display name has to be settable on every instance, not only on the
+        # ones that expose profile pages.
+        user = self._setup_user(TEST_USER_EMAIL)
+        with self._different_user(email=TEST_USER_EMAIL):
+            update_response = self.__update(user, data={"display_name": "Carl von Linné"})
+            self._assert_status_code_is(update_response, 200)
+            assert update_response.json()["display_name"] == "Carl von Linné"
+
+            # surrounding whitespace is stripped rather than rejected
+            update_response = self.__update(user, data={"display_name": "  Carl von Linné  "})
+            self._assert_status_code_is(update_response, 200)
+            assert update_response.json()["display_name"] == "Carl von Linné"
+
+            # an empty display name clears the field
+            update_response = self.__update(user, data={"display_name": ""})
+            self._assert_status_code_is(update_response, 200)
+            assert update_response.json()["display_name"] is None
+
+            # text-direction characters would let the name render as other text
+            update_response = self.__update(user, data={"display_name": "Carl\u202evon Linné"})
+            self._assert_status_code_is(update_response, 400)
+
+            # over the column length
+            update_response = self.__update(user, data={"display_name": "N" * 256})
+            self._assert_status_code_is(update_response, 400)
+
     @requires_admin
     @requires_new_user
     def test_admin_update(self):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -175,6 +175,27 @@ class TestUsersApi(ApiTestCase):
             update_response = self.__update(user, data={"email": other_user["email"]})
             self._assert_status_code_is(update_response, 400)
 
+    @requires_new_user
+    def test_extra_preferences_inputs(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        with self._different_user(email=TEST_USER_EMAIL):
+            response = self._get(f"users/{user['id']}/extra_preferences/inputs")
+            self._assert_status_code_is(response, 200)
+            # The default test instance configures no extra preferences.
+            assert response.json()["inputs"] == []
+
+            response = self._put(f"users/{user['id']}/extra_preferences/inputs", data={}, json=True)
+            self._assert_status_code_is(response, 200)
+            assert "message" in response.json()
+
+    @requires_new_user
+    def test_extra_preferences_inputs_other_user_forbidden(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        self._setup_user("extra_prefs_other@bx.psu.edu")
+        with self._different_user(email="extra_prefs_other@bx.psu.edu"):
+            response = self._get(f"users/{user['id']}/extra_preferences/inputs")
+            self._assert_status_code_is(response, 403)
+
     @requires_admin
     @requires_new_user
     def test_delete_user(self):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -20,6 +20,8 @@ TEST_USER_EMAIL_DELETE_CANCEL_JOBS = "user_for_delete_cancel_jobs_test@bx.psu.ed
 TEST_USER_EMAIL_PURGE = "user_for_purge_test@bx.psu.edu"
 TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 TEST_USER_EMAIL_SHOW = "user_for_show_test@bx.psu.edu"
+TEST_USER_EMAIL_UPDATE = "user_for_email_update_test@bx.psu.edu"
+TEST_USER_EMAIL_UPDATED = "user_for_email_update_test_changed@bx.psu.edu"
 
 
 class TestUsersApi(ApiTestCase):
@@ -151,6 +153,27 @@ class TestUsersApi(ApiTestCase):
         self._assert_status_code_is(update_response, 200)
         update_json = update_response.json()
         assert update_json["username"] == payload["username"]
+
+    @requires_new_user
+    def test_update_email(self):
+        user = self._setup_user(TEST_USER_EMAIL_UPDATE)
+        with self._different_user(email=TEST_USER_EMAIL_UPDATE):
+            update_response = self.__update(user, data={"email": TEST_USER_EMAIL_UPDATED})
+            self._assert_status_code_is(update_response, 200)
+            assert update_response.json()["email"] == TEST_USER_EMAIL_UPDATED
+
+    @requires_new_user
+    def test_update_email_invalid(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        other_user = self._setup_user("email_update_conflict@bx.psu.edu")
+        with self._different_user(email=TEST_USER_EMAIL):
+            # malformed
+            update_response = self.__update(user, data={"email": "not-an-email"})
+            self._assert_status_code_is(update_response, 400)
+
+            # already taken by another account
+            update_response = self.__update(user, data={"email": other_user["email"]})
+            self._assert_status_code_is(update_response, 400)
 
     @requires_admin
     @requires_new_user

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -179,6 +179,28 @@ class TestUsersApi(ApiTestCase):
             update_response = self.__update(user, data={"email": None})
             self._assert_status_code_is(update_response, 400)
 
+    @requires_admin
+    @requires_new_user
+    def test_update_active_requires_admin(self):
+        email = "active_flag_update@bx.psu.edu"
+        user = self._setup_user(email)
+        with self._different_user(email=email):
+            # activation is the email-verification gate, so users cannot flip it on themselves
+            update_response = self.__update(user, data={"active": True})
+            self._assert_status_code_is(update_response, 403)
+
+        update_url = self._api_url(f"users/{user['id']}")
+        for active in (False, True):
+            update_response = self._put(update_url, data={"active": active}, admin=True, json=True)
+            self._assert_status_code_is(update_response, 200)
+            # `active` is not on DetailedUserModel, so it is read back from the index.
+            listed = self._get("users", data={"f_email": email}, admin=True).json()
+            assert [u for u in listed if u["id"] == user["id"]][0]["active"] is active
+
+        # null is not a bool; reject it before it reaches the NOT NULL column
+        update_response = self._put(update_url, data={"active": None}, admin=True, json=True)
+        self._assert_status_code_is(update_response, 400)
+
     @requires_new_user
     def test_extra_preferences_inputs(self):
         user = self._setup_user(TEST_USER_EMAIL)

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -175,6 +175,10 @@ class TestUsersApi(ApiTestCase):
             update_response = self.__update(user, data={"email": other_user["email"]})
             self._assert_status_code_is(update_response, 400)
 
+            # null passes the schema because the field is optional
+            update_response = self.__update(user, data={"email": None})
+            self._assert_status_code_is(update_response, 400)
+
     @requires_new_user
     def test_extra_preferences_inputs(self):
         user = self._setup_user(TEST_USER_EMAIL)

--- a/test/integration/test_users.py
+++ b/test/integration/test_users.py
@@ -108,6 +108,35 @@ class TestAdminResendActivationEmail(integration_util.IntegrationTestCase):
         config["email_from"] = "galaxy-noreply@example.com"
         config["smtp_server"] = f"mock_emails_to_path://{cls.email_directory}/email.json"
 
+    def test_email_change_deactivates_and_mails_the_new_address(self):
+        old_email = "email-change-before@test.gx"
+        new_email = "email-change-after@test.gx"
+        user = self._setup_user(old_email)
+
+        with self._different_user(email=old_email):
+            response = self._put(f"users/{user['id']}", data={"email": new_email}, json=True)
+            self._assert_status_code_is_ok(response)
+            updated = response.json()
+
+        assert updated["email"] == new_email
+
+        # Changing the address has to re-verify it, otherwise activation is a
+        # one-time gate that any later edit walks straight past. `active` is not on
+        # DetailedUserModel, so it is read back from the index.
+        listed = self._get("users", data={"f_email": new_email}, admin=True).json()
+        assert [u for u in listed if u["email"] == new_email][0]["active"] is False
+
+        with open(os.path.join(self.email_directory, "email.json")) as f:
+            email = json.loads(f.read())
+        assert email["to"] == new_email
+        assert email["subject"] == "Galaxy Account Activation"
+
+        # The private role is named for the email and is what dataset permissions
+        # are granted against, so it has to follow the address.
+        role_names = [role["name"] for role in self._get("roles", admin=True).json()]
+        assert new_email in role_names
+        assert old_email not in role_names
+
     def test_resend_activation_includes_qualified_link(self):
         user = self._setup_user("resend-activation@test.gx")
         response = self._post(f"users/{user['id']}/send_activation_email", admin=True)

--- a/test/integration/test_vault_extra_prefs.py
+++ b/test/integration/test_vault_extra_prefs.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import (
     Any,
@@ -27,20 +26,18 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_vault_storage(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
         # create some initial data
         put(
             url,
-            data=json.dumps(
-                {
-                    "vaulttestsection|client_id": "hello_client_id",
-                    "vaulttestsection|client_secret": "hello_client_secret",
-                    "vaulttestsection|refresh_token": "a_super_secret_value",
-                }
-            ),
+            json={
+                "vaulttestsection|client_id": "hello_client_id",
+                "vaulttestsection|client_secret": "hello_client_secret",
+                "vaulttestsection|refresh_token": "a_super_secret_value",
+            },
         )
 
         # retrieve saved data
@@ -83,28 +80,24 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_vault_storage_update_secret(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
         # write the initial secret value
         put(
             url,
-            data=json.dumps(
-                {
-                    "vaulttestsection|refresh_token": "a_new_secret_value",
-                }
-            ),
+            json={
+                "vaulttestsection|refresh_token": "a_new_secret_value",
+            },
         )
 
         # attempt to overwrite it with placeholder
         put(
             url,
-            data=json.dumps(
-                {
-                    "vaulttestsection|refresh_token": "__SECRET_PLACEHOLDER__",
-                }
-            ),
+            json={
+                "vaulttestsection|refresh_token": "__SECRET_PLACEHOLDER__",
+            },
         )
 
         # value should not have been overwritten
@@ -116,11 +109,9 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         # write a new value
         put(
             url,
-            data=json.dumps(
-                {
-                    "vaulttestsection|refresh_token": "an_updated_secret_value",
-                }
-            ),
+            json={
+                "vaulttestsection|refresh_token": "an_updated_secret_value",
+            },
         )
 
         # value should now be overwritten
@@ -131,19 +122,17 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_secret_not_in_vault(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
         # create some initial data
         put(
             url,
-            data=json.dumps(
-                {
-                    "non_vault_test_section|user": "test_user",
-                    "non_vault_test_section|pass": "test_pass",
-                }
-            ),
+            json={
+                "non_vault_test_section|user": "test_user",
+                "non_vault_test_section|pass": "test_pass",
+            },
         )
 
         # retrieve saved data
@@ -172,12 +161,10 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         # changing the text property value should not change the secret property value
         put(
             url,
-            data=json.dumps(
-                {
-                    "non_vault_test_section|user": "a_new_test_user",
-                    "non_vault_test_section|pass": "__SECRET_PLACEHOLDER__",
-                }
-            ),
+            json={
+                "non_vault_test_section|user": "a_new_test_user",
+                "non_vault_test_section|pass": "__SECRET_PLACEHOLDER__",
+            },
         )
 
         response = get(url).json()
@@ -195,12 +182,10 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         # changing the secret value should update the secret value
         put(
             url,
-            data=json.dumps(
-                {
-                    "non_vault_test_section|user": "a_new_test_user",
-                    "non_vault_test_section|pass": "a_new_test_pass",
-                }
-            ),
+            json={
+                "non_vault_test_section|user": "a_new_test_user",
+                "non_vault_test_section|pass": "a_new_test_pass",
+            },
         )
 
         response = get(url).json()
@@ -211,6 +196,25 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         # the secret value should be updated in the internal user preferences model
         app.model.session.refresh(db_user)
         assert db_user.extra_preferences["non_vault_test_section|pass"] == "a_new_test_pass"
+
+    def test_legacy_information_inputs_still_serves_extra_prefs(self):
+        # The deprecated endpoint delegates to the same service code, so it has to
+        # keep working until it is removed.
+        user = self._setup_user("vault-legacy-shim@test.gx")
+        legacy_url = self.__url("information/inputs", user)
+
+        put(legacy_url, json={"vaulttestsection|client_id": "legacy_client_id"})
+
+        response = get(legacy_url).json()
+        section = [section for section in response["inputs"] if section["name"] == "vaulttestsection"][0]
+        client_id = [input for input in section["inputs"] if input["name"] == "client_id"][0]
+        assert client_id["value"] == "legacy_client_id"
+
+        # and the typed endpoint sees the same stored value
+        typed_response = get(self.__url("extra_preferences/inputs", user)).json()
+        typed_section = [section for section in typed_response["inputs"] if section["name"] == "vaulttestsection"][0]
+        typed_client_id = [input for input in typed_section["inputs"] if input["name"] == "client_id"][0]
+        assert typed_client_id["value"] == "legacy_client_id"
 
     def __url(self, action, user):
         return self._api_url(f"users/{user['id']}/{action}", params=dict(key=self.master_api_key))

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -313,6 +313,52 @@ class TestUserManager(BaseTestCase):
         message = self.user_manager.send_reset_email(cast("GalaxyWebTransaction", self.trans), {"email": user_email})
         assert message is None
 
+    def test_update_display_name(self):
+        # No assertion on the initial value here: asserting `is None` would narrow
+        # the attribute to None for the rest of the function, and mypy would then
+        # read every later comparison as always-false. The default is covered by
+        # test_display_name_defaults_to_none.
+        user = self.user_manager.create(**user2_data)
+
+        self.log("display names should be updatable")
+        self.user_manager.update_display_name(user, "Ada Lovelace")
+        assert user.display_name == "Ada Lovelace"
+
+        self.log("surrounding whitespace should be stripped rather than rejected")
+        self.user_manager.update_display_name(user, "  Ada Lovelace  ")
+        assert user.display_name == "Ada Lovelace"
+
+        self.log("an empty display name should clear the field")
+        self.user_manager.update_display_name(user, "")
+        assert user.display_name is None
+        self.user_manager.update_display_name(user, "Ada Lovelace")
+        self.user_manager.update_display_name(user, "   ")
+        assert user.display_name is None
+        self.user_manager.update_display_name(user, "Ada Lovelace")
+        self.user_manager.update_display_name(user, None)
+        assert user.display_name is None
+
+    def test_update_display_name_validation(self):
+        user = self.user_manager.create(**user2_data)
+
+        self.log("display names cannot contain text-direction characters")
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.user_manager.update_display_name(user, "Ada\u202eLovelace")
+
+        self.log("display names have a maximum length")
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.user_manager.update_display_name(user, "N" * 256)
+
+        assert user.display_name is None
+
+    def test_display_names_need_not_be_unique(self):
+        self.log("unlike usernames, two users may share a display name")
+        user2 = self.user_manager.create(**user2_data)
+        user3 = self.user_manager.create(**user3_data)
+        self.user_manager.update_display_name(user2, "Ada Lovelace")
+        self.user_manager.update_display_name(user3, "Ada Lovelace")
+        assert user2.display_name == user3.display_name == "Ada Lovelace"
+
     def test_get_user_by_identity(self):
         # return None if username/email not found
         assert self.user_manager.get_user_by_identity("xyz") is None
@@ -478,6 +524,23 @@ class TestUserDeserializer(BaseTestCase):
         new_user = self.user_manager.by_id(user.id)
         assert new_user is not None
         assert new_user.username == new_name
+
+    def test_display_name_validation(self):
+        user = self.user_manager.create(**user2_data)
+
+        self.log("display names reject text-direction characters")
+        with self.assertRaises(base_manager.ModelDeserializingError):
+            self.deserializer.deserialize(user, {"display_name": "Ada\u202eLovelace"}, trans=self.trans)
+
+        self.log("display names should be updatable and trimmed")
+        self.deserializer.deserialize(user, {"display_name": "  Ada Lovelace  "}, trans=self.trans)
+        new_user = self.user_manager.by_id(user.id)
+        assert new_user is not None
+        assert new_user.display_name == "Ada Lovelace"
+
+        self.log("an empty display name clears the field")
+        self.deserializer.deserialize(user, {"display_name": ""}, trans=self.trans)
+        assert user.display_name is None
 
 
 # =============================================================================

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -542,6 +542,21 @@ class TestUserDeserializer(BaseTestCase):
         self.deserializer.deserialize(user, {"display_name": ""}, trans=self.trans)
         assert user.display_name is None
 
+    def test_active_requires_admin(self):
+        user = self.user_manager.create(**user2_data)
+        user.active = False
+
+        self.log("a non-admin cannot re-activate an account")
+        self.mock_trans.user_is_admin = False
+        with self.assertRaises(exceptions.AdminRequiredException):
+            self.deserializer.deserialize(user, {"active": True}, trans=self.trans)
+        assert user.active is False
+
+        self.log("an admin can")
+        self.mock_trans.user_is_admin = True
+        self.deserializer.deserialize(user, {"active": True}, trans=self.trans)
+        assert user.active is True
+
 
 # =============================================================================
 class TestAdminUserFilterParser(BaseTestCase):

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -529,7 +529,7 @@ class TestUserDeserializer(BaseTestCase):
         user = self.user_manager.create(**user2_data)
 
         self.log("display names reject text-direction characters")
-        with self.assertRaises(base_manager.ModelDeserializingError):
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
             self.deserializer.deserialize(user, {"display_name": "Ada\u202eLovelace"}, trans=self.trans)
 
         self.log("display names should be updatable and trimmed")

--- a/test/unit/data/model/db/test_user.py
+++ b/test/unit/data/model/db/test_user.py
@@ -88,6 +88,32 @@ def test_username_is_unique(make_user):
         make_user(username="a")
 
 
+def test_display_name_defaults_to_none(make_user):
+    # Verify display_name model definition
+    user = make_user()
+    assert user.display_name is None
+
+
+def test_display_name_round_trips(session, make_user):
+    user = make_user(display_name="Ada Lovelace")
+    session.expire(user)
+    assert user.display_name == "Ada Lovelace"
+
+
+def test_display_name_is_not_unique(make_user):
+    # Deliberately unlike username: display names collide by design, which is
+    # why the username stays reachable everywhere a display name is shown.
+    make_user(display_name="Ada Lovelace")
+    make_user(display_name="Ada Lovelace")
+
+
+def test_display_name_is_truncated_at_column_length(session, make_user):
+    # TrimmedString is a backstop under the validator, not a substitute for it.
+    user = make_user(display_name="N" * 300)
+    session.expire(user)
+    assert user.display_name == "N" * 255
+
+
 def test_cleanup_nonprivate_user_roles(session, make_user_and_role, make_role, make_user_role_association):
     # Create 3 users with private roles
     user1, role_private1 = make_user_and_role(email="user1@foo.com")

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -5,6 +5,7 @@ from galaxy.security import validate_user_input
 from galaxy.security.validate_user_input import (
     extract_domain,
     is_email_banned,
+    validate_display_name_str,
     validate_email_domain_name,
     validate_email_str,
     validate_publicname_str,
@@ -40,6 +41,36 @@ def test_validate_username():
     assert validate_publicname_str("test-user") == ""
     assert validate_publicname_str("test@user") != ""
     assert validate_publicname_str("test user") != ""
+
+
+def test_validate_display_name_str():
+    # Free-form across scripts: anything a person might actually be called.
+    assert validate_display_name_str("Ada Lovelace") == ""
+    assert validate_display_name_str("Zoë Müller") == ""
+    assert validate_display_name_str("محمد") == ""
+    assert validate_display_name_str("张伟") == ""
+    assert validate_display_name_str("Ada 🧬") == ""
+    # Unlike a username, a display name may collide with anything.
+    assert validate_display_name_str("admin") == ""
+    # Empty means "unset", which is a legitimate value rather than an error.
+    assert validate_display_name_str("") == ""
+    assert validate_display_name_str(None) == ""
+
+
+def test_validate_display_name_str_length():
+    assert validate_display_name_str("N" * 255) == ""
+    assert validate_display_name_str("N" * 256) != ""
+
+
+def test_validate_display_name_str_rejects_invisible_characters():
+    assert validate_display_name_str("Ada\nLovelace") != ""  # C0 control
+    assert validate_display_name_str("Ada\x7fLovelace") != ""  # DEL
+    assert validate_display_name_str("Ada\u009fLovelace") != ""  # C1 control
+    assert validate_display_name_str("Ada\u200bLovelace") != ""  # zero-width space
+    assert validate_display_name_str("Ada\u200dLovelace") != ""  # zero-width joiner
+    assert validate_display_name_str("Ada\u202eLovelace") != ""  # right-to-left override
+    assert validate_display_name_str("Ada\u2066Lovelace") != ""  # left-to-right isolate
+    assert validate_display_name_str("Ada\ufeffLovelace") != ""  # zero-width no-break space
 
 
 def test_validate_email_str():


### PR DESCRIPTION
Regroups the server-side half of the user account work that was previously split across this PR and #23304, #23305 and #23308. Same commits, same content, one PR against `dev` instead of four stacked branches — per the review feedback that the split was too atomic.

The client half (the native Account page and the preference grouping, previously #23306 and #23307) follows in a separate PR once this one lands. The migration data-fix this used to sit on top of is #23314, merged on its own first: adding a column to `galaxy_user` is exactly what the old data fix selecting the whole ORM model broke on.

---

## Display name on `galaxy_user`

Adds a `display_name` column to `galaxy_user`: a free-form name shown in place of the username.

Galaxy has one name per user doing three jobs at once — it signs you in, it is the `/u/{username}/...` URL segment, and it is what other people see. Those pull in different directions: a URL segment wants to be short, unique and lowercase; a name people see wants to be whatever the person is actually called. This adds the presentational half so the username can stop pretending to be both. It is groundwork for the public profile pages work, but it is useful on its own — it is what lets a later change show a real name next to published items.

**Why on `galaxy_user` rather than a profile table.** The profile pages branch puts profile fields on a `user_profile` side table gated behind `enable_user_profile_pages`. A display name has to work on every instance, so it belongs on the user.

Design notes:

- Nullable, falling back to the username. Nothing is backfilled — making it required would mean either copying every username into it or blocking every account save on an empty field.
- Not unique and not indexed. Display names collide by design, nothing resolves a user by one, and the only plausible consumer (admin user search) uses a leading-wildcard `LIKE` that an index cannot serve.
- Exposed on `DetailedUserModel` only, deliberately not on `BaseUserModel`, `UserModel` or the `Dictifiable` key lists. Those feed `GET /api/users`, and an instance setting `expose_user_name: false` has chosen to hide identity; a real name leaking through that gap would be worse than the username it replaces.
- One writer, `PUT /api/users/{user_id}`. Two write paths would mean two validation sites and undefined precedence.
- Validation is a denylist, not an allowlist: names are free-form and may be in any script, so the rule is length plus the invisible characters (C0/C1 controls, zero-width, bidirectional formatting). The bidi overrides are why the check exists — `U+202E` lets a stored name render as text unrelated to what is saved, which turns a non-unique field into an impersonation vector.
- Deliberately **not** doing: rejecting names that collide with an existing username (a query per save, a nonsensical "taken" error on a non-unique field, trivially bypassed), or an `admin`/`galaxy` denylist (blocks a real given name and a real organisation while `Galaxy Admin` and `GaIaxy` sail through). The anti-impersonation control is that the `@username` stays visible wherever a display name renders.

`UserManager.purge` hashed email and username but would have left `display_name` — free text that typically holds a real name — on the row. It is now dropped on purge; dropped rather than hashed, because unlike the username there is no reason to re-derive it.

Anyone who has already run this branch's migration on a dev database gets the column added normally; the migration is a plain nullable `add_column` and round-trips cleanly.


---

## Email changes via `PUT /api/users/{user_id}`

`PUT /api/users/{user_id}` now accepts `email`.

Changing an email address was previously only possible through `PUT /api/users/{id}/information/inputs`, a legacy `@expose_api` WSGI action that is absent from the OpenAPI schema and therefore invisible to the typed client. A typed endpoint for the same resource already existed and already handled `username`, so this closes the gap rather than adding a third way to write to a user.

The deserializer delegates to `UserManager.update_email(..., commit=False, send_activation_email=True)` — the identical call the legacy handler makes — so the following are unchanged: validation including duplicate addresses and blocked or non-allowlisted domains; the private role rename (the role is named for the email and is what dataset permissions are granted against); and deactivate-and-mail when `user_activation_on` is set. `ModelDeserializer.deserialize` supplies the single trailing commit, which is what lets `update_email` roll back when the activation mail fails to send.

`active` on the same endpoint is now admin-only. It was a bare `setattr` for any authenticated user, which with `user_activation_on` let someone change their email, get deactivated, and then re-activate themselves without ever verifying the new address. That hole predates this PR; the gate is its own commit so it can be backported to the release branches. A non-admin sending `active` gets a 403, and the field description says so. The only client that sends `active` is the admin user grid.

Out of scope, but worth recording: changing an email requires no re-authentication, while changing a password requires the current password. That is pre-existing and unchanged here.


---

## Typed endpoints for extra user preferences

Adds `GET|PUT /api/users/{user_id}/extra_preferences/inputs` and moves the admin-defined extra-preference handling out of the legacy controller into `UsersService`.

`information/inputs` was doing two unrelated jobs: a fixed, typed set of account fields (email, username), and an open-ended set of admin-authored sections from `user_preferences_extra_conf.yml`. The first belongs on the typed user endpoint. The second is genuinely dynamic — its shape comes from an administrator's YAML — so form-JSON and the generic form remain the right tools for it; it just needs its own address rather than being appended to the account page.

The logic **moves**, it is not copied: `information/inputs` now delegates to the same service methods, so the deprecated endpoint and the new one cannot drift apart and every existing caller keeps working. The vault and `__SECRET_PLACEHOLDER__` handling is moved verbatim — it is fiddly, its only coverage needs a real vault, and a regression there would silently overwrite users' stored secrets with the literal placeholder string, so it is deliberately not tidied up on the way past.

Also adds a derived `has_user_preferences_extra` config flag, mirroring `has_user_tool_filters`, so the client can hide the entry on instances that configure nothing rather than linking to an empty form.

`information/inputs` now logs a deprecation warning once per process and carries a `.. deprecated::` note. It should be removed a release from now, together with the `buildapp.py` mapper entries. One loose end for that removal: the `info` conditional (admin `FormDefinition` USER_INFO forms) is the only part of the endpoint with no new home — it is admin-configured and dynamic, the same category as extra preferences, and it would be worth asking the admin community whether any deployment still uses it.


---

## Postal addresses behind `enable_user_addresses`

Adds `enable_user_addresses` (default `true`) gating postal address storage, and deletes two dead helpers.

`UserAddress` is a leftover. Nothing in Galaxy reads these addresses — they are written and read by exactly one place, the deprecated `information/inputs` endpoint. There is no manager, job, tool or quota that consults them. Galaxy's interface no longer offers them at all now that the Account page has replaced the generic form, so this option only affects that deprecated endpoint. It gives administrators a way to stop accepting addresses ahead of the table being dropped, and gives that removal a single line to flip.

The default is `true`, so nothing changes for API consumers today.

`save_widget_field` and `get_form_values` in `webapps/base/controller.py` have no callers anywhere in `lib` or `test`. `get_form_values` was the only code path that could create a `UserAddress` from a generic form, so removing it also removes the last writer outside the deprecated endpoint.

One detail worth a reviewer's eye: the gate wraps the **whole** address block, not just the payload parsing. The block rebuilds `user.addresses` from scratch on every save, so gating only the parsing would have left `user.addresses = []` running unconditionally, silently discarding stored addresses the first time anyone saved with the feature off.

Dropping the table itself needs team sign-off and is irreversible — it would remove `user_address`, `AddressField`, the `address` form-builder type, the GDPR redaction branch, and this option. It is blocked on `test_tools.py::test_model_attributes_sanitization`, which uses an address field as its vehicle for a string containing a double quote and asserts on the `model_attributes` tool's output; that needs a different field first.


---

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `./run_tests.sh -unit test/unit/data/security/test_validate_user_input.py test/unit/app/managers/test_UserManager.py test/unit/data/model/db/test_user.py`
  2. `./run_tests.sh -api lib/galaxy_test/api/test_users.py`
  3. `./run_tests.sh -integration test/integration/test_users.py test/integration/test_vault_extra_prefs.py`
  4. Migration round trip: `sh manage_db.sh upgrade gxy@head`, confirm `galaxy_user.display_name` exists, then `sh manage_db.sh downgrade <previous>` and confirm it is gone. `sh manage_db.sh heads` should still show exactly one `gxy` head.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

