### PR TITLE
Typed endpoints for extra user preferences

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -6211,6 +6211,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users/{user_id}/extra_preferences/inputs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the administrator-defined extra user preferences as form inputs */
+        get: operations["get_extra_preferences_api_users__user_id__extra_preferences_inputs_get"];
+        /** Save values for the administrator-defined extra user preferences */
+        put: operations["set_extra_preferences_api_users__user_id__extra_preferences_inputs_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/users/{user_id}/favorites/order": {
         parameters: {
             query?: never;
@@ -25957,6 +25975,38 @@ export interface components {
              * @example 0123456789ABCDEF
              */
             id: string;
+        };
+        /**
+         * UserExtraPreferencesInputs
+         * @description Form-builder inputs for the admin-defined extra user preferences.
+         *
+         *     The sections come from ``user_preferences_extra_conf.yml``, so their shape is
+         *     whatever an administrator wrote. Modelling it any further would be fiction.
+         */
+        UserExtraPreferencesInputs: {
+            /**
+             * Inputs
+             * @description One form-builder section per configured group of extra preferences.
+             */
+            inputs?: {
+                [key: string]: unknown;
+            }[];
+        };
+        /**
+         * UserExtraPreferencesPayload
+         * @description Flat map of ``<section>|<input>`` to value, as produced by the generic form.
+         * @default {}
+         */
+        UserExtraPreferencesPayload: {
+            [key: string]: unknown;
+        };
+        /** UserExtraPreferencesUpdated */
+        UserExtraPreferencesUpdated: {
+            /**
+             * Message
+             * @description Human readable confirmation that the preferences were saved.
+             */
+            message: string;
         };
         /** UserFileSourceModel */
         UserFileSourceModel: {
@@ -51314,6 +51364,98 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeletedCustomBuild"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    get_extra_preferences_api_users__user_id__extra_preferences_inputs_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the user. */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserExtraPreferencesInputs"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    set_extra_preferences_api_users__user_id__extra_preferences_inputs_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the user. */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UserExtraPreferencesPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserExtraPreferencesUpdated"];
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1154,6 +1154,9 @@ class GalaxyAppConfiguration(GalaxyAppConfigurationAttributes, BaseAppConfigurat
                     f"Config file ({self.user_preferences_extra_conf_path}) could not be found or is malformed."
                 )
             self.user_preferences_extra = {"preferences": {}}
+        # Lets the client hide the extra preferences entry entirely on instances
+        # that configure none, rather than linking to an empty form.
+        self.has_user_preferences_extra = bool(self.user_preferences_extra.get("preferences"))
 
         # default allow_local_account_creation to false if disable_local_accounts is true
         if "disable_local_accounts" in kwargs and self.disable_local_accounts:

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -176,6 +176,7 @@ class ConfigSerializer(base.ModelSerializer):
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,
             "has_user_tool_filters": _defaults_to(False),
+            "has_user_preferences_extra": _defaults_to(False),
             # TODO: is there no 'correct' way to get an api url? controller='api', action='tools' is a hack
             # at any rate: the following works with path_prefix but is still brittle
             # TODO: change this to (more generic) upload_path and incorporate config.nginx_upload_path into building it

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -436,6 +436,34 @@ class UserUpdatePayload(Model):
     ] = None
 
 
+class UserExtraPreferencesInputs(Model):
+    """Form-builder inputs for the admin-defined extra user preferences.
+
+    The sections come from ``user_preferences_extra_conf.yml``, so their shape is
+    whatever an administrator wrote. Modelling it any further would be fiction.
+    """
+
+    inputs: list[dict[str, Any]] = Field(
+        default_factory=list,
+        title="Inputs",
+        description="One form-builder section per configured group of extra preferences.",
+    )
+
+
+class UserExtraPreferencesPayload(RootModel):
+    """Flat map of ``<section>|<input>`` to value, as produced by the generic form."""
+
+    root: dict[str, Any] = {}
+
+
+class UserExtraPreferencesUpdated(Model):
+    message: str = Field(
+        default=...,
+        title="Message",
+        description="Human readable confirmation that the preferences were saved.",
+    )
+
+
 class UserCreationPayload(Model):
     password: str = Field(default=..., title="user_password", description="The password of the user.")
     email: str = UserEmailField

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -2,7 +2,6 @@
 API operations on User objects.
 """
 
-import copy
 import json
 import logging
 import re
@@ -64,6 +63,9 @@ from galaxy.schema.schema import (
     UserBeaconSetting,
     UserCreationPayload,
     UserDeletionPayload,
+    UserExtraPreferencesInputs,
+    UserExtraPreferencesPayload,
+    UserExtraPreferencesUpdated,
     UserUpdatePayload,
 )
 from galaxy.security.validate_user_input import (
@@ -71,7 +73,6 @@ from galaxy.security.validate_user_input import (
     validate_password,
     validate_publicname,
 )
-from galaxy.security.vault import UserVaultWrapper
 from galaxy.tool_util.toolbox.filters import FilterFactory
 from galaxy.util import (
     docstring_trim,
@@ -96,6 +97,21 @@ from galaxy.webapps.galaxy.services.users import UsersService
 from galaxy.work.context import SessionRequestContext
 
 log = logging.getLogger(__name__)
+
+_information_inputs_deprecation_warned = False
+
+
+def _warn_information_inputs_deprecated() -> None:
+    """Log once per process, so a busy instance does not fill its log with this."""
+    global _information_inputs_deprecation_warned
+    if not _information_inputs_deprecation_warned:
+        _information_inputs_deprecation_warned = True
+        log.warning(
+            "/api/users/{id}/information/inputs is deprecated and will be removed in a future release. "
+            "Use /api/users/{user_id} for email, username and display name, and "
+            "/api/users/{user_id}/extra_preferences/inputs for administrator-defined extra preferences."
+        )
+
 
 router = Router(tags=["users"])
 
@@ -432,6 +448,35 @@ class FastAPIUsers:
         favorites = self.favorites_manager.add(trans, user, object_type, payload.object_id)
         return FavoriteObjectsSummary.model_validate(favorites)
 
+    @router.get(
+        "/api/users/{user_id}/extra_preferences/inputs",
+        name="get_extra_preferences",
+        summary="Return the administrator-defined extra user preferences as form inputs",
+    )
+    def get_extra_preferences(
+        self,
+        user_id: UserIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> UserExtraPreferencesInputs:
+        user = self.service.get_user(trans, user_id)
+        return UserExtraPreferencesInputs(inputs=self.service.build_extra_preferences_inputs(trans, user))
+
+    @router.put(
+        "/api/users/{user_id}/extra_preferences/inputs",
+        name="set_extra_preferences",
+        summary="Save values for the administrator-defined extra user preferences",
+    )
+    def set_extra_preferences(
+        self,
+        user_id: UserIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+        payload: UserExtraPreferencesPayload = Body(default_factory=UserExtraPreferencesPayload),
+    ) -> UserExtraPreferencesUpdated:
+        user = self.service.get_user(trans, user_id)
+        self.service.save_extra_preferences(trans, user, payload.root)
+        trans.sa_session.commit()
+        return UserExtraPreferencesUpdated(message="Extra preferences have been saved.")
+
     @router.put(
         "/api/users/{user_id}/theme/{theme}",
         name="set_theme",
@@ -750,66 +795,21 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         deleted = util.string_as_bool(deleted)
         return self.service.get_user_full(trans, user_id, deleted)
 
-    def _get_extra_user_preferences(self, trans: ProvidesAppContext):
-        """
-        Reads the file user_preferences_extra_conf.yml to display
-        admin defined user informations
-        """
-        return trans.app.config.user_preferences_extra["preferences"]
-
-    def _build_extra_user_pref_inputs(self, trans: ProvidesAppContext, preferences, user):
-        """
-        Build extra user preferences inputs list.
-        Add values to the fields if present
-        """
-        if not preferences:
-            return []
-        extra_pref_inputs = []
-        # Build sections for different categories of inputs
-        user_vault = UserVaultWrapper(trans.app.vault, user)
-        for item, value in preferences.items():
-            if value is not None:
-                input_fields = copy.deepcopy(value["inputs"])
-                for input in input_fields:
-                    help = input.get("help", "")
-                    required = "Required" if util.string_as_bool(input.get("required")) else ""
-                    if help:
-                        input["help"] = f"{help} {required}"
-                    else:
-                        input["help"] = required
-                    if input.get("store") == "vault":
-                        field = f"{item}/{input['name']}"
-                        input["value"] = user_vault.read_secret(f"preferences/{field}")
-                    else:
-                        field = f"{item}|{input['name']}"
-                        for data_item in user.extra_preferences:
-                            if field in data_item:
-                                input["value"] = user.extra_preferences[data_item]
-                    # regardless of the store, do not send secret type values to client
-                    if input.get("type") == "secret":
-                        input["value"] = "__SECRET_PLACEHOLDER__"
-                        # let the client treat it as a password field
-                        input["type"] = "password"
-                extra_pref_inputs.append(
-                    {
-                        "type": "section",
-                        "title": value["description"],
-                        "name": item,
-                        "expanded": True,
-                        "inputs": input_fields,
-                    }
-                )
-        return extra_pref_inputs
-
     @expose_api
     def get_information(self, trans: GalaxyWebTransaction, id, **kwd):
         """
         GET /api/users/{id}/information/inputs
         Return user details such as username, email, addresses etc.
 
+        .. deprecated::
+            Use ``GET /api/users/{user_id}`` for email, username and display name,
+            and ``GET /api/users/{user_id}/extra_preferences/inputs`` for the
+            administrator-defined extra preferences.
+
         :param id: the encoded id of the user
         :type  id: str
         """
+        _warn_information_inputs_deprecated()
         user = self._get_user(trans, id)
         email = user.email
         username = user.username
@@ -901,8 +901,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                 user_info["addresses"] = [address.to_dict(trans) for address in user.addresses]
 
             # Build input sections for extra user preferences
-            extra_user_pref = self._build_extra_user_pref_inputs(trans, self._get_extra_user_preferences(trans), user)
-            for item in extra_user_pref:
+            for item in self.service.build_extra_preferences_inputs(trans, user):
                 inputs.append(item)
         else:
             if user.active_repositories:
@@ -936,12 +935,18 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         PUT /api/users/{id}/information/inputs
         Save a user's email, username, addresses etc.
 
+        .. deprecated::
+            Use ``PUT /api/users/{user_id}`` for email, username and display name,
+            and ``PUT /api/users/{user_id}/extra_preferences/inputs`` for the
+            administrator-defined extra preferences.
+
         :param id: the encoded id of the user
         :type  id: str
 
         :param payload: data with new settings
         :type  payload: dict
         """
+        _warn_information_inputs_deprecated()
         payload = payload or {}
         user = self._get_user(trans, id)
         # Update email
@@ -971,39 +976,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             user.values = form_values
 
         # Update values for extra user preference items
-        extra_user_pref_data = {}
-        extra_pref_keys = self._get_extra_user_preferences(trans)
-        user_vault = UserVaultWrapper(trans.app.vault, user)
-        current_extra_user_pref_data = json.loads(user.preferences.get("extra_user_preferences", "{}"))
-        if extra_pref_keys is not None:
-            for key in extra_pref_keys:
-                key_prefix = f"{key}|"
-                for item in payload:
-                    if item.startswith(key_prefix):
-                        keys = item.split("|")
-                        section = extra_pref_keys[keys[0]]
-                        matching_input = [input for input in section["inputs"] if input["name"] == keys[1]]
-                        if matching_input:
-                            input = matching_input[0]
-                            if input.get("required") and payload[item] == "":
-                                raise exceptions.ObjectAttributeMissingException("Please fill the required field")
-                            input_type = input.get("type")
-                            is_secret_value_unchanged = (
-                                input_type == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"
-                            )
-                            is_stored_in_vault = input.get("store") == "vault"
-                            if is_secret_value_unchanged:
-                                if not is_stored_in_vault:
-                                    # If the value is unchanged, keep the current value
-                                    extra_user_pref_data[item] = current_extra_user_pref_data.get(item, "")
-                            else:
-                                if is_stored_in_vault:
-                                    user_vault.write_secret(f"preferences/{keys[0]}/{keys[1]}", str(payload[item]))
-                                else:
-                                    extra_user_pref_data[item] = payload[item]
-                        else:
-                            extra_user_pref_data[item] = payload[item]
-            user.preferences["extra_user_preferences"] = json.dumps(extra_user_pref_data)
+        self.service.save_extra_preferences(trans, user, payload)
 
         # Update user addresses
         address_dicts: dict[int, dict[str, Any]] = {}

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -1,4 +1,7 @@
+import copy
+import json
 from typing import (
+    Any,
     TYPE_CHECKING,
 )
 
@@ -33,6 +36,7 @@ from galaxy.schema.schema import (
     UserModel,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.security.vault import UserVaultWrapper
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.roles import role_to_model
 
@@ -114,6 +118,104 @@ class UsersService(ServiceBase):
             raise glx_exceptions.InsufficientPermissionsException("Access denied.")
         user = self.user_manager.by_id(user_id)
         return user
+
+    def get_extra_preferences(self, trans: ProvidesUserContext) -> dict[str, Any] | None:
+        """The admin-defined sections from ``user_preferences_extra_conf.yml``.
+
+        None when the file declares a ``preferences`` key with nothing under it,
+        which is why callers guard against it rather than assuming a dict.
+        """
+        return trans.app.config.user_preferences_extra["preferences"]
+
+    def build_extra_preferences_inputs(self, trans: ProvidesUserContext, user: User) -> list[dict[str, Any]]:
+        """
+        Build the form-builder input list for the admin-defined extra preferences,
+        filling in the user's stored values.
+
+        The shape is deliberately untyped form JSON: the sections come from admin
+        authored YAML, so there is no fixed schema to model.
+        """
+        preferences = self.get_extra_preferences(trans)
+        if not preferences:
+            return []
+        extra_pref_inputs = []
+        # Build sections for different categories of inputs
+        user_vault = UserVaultWrapper(trans.app.vault, user)
+        for item, value in preferences.items():
+            if value is not None:
+                input_fields = copy.deepcopy(value["inputs"])
+                for input in input_fields:
+                    help = input.get("help", "")
+                    required = "Required" if util.string_as_bool(input.get("required")) else ""
+                    if help:
+                        input["help"] = f"{help} {required}"
+                    else:
+                        input["help"] = required
+                    if input.get("store") == "vault":
+                        field = f"{item}/{input['name']}"
+                        input["value"] = user_vault.read_secret(f"preferences/{field}")
+                    else:
+                        field = f"{item}|{input['name']}"
+                        for data_item in user.extra_preferences:
+                            if field in data_item:
+                                input["value"] = user.extra_preferences[data_item]
+                    # regardless of the store, do not send secret type values to client
+                    if input.get("type") == "secret":
+                        input["value"] = "__SECRET_PLACEHOLDER__"
+                        # let the client treat it as a password field
+                        input["type"] = "password"
+                extra_pref_inputs.append(
+                    {
+                        "type": "section",
+                        "title": value["description"],
+                        "name": item,
+                        "expanded": True,
+                        "inputs": input_fields,
+                    }
+                )
+        return extra_pref_inputs
+
+    def save_extra_preferences(self, trans: ProvidesUserContext, user: User, payload: dict[str, Any]) -> None:
+        """
+        Store values for the admin-defined extra preferences.
+
+        Payload keys are flat ``<section>|<input>`` pairs, as produced by the
+        generic form. Secrets are either written to the user vault or kept in the
+        user's preferences; a secret that comes back as the placeholder means the
+        client never saw it and the stored value must be left alone.
+        """
+        extra_user_pref_data = {}
+        extra_pref_keys = self.get_extra_preferences(trans)
+        if extra_pref_keys is None:
+            return
+        user_vault = UserVaultWrapper(trans.app.vault, user)
+        current_extra_user_pref_data = json.loads(user.preferences.get("extra_user_preferences", "{}"))
+        for key in extra_pref_keys:
+            key_prefix = f"{key}|"
+            for item in payload:
+                if item.startswith(key_prefix):
+                    keys = item.split("|")
+                    section = extra_pref_keys[keys[0]]
+                    matching_input = [input for input in section["inputs"] if input["name"] == keys[1]]
+                    if matching_input:
+                        input = matching_input[0]
+                        if input.get("required") and payload[item] == "":
+                            raise glx_exceptions.ObjectAttributeMissingException("Please fill the required field")
+                        input_type = input.get("type")
+                        is_secret_value_unchanged = input_type == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"
+                        is_stored_in_vault = input.get("store") == "vault"
+                        if is_secret_value_unchanged:
+                            if not is_stored_in_vault:
+                                # If the value is unchanged, keep the current value
+                                extra_user_pref_data[item] = current_extra_user_pref_data.get(item, "")
+                        else:
+                            if is_stored_in_vault:
+                                user_vault.write_secret(f"preferences/{keys[0]}/{keys[1]}", str(payload[item]))
+                            else:
+                                extra_user_pref_data[item] = payload[item]
+                    else:
+                        extra_user_pref_data[item] = payload[item]
+        user.preferences["extra_user_preferences"] = json.dumps(extra_user_pref_data)
 
     def _anon_user_api_value(self, trans: ProvidesHistoryContext):
         """Return data for an anonymous user, truncated to only usage and quota_percent"""

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -175,6 +175,27 @@ class TestUsersApi(ApiTestCase):
             update_response = self.__update(user, data={"email": other_user["email"]})
             self._assert_status_code_is(update_response, 400)
 
+    @requires_new_user
+    def test_extra_preferences_inputs(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        with self._different_user(email=TEST_USER_EMAIL):
+            response = self._get(f"users/{user['id']}/extra_preferences/inputs")
+            self._assert_status_code_is(response, 200)
+            # The default test instance configures no extra preferences.
+            assert response.json()["inputs"] == []
+
+            response = self._put(f"users/{user['id']}/extra_preferences/inputs", data={}, json=True)
+            self._assert_status_code_is(response, 200)
+            assert "message" in response.json()
+
+    @requires_new_user
+    def test_extra_preferences_inputs_other_user_forbidden(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        self._setup_user("extra_prefs_other@bx.psu.edu")
+        with self._different_user(email="extra_prefs_other@bx.psu.edu"):
+            response = self._get(f"users/{user['id']}/extra_preferences/inputs")
+            self._assert_status_code_is(response, 403)
+
     @requires_admin
     @requires_new_user
     def test_delete_user(self):

--- a/test/integration/test_vault_extra_prefs.py
+++ b/test/integration/test_vault_extra_prefs.py
@@ -27,7 +27,7 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_vault_storage(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
@@ -83,7 +83,7 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_vault_storage_update_secret(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
@@ -131,7 +131,7 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
 
     def test_extra_prefs_secret_not_in_vault(self):
         user = self._setup_user(TEST_USER_EMAIL)
-        url = self.__url("information/inputs", user)
+        url = self.__url("extra_preferences/inputs", user)
         app = cast(Any, self._test_driver.app if self._test_driver else None)
         db_user = self._get_dbuser(app, user)
 
@@ -211,6 +211,25 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         # the secret value should be updated in the internal user preferences model
         app.model.session.refresh(db_user)
         assert db_user.extra_preferences["non_vault_test_section|pass"] == "a_new_test_pass"
+
+    def test_legacy_information_inputs_still_serves_extra_prefs(self):
+        # The deprecated endpoint delegates to the same service code, so it has to
+        # keep working until it is removed.
+        user = self._setup_user("vault-legacy-shim@test.gx")
+        legacy_url = self.__url("information/inputs", user)
+
+        put(legacy_url, data=json.dumps({"vaulttestsection|client_id": "legacy_client_id"}))
+
+        response = get(legacy_url).json()
+        section = [section for section in response["inputs"] if section["name"] == "vaulttestsection"][0]
+        client_id = [input for input in section["inputs"] if input["name"] == "client_id"][0]
+        assert client_id["value"] == "legacy_client_id"
+
+        # and the typed endpoint sees the same stored value
+        typed_response = get(self.__url("extra_preferences/inputs", user)).json()
+        typed_section = [section for section in typed_response["inputs"] if section["name"] == "vaulttestsection"][0]
+        typed_client_id = [input for input in typed_section["inputs"] if input["name"] == "client_id"][0]
+        assert typed_client_id["value"] == "legacy_client_id"
 
     def __url(self, action, user):
         return self._api_url(f"users/{user['id']}/{action}", params=dict(key=self.master_api_key))


### PR DESCRIPTION
Adds `GET|PUT /api/users/{user_id}/extra_preferences/inputs` and moves the admin-defined extra-preference handling out of the legacy controller into `UsersService`.

`information/inputs` was doing two unrelated jobs: a fixed, typed set of account fields (email, username), and an open-ended set of admin-authored sections from `user_preferences_extra_conf.yml`. The first belongs on the typed user endpoint. The second is genuinely dynamic — its shape comes from an administrator's YAML — so form-JSON and the generic form remain the right tools for it; it just needs its own address rather than being appended to the account page.

The logic **moves**, it is not copied: `information/inputs` now delegates to the same service methods, so the deprecated endpoint and the new one cannot drift apart and every existing caller keeps working. The vault and `__SECRET_PLACEHOLDER__` handling is moved verbatim — it is fiddly, its only coverage needs a real vault, and a regression there would silently overwrite users' stored secrets with the literal placeholder string, so it is deliberately not tidied up on the way past.

Also adds a derived `has_user_preferences_extra` config flag, mirroring `has_user_tool_filters`, so the client can hide the entry on instances that configure nothing rather than linking to an empty form.

`information/inputs` now logs a deprecation warning once per process and carries a `.. deprecated::` note. It should be removed a release from now, together with the `buildapp.py` mapper entries. One loose end for that removal: the `info` conditional (admin `FormDefinition` USER_INFO forms) is the only part of the endpoint with no new home — it is admin-configured and dynamic, the same category as extra preferences, and it would be worth asking the admin community whether any deployment still uses it.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `./run_tests.sh -api lib/galaxy_test/api/test_users.py -k extra_preferences`
  2. `./run_tests.sh -integration test/integration/test_vault_extra_prefs.py` — the suite moves to the new endpoint and keeps one case pointed at the deprecated one, which is what proves the delegation works rather than the two paths having quietly diverged.
  3. Point `user_preferences_extra_conf_path` at `lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample` and restart. `GET /api/users/current/extra_preferences/inputs` returns one form-builder section per configured group; `GET /api/users/{id}/information/inputs` returns the same sections.
  4. **Secret round trip:** PUT a `store: vault` secret, GET again and confirm the field reads `__SECRET_PLACEHOLDER__` rather than the value, then PUT again *without touching that field* and confirm server-side that the stored secret is unchanged — it must not have been overwritten with the placeholder.
  5. Requesting another user's extra preferences as a non-admin returns 403.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
