### PR TITLE
Support email changes via PUT /api/users/{user_id}

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -26559,6 +26559,11 @@ export interface components {
              */
             display_name?: string | null;
             /**
+             * Email
+             * @description New email address. When `user_activation_on` is set, changing the email deactivates the account and sends an activation link to the new address.
+             */
+            email?: string | null;
+            /**
              * Preferred Object Store ID
              * @description The ID of the object store that should be used to store new datasets in this history.
              */

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -839,8 +839,18 @@ class UserDeserializer(base.ModelDeserializer):
             "username": self.deserialize_username,
             "display_name": self.deserialize_display_name,
             "preferred_object_store_id": self.deserialize_preferred_object_store_id,
+            "email": self.deserialize_email,
         }
         self.deserializers.update(user_deserializers)
+
+    def deserialize_email(self, item, key, email, trans: ProvidesAppContext | None = None, **context):
+        if trans is None:
+            raise base.ModelDeserializingError("Email addresses cannot be changed in this context.")
+        # update_email keeps the private role in sync and honours user_activation_on.
+        # commit=False because ModelDeserializer.deserialize commits once at the end,
+        # which is also what lets update_email roll back if the activation mail fails.
+        self.manager.update_email(trans, item, email, commit=False, send_activation_email=True)
+        return email
 
     def deserialize_preferred_object_store_id(
         self, item: Any, key: Any, val: Any, trans: ProvidesUserContext | None = None, **context

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -421,6 +421,19 @@ class UserUpdatePayload(Model):
     username: Annotated[str | None, Field(title="Username", description="The name of the user.")] = None
     display_name: Annotated[str | None, UserDisplayNameField] = None
     preferred_object_store_id: Annotated[str | None, PreferredObjectStoreIdField]
+    # Declared last so that a payload combining it with `active` ends on the
+    # deactivation, not on a stale activation. The admin gate on `active` is the
+    # real protection; this is belt and braces.
+    email: Annotated[
+        str | None,
+        Field(
+            title="Email",
+            description=(
+                "New email address. When `user_activation_on` is set, changing the email deactivates the account "
+                "and sends an activation link to the new address."
+            ),
+        ),
+    ] = None
 
 
 class UserCreationPayload(Model):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -20,6 +20,8 @@ TEST_USER_EMAIL_DELETE_CANCEL_JOBS = "user_for_delete_cancel_jobs_test@bx.psu.ed
 TEST_USER_EMAIL_PURGE = "user_for_purge_test@bx.psu.edu"
 TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 TEST_USER_EMAIL_SHOW = "user_for_show_test@bx.psu.edu"
+TEST_USER_EMAIL_UPDATE = "user_for_email_update_test@bx.psu.edu"
+TEST_USER_EMAIL_UPDATED = "user_for_email_update_test_changed@bx.psu.edu"
 
 
 class TestUsersApi(ApiTestCase):
@@ -151,6 +153,27 @@ class TestUsersApi(ApiTestCase):
         self._assert_status_code_is(update_response, 200)
         update_json = update_response.json()
         assert update_json["username"] == payload["username"]
+
+    @requires_new_user
+    def test_update_email(self):
+        user = self._setup_user(TEST_USER_EMAIL_UPDATE)
+        with self._different_user(email=TEST_USER_EMAIL_UPDATE):
+            update_response = self.__update(user, data={"email": TEST_USER_EMAIL_UPDATED})
+            self._assert_status_code_is(update_response, 200)
+            assert update_response.json()["email"] == TEST_USER_EMAIL_UPDATED
+
+    @requires_new_user
+    def test_update_email_invalid(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        other_user = self._setup_user("email_update_conflict@bx.psu.edu")
+        with self._different_user(email=TEST_USER_EMAIL):
+            # malformed
+            update_response = self.__update(user, data={"email": "not-an-email"})
+            self._assert_status_code_is(update_response, 400)
+
+            # already taken by another account
+            update_response = self.__update(user, data={"email": other_user["email"]})
+            self._assert_status_code_is(update_response, 400)
 
     @requires_admin
     @requires_new_user

--- a/test/integration/test_users.py
+++ b/test/integration/test_users.py
@@ -108,6 +108,35 @@ class TestAdminResendActivationEmail(integration_util.IntegrationTestCase):
         config["email_from"] = "galaxy-noreply@example.com"
         config["smtp_server"] = f"mock_emails_to_path://{cls.email_directory}/email.json"
 
+    def test_email_change_deactivates_and_mails_the_new_address(self):
+        old_email = "email-change-before@test.gx"
+        new_email = "email-change-after@test.gx"
+        user = self._setup_user(old_email)
+
+        with self._different_user(email=old_email):
+            response = self._put(f"users/{user['id']}", data={"email": new_email}, json=True)
+            self._assert_status_code_is_ok(response)
+            updated = response.json()
+
+        assert updated["email"] == new_email
+
+        # Changing the address has to re-verify it, otherwise activation is a
+        # one-time gate that any later edit walks straight past. `active` is not on
+        # DetailedUserModel, so it is read back from the index.
+        listed = self._get("users", data={"f_email": new_email}, admin=True).json()
+        assert [u for u in listed if u["email"] == new_email][0]["active"] is False
+
+        with open(os.path.join(self.email_directory, "email.json")) as f:
+            email = json.loads(f.read())
+        assert email["to"] == new_email
+        assert email["subject"] == "Galaxy Account Activation"
+
+        # The private role is named for the email and is what dataset permissions
+        # are granted against, so it has to follow the address.
+        role_names = [role["name"] for role in self._get("roles", admin=True).json()]
+        assert new_email in role_names
+        assert old_email not in role_names
+
     def test_resend_activation_includes_qualified_link(self):
         user = self._setup_user("resend-activation@test.gx")
         response = self._post(f"users/{user['id']}/send_activation_email", admin=True)


### PR DESCRIPTION
`PUT /api/users/{user_id}` now accepts `email`.

Changing an email address was previously only possible through `PUT /api/users/{id}/information/inputs`, a legacy `@expose_api` WSGI action that is absent from the OpenAPI schema and therefore invisible to the typed client. A typed endpoint for the same resource already existed and already handled `username`, so this closes the gap rather than adding a third way to write to a user.

The deserializer delegates to `UserManager.update_email(..., commit=False, send_activation_email=True)` — the identical call the legacy handler makes — so the following are unchanged: validation including duplicate addresses and blocked or non-allowlisted domains; the private role rename (the role is named for the email and is what dataset permissions are granted against); and deactivate-and-mail when `user_activation_on` is set. `ModelDeserializer.deserialize` supplies the single trailing commit, which is what lets `update_email` roll back when the activation mail fails to send.

Out of scope, but worth recording: changing an email requires no re-authentication, while changing a password requires the current password. That is pre-existing and unchanged here.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `./run_tests.sh -api lib/galaxy_test/api/test_users.py -k email`
  2. `./run_tests.sh -integration test/integration/test_users.py -k email_change` — asserts the account is deactivated, the activation mail goes to the **new** address, and the private role follows the rename.
  3. With `user_activation_on: true` in `config/galaxy.yml`, `curl -X PUT -H "Content-Type: application/json" -d '{"email":"new@example.org"}' "$GALAXY/api/users/current?key=$KEY"`, then check the mail sink for a message addressed to `new@example.org` and confirm the account is now inactive.
  4. Sending an address already in use, or a malformed one, returns 400.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
