### PR TITLE
Group user preferences under headings

### DIFF
--- a/client/src/components/Form/FormCard.vue
+++ b/client/src/components/Form/FormCard.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="ui-portlet-section">
-        <div :tabindex="collapsible ? 0 : -1" :class="portletHeaderClasses" @keydown="onKeyDown" @click="onCollapse">
+        <div
+            :tabindex="collapsible ? 0 : -1"
+            class="mb-2"
+            :class="portletHeaderClasses"
+            @keydown="onKeyDown"
+            @click="onCollapse">
             <div class="portlet-operations">
                 <slot name="operations" />
                 <GButton

--- a/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
@@ -1,5 +1,7 @@
 <template>
     <section class="external-id">
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
         <b-alert :show="!!connectExternal" variant="info">
             You are logged in. You can now connect the Galaxy user account with the email <i>{{ userEmail }}</i
             >, to your preferred external provider.
@@ -18,10 +20,6 @@
                 @dismissed="errorMessage = null"
                 >{{ errorMessage }}</b-alert
             >
-
-            <hgroup class="external-id-title">
-                <h1 class="h-lg">Manage External Identities</h1>
-            </hgroup>
 
             <p>
                 Users with existing Galaxy user accounts (e.g., via Galaxy username and password) can associate their
@@ -81,12 +79,14 @@ import { capitalizeFirstLetter } from "@/utils/strings";
 
 import svc from "./service";
 
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import ExternalLogin from "@/components/User/ExternalIdentities/ExternalLogin.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
+        BreadcrumbHeading,
         ExternalLogin,
     },
     setup() {
@@ -99,6 +99,7 @@ export default {
         const galaxy = getGalaxyInstance();
         return {
             items: [],
+            breadcrumbItems: [{ title: "User Preferences", to: "/user" }, { title: "Manage External Identities" }],
             showHelp: true,
             loading: false,
             doomedItem: null,

--- a/client/src/components/User/UserPreferences.test.ts
+++ b/client/src/components/User/UserPreferences.test.ts
@@ -39,6 +39,18 @@ vi.mock("@/composables/confirmDialog", () => ({
 const localVue = getLocalVue();
 localVue.use(VueRouter);
 
+const STUBS = {
+    BreadcrumbHeading: true,
+    UserDetailsElement: true,
+    UserPreferencesElement: true,
+    Heading: true,
+    BAlert: true,
+    UserPickTheme: true,
+    UserBeaconSettings: true,
+    UserPreferredObjectStore: true,
+    UserDeletion: true,
+};
+
 describe("UserPreferences.vue", () => {
     const mockPreferences = (passwordDisabled: boolean) => {
         // @ts-expect-error - getUserPreferencesModel is mocked
@@ -77,17 +89,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#oidc-profile").exists()).toBe(true);
@@ -110,17 +112,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#oidc-profile").exists()).toBe(false);
@@ -148,20 +140,49 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#edit-preferences-password").exists()).toBe(false);
+    });
+
+    it("always offers the account page", async () => {
+        vi.mocked(useConfig).mockReturnValue({
+            config: computed(() => ({ oidc: {}, themes: {} })),
+            isConfigLoaded: computed(() => true),
+        });
+
+        const wrapper = shallowMount(UserPreferences, {
+            localVue,
+            router: new VueRouter(),
+            pinia: createTestingPinia({ createSpy: vi.fn }),
+            stubs: STUBS,
+        });
+
+        expect(wrapper.find("#edit-preferences-information").exists()).toBe(true);
+    });
+
+    it.each([
+        [true, true],
+        [false, false],
+    ])("shows the extra configurations entry when configured: %s", async (configured, expected) => {
+        vi.mocked(useConfig).mockReturnValue({
+            config: computed(() => ({
+                oidc: {},
+                themes: {},
+                has_user_preferences_extra: configured,
+            })),
+            isConfigLoaded: computed(() => true),
+        });
+
+        const wrapper = shallowMount(UserPreferences, {
+            localVue,
+            router: new VueRouter(),
+            pinia: createTestingPinia({ createSpy: vi.fn }),
+            stubs: STUBS,
+        });
+
+        expect(wrapper.find("#edit-preferences-extra").exists()).toBe(expected);
     });
 
     it("shows password preference when allowed", async () => {
@@ -179,17 +200,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#edit-preferences-password").exists()).toBe(true);

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -15,6 +15,7 @@ import {
     faPerson,
     faRadiation,
     faSignOut,
+    faSliders,
     faUser,
     faUsers,
 } from "font-awesome-6";
@@ -64,11 +65,20 @@ const showDeleteAccountModal = ref(false);
 const showDataPrivateModal = ref(false);
 const showThemPickerModal = ref(false);
 
+// The remaining generic-form preferences are placed by hand rather than looped
+// over, because they belong in different groups: the password sits with account
+// and sign-in, toolbox filters with data and tools.
 const activePreferences = computed(() => {
     const userPreferencesEntries = getUserPreferencesModel();
     const enabledPreferences = Object.entries(userPreferencesEntries).filter(([, value]) => !value.disabled);
     return Object.fromEntries(enabledPreferences);
 });
+
+const passwordPreference = computed(() => activePreferences.value.password);
+
+const toolboxFiltersPreference = computed(() => activePreferences.value.toolbox_filters);
+
+const hasExtraPreferences = computed(() => isConfigLoaded.value && Boolean(config.value.has_user_preferences_extra));
 // Show the OIDC profile management widget if local account editing is disabled and OIDC profile is configured
 // through a single provider
 const showOidcProfile = computed<boolean>(() => {
@@ -181,6 +191,8 @@ onMounted(async () => {
         <UserDetailsElement />
 
         <div class="d-flex flex-gapy-1 flex-column">
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Account and sign-in</Heading>
+
             <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="showOidcProfile"
@@ -198,14 +210,32 @@ onMounted(async () => {
                     to="/user/information" />
 
                 <UserPreferencesElement
-                    v-for="(link, index) in activePreferences"
-                    :id="link.id"
-                    :key="index"
-                    :icon="link.icon"
-                    :title="link.title"
-                    :description="link.description"
-                    :to="`/user/${index}`" />
+                    v-if="passwordPreference"
+                    :id="passwordPreference.id"
+                    :icon="passwordPreference.icon"
+                    :title="passwordPreference.title"
+                    :description="passwordPreference.description"
+                    to="/user/password" />
 
+                <UserPreferencesElement
+                    v-if="isConfigLoaded && config.enable_oidc && !config.fixed_delegated_auth"
+                    id="manage-third-party-identities"
+                    :icon="faIdCard"
+                    :title="localize('Manage Third-Party Identities')"
+                    :description="localize('Connect or disconnect access to your third-party identities.')"
+                    to="/user/external_ids" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-api-key"
+                    :icon="faKey"
+                    :title="localize('Manage Galaxy API Key')"
+                    :description="localize('Access your current Galaxy API key or create a new one.')"
+                    to="/user/api_key" />
+            </div>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Sharing and privacy</Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="isConfigLoaded && !config.single_user"
                     id="edit-preferences-permissions"
@@ -217,50 +247,6 @@ onMounted(async () => {
                         )
                     "
                     to="/user/permissions" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-api-key"
-                    :icon="faKey"
-                    :title="localize('Manage Galaxy API Key')"
-                    :description="localize('Access your current Galaxy API key or create a new one.')"
-                    to="/user/api_key" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-credentials"
-                    :icon="faKey"
-                    :title="localize('Manage Your Tools Credentials')"
-                    :description="localize('Manage your tools credentials groups for accessing external services.')"
-                    to="/user/credentials" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-notifications"
-                    :icon="faBell"
-                    :title="localize('Manage Notifications')"
-                    :description="localize('Manage your notification settings.')"
-                    to="/user/notifications/preferences" />
-
-                <UserPreferencesElement
-                    v-if="isConfigLoaded && config.enable_oidc && !config.fixed_delegated_auth"
-                    id="manage-third-party-identities"
-                    :icon="faIdCard"
-                    :title="localize('Manage Third-Party Identities')"
-                    :description="localize('Connect or disconnect access to your third-party identities.')"
-                    to="/user/external_ids" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-custom-builds"
-                    :icon="faCubes"
-                    :title="localize('Manage Custom Builds')"
-                    :description="localize('Add or remove custom builds using history datasets.')"
-                    to="/custom_builds" />
-
-                <UserPreferencesElement
-                    v-if="hasThemes"
-                    id="edit-preferences-theme"
-                    :icon="faPalette"
-                    :title="localize('Pick a Color Theme')"
-                    :description="localize('Click here to change the user interface color theme.')"
-                    @click="toggleThemeModal" />
 
                 <UserPreferencesElement
                     v-if="isConfigLoaded && !config.single_user"
@@ -277,7 +263,32 @@ onMounted(async () => {
                     :title="localize('Manage Beacon')"
                     :description="localize('Contribute variants to Beacon')"
                     @click="toggleBeaconModal" />
+            </div>
 
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">
+                Appearance and notifications
+            </Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
+                <UserPreferencesElement
+                    v-if="hasThemes"
+                    id="edit-preferences-theme"
+                    :icon="faPalette"
+                    :title="localize('Pick a Color Theme')"
+                    :description="localize('Click here to change the user interface color theme.')"
+                    @click="toggleThemeModal" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-notifications"
+                    :icon="faBell"
+                    :title="localize('Manage Notifications')"
+                    :description="localize('Manage your notification settings.')"
+                    to="/user/notifications/preferences" />
+            </div>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Data and tools</Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="isConfigLoaded && config.object_store_allows_id_selection"
                     id="manage-preferred-object-store"
@@ -307,7 +318,46 @@ onMounted(async () => {
                         )
                     "
                     to="/file_source_instances/index" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-credentials"
+                    :icon="faKey"
+                    :title="localize('Manage Your Tools Credentials')"
+                    :description="localize('Manage your tools credentials groups for accessing external services.')"
+                    to="/user/credentials" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-custom-builds"
+                    :icon="faCubes"
+                    :title="localize('Manage Custom Builds')"
+                    :description="localize('Add or remove custom builds using history datasets.')"
+                    to="/custom_builds" />
+
+                <UserPreferencesElement
+                    v-if="toolboxFiltersPreference"
+                    :id="toolboxFiltersPreference.id"
+                    :icon="toolboxFiltersPreference.icon"
+                    :title="toolboxFiltersPreference.title"
+                    :description="toolboxFiltersPreference.description"
+                    to="/user/toolbox_filters" />
             </div>
+
+            <template v-if="hasExtraPreferences">
+                <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Instance settings</Heading>
+
+                <div class="d-flex flex-wrap mb-4 user-preferences-cards">
+                    <UserPreferencesElement
+                        id="edit-preferences-extra"
+                        :icon="faSliders"
+                        :title="localize('Extra Configurations')"
+                        :description="
+                            localize('Settings this Galaxy instance defines, such as external service credentials.')
+                        "
+                        to="/user/extra_preferences" />
+                </div>
+            </template>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Danger zone</Heading>
 
             <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement

--- a/client/src/components/User/UserPreferencesModel.test.ts
+++ b/client/src/components/User/UserPreferencesModel.test.ts
@@ -59,4 +59,21 @@ describe("getUserPreferencesModel", () => {
         const prefs = getUserPreferencesModel("user-id");
         expect(prefs.password.disabled).toBe(false);
     });
+
+    it("disables extra preferences when the instance configures none", () => {
+        mockConfig({ has_user_preferences_extra: false, themes: {} });
+
+        const prefs = getUserPreferencesModel("user-id");
+        expect(prefs.extra_preferences.disabled).toBe(true);
+    });
+
+    it("points extra preferences at the typed endpoint when configured", () => {
+        mockConfig({ has_user_preferences_extra: true, themes: {} });
+
+        const prefs = getUserPreferencesModel("user-id");
+        expect(prefs.extra_preferences.disabled).toBe(false);
+        expect(prefs.extra_preferences.url).toBe("/api/users/user-id/extra_preferences/inputs");
+        // The generic form redirects back to the preferences index on save.
+        expect(prefs.extra_preferences.redirect).toBe("/user");
+    });
 });

--- a/client/src/components/User/UserPreferencesModel.ts
+++ b/client/src/components/User/UserPreferencesModel.ts
@@ -1,4 +1,4 @@
-import { faFilter, faUnlockAlt, type IconDefinition } from "font-awesome-6";
+import { faFilter, faSliders, faUnlockAlt, type IconDefinition } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 
 import { isRegisteredUser } from "@/api";
@@ -6,7 +6,7 @@ import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 
-export type UserPreferencesKey = "password" | "toolbox_filters";
+export type UserPreferencesKey = "password" | "toolbox_filters" | "extra_preferences";
 
 interface UserPreference {
     title: string;
@@ -53,6 +53,16 @@ export const getUserPreferencesModel: (user_id?: string) => UserPreferencesModel
             submitTitle: "Save Filters",
             redirect: "/user",
             disabled: isConfigLoaded.value && !config.value.has_user_tool_filters,
+        },
+        extra_preferences: {
+            title: localize("Extra Configurations"),
+            id: "edit-preferences-extra",
+            description: localize("Settings this Galaxy instance defines, such as external service credentials."),
+            url: `/api/users/${user_id}/extra_preferences/inputs`,
+            icon: faSliders,
+            submitTitle: "Save Settings",
+            redirect: "/user",
+            disabled: isConfigLoaded.value && !config.value.has_user_preferences_extra,
         },
     };
 };


### PR DESCRIPTION
Groups the User Preferences cards under headings and adds an **Extra Configurations** entry.

Seventeen undifferentiated cards are a wall to scan, and the ordering carried no meaning — storage sat between a theme picker and a privacy switch. Every card is unchanged, and the click depth is the same; they are now grouped by what someone is actually trying to do:

- **Account and sign-in** — Account, Change Password, Third-Party Identities, API Key
- **Sharing and privacy** — Dataset Permissions, Make All Data Private, Beacon
- **Appearance and notifications** — Color Theme, Notifications
- **Data and tools** — Storage, Repositories, Tool Credentials, Custom Builds, Toolbox Filters
- **Instance settings** — Extra Configurations
- **Danger zone** — Delete Account, Sign Out of All Sessions

Password and toolbox filters are placed manually rather than looped over because they belong to different groups.

**Extra Configurations** is the settings an administrator defines for this instance — external service credentials and the like. They used to be appended to the bottom of Manage Information, where, on a busy instance, they buried email and username below the fold. They now have their own entry, pointed at the typed `extra_preferences/inputs` endpoint, and the whole group is hidden on instances that configure none rather than linking to an empty form.

|Before|After|
|---|---|
|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/5876d793-6abb-4b3a-976c-0cc2aeda8ea4" />|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/c2730504-5f15-479d-bab9-2948e7b42b7b" />|

### Extra Configurations `/user/extra_preferences`
<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/fa2d1649-744a-4585-9554-302fafe9d856" />


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make client-test` — `UserPreferences.test.ts` covers the account entry always being present and the extra-configurations entry appearing only when configured; `UserPreferencesModel.test.ts` covers the endpoint it points at.
  2. `sh run.sh` and `make client-dev-server`, then open `/user`: five headings in order, each card under a sensible one, and every card still navigates where it did before.
  3. With no `user_preferences_extra_conf.yml` configured, the **Instance settings** group is absent entirely.
  4. Point `user_preferences_extra_conf_path` at `lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample`, restart, and reload `/user`: the group appears, and the card opens a form with one section per configured group.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
