### PR TITLE
Gate postal addresses behind enable_user_addresses

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -477,9 +477,14 @@
     process composes its named store with the default
     (``tool_source_database_connection``) store at runtime, with reads
     tried in declared order and writes always landing on the default.
-    Each entry takes a SQLAlchemy ``url`` and an optional ``read_only:
-    true`` flag. For SQLite connection-level read-only, use a SQLite
-    URI with ``mode=ro&uri=true``.
+    Each entry takes either a normal SQLAlchemy ``url`` or an
+    ``external_store_directory`` containing versioned publisher
+    bundles. Galaxy never consults manifests for a normal URL. For an
+    external directory it reads the sidecars and automatically selects
+    the newest cohort compatible with its store/source/index formats
+    and index schema. External stores are always read-only.
+    For SQLite connection-level read-only, use a SQLite URI with
+    ``mode=ro&uri=true``.
     For details see
     https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
 :Default: ``None``
@@ -2072,6 +2077,21 @@
 :Description:
     Allow users to manage their account data, change passwords or
     delete their accounts.
+:Default: ``true``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_user_addresses``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Allow users to store postal addresses on their account, through
+    the deprecated /api/users/{id}/information/inputs endpoint.
+    This feature is deprecated and the user_address table will be
+    removed in a future release. Galaxy's own interface no longer
+    offers these addresses, so this option only affects that endpoint;
+    set it to false to stop accepting them ahead of the removal.
 :Default: ``true``
 :Type: bool
 

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -159,6 +159,7 @@ class GalaxyAppConfigurationAttributes:
     inactivity_box_content: str
     password_expiration_period: timedelta
     enable_account_interface: bool
+    enable_user_addresses: bool
     session_duration: int
     ga_code: str | None
     plausible_server: str | None

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -620,11 +620,13 @@ galaxy:
   # (``tool_source_database_connection``) store at runtime, with reads
   # tried in declared order and writes always landing on the default.
   # Each entry takes either a normal SQLAlchemy ``url`` or an
-  # ``external_store_directory`` of versioned publisher bundles. Manifests
-  # are ignored for normal URL stores. Galaxy automatically selects the
-  # newest manifest-compatible bundle from an external directory, which is
-  # always read-only. For an explicit SQLite URL, use ``mode=ro&uri=true``
-  # when connection-level read-only behavior is wanted.
+  # ``external_store_directory`` containing versioned publisher bundles.
+  # Galaxy never consults manifests for a normal URL. For an external
+  # directory it reads the sidecars and automatically selects the newest
+  # cohort compatible with its store/source/index formats and index
+  # schema. External stores are always read-only.
+  # For SQLite connection-level read-only, use a SQLite URI with
+  # ``mode=ro&uri=true``.
   # For details see
   # https://docs.galaxyproject.org/en/master/admin/tool_source_storage.html
   #tool_source_stores: null
@@ -1399,6 +1401,14 @@ galaxy:
   # Allow users to manage their account data, change passwords or delete
   # their accounts.
   #enable_account_interface: true
+
+  # Allow users to store postal addresses on their account, through the
+  # deprecated /api/users/{id}/information/inputs endpoint.
+  # This feature is deprecated and the user_address table will be
+  # removed in a future release. Galaxy's own interface no longer offers
+  # these addresses, so this option only affects that endpoint; set it
+  # to false to stop accepting them ahead of the removal.
+  #enable_user_addresses: true
 
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this
@@ -3443,3 +3453,4 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1561,6 +1561,19 @@ mapping:
           Allow users to manage their account data, change passwords or delete their
           accounts.
 
+      enable_user_addresses:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Allow users to store postal addresses on their account, through the
+          deprecated /api/users/{id}/information/inputs endpoint.
+
+          This feature is deprecated and the user_address table will be removed in a
+          future release. Galaxy's own interface no longer offers these addresses,
+          so this option only affects that endpoint; set it to false to stop
+          accepting them ahead of the removal.
+
       session_duration:
         type: int
         default: 0

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -59,11 +59,6 @@ from galaxy.web import (
     error,
     url_for,
 )
-from galaxy.web.form_builder import (
-    AddressField,
-    CheckboxField,
-    PasswordField,
-)
 from galaxy.workflow.modules import WorkflowModuleInjector
 
 if TYPE_CHECKING:
@@ -699,54 +694,6 @@ class UsesFormDefinitionsMixin:
             return [fdc.latest_form for fdc in fdc_list]
         else:
             return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
-
-    def save_widget_field(self, trans: ProvidesUserContext, field_obj, widget_name, **kwd):
-        # Save a form_builder field object
-        params = util.Params(kwd)
-        if isinstance(field_obj, trans.model.UserAddress):
-            field_obj.desc = util.restore_text(params.get(f"{widget_name}_short_desc", ""))
-            field_obj.name = util.restore_text(params.get(f"{widget_name}_name", ""))
-            field_obj.institution = util.restore_text(params.get(f"{widget_name}_institution", ""))
-            field_obj.address = util.restore_text(params.get(f"{widget_name}_address", ""))
-            field_obj.city = util.restore_text(params.get(f"{widget_name}_city", ""))
-            field_obj.state = util.restore_text(params.get(f"{widget_name}_state", ""))
-            field_obj.postal_code = util.restore_text(params.get(f"{widget_name}_postal_code", ""))
-            field_obj.country = util.restore_text(params.get(f"{widget_name}_country", ""))
-            field_obj.phone = util.restore_text(params.get(f"{widget_name}_phone", ""))
-            trans.sa_session.add(field_obj)
-            trans.sa_session.commit()
-
-    def get_form_values(self, trans: ProvidesUserContext, user, form_definition, **kwd):
-        """
-        Returns the name:value dictionary containing all the form values
-        """
-        params = util.Params(kwd)
-        values = {}
-        for field in form_definition.fields:
-            field_type = field["type"]
-            field_name = field["name"]
-            input_value = params.get(field_name, "")
-            field_value: int | str | bool
-            if field_type == AddressField.__name__:
-                input_text_value = util.restore_text(input_value)
-                if input_text_value == "new":
-                    # Save this new address in the list of this user's addresses
-                    user_address = trans.model.UserAddress(user=user)
-                    self.save_widget_field(trans, user_address, field_name, **kwd)
-                    trans.sa_session.refresh(user)
-                    field_value = int(user_address.id)
-                elif input_text_value in ["", "none", "None", None]:
-                    field_value = ""
-                else:
-                    field_value = int(input_text_value)
-            elif field_type == CheckboxField.__name__:
-                field_value = CheckboxField.is_checked(input_value)
-            elif field_type == PasswordField.__name__:
-                field_value = kwd.get(field_name, "")
-            else:
-                field_value = util.restore_text(input_value)
-            values[field_name] = field_value
-        return values
 
 
 class SharableMixin:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -878,7 +878,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                     info_field["cases"].append({"value": info_form["id"], "inputs": info_form["inputs"]})
                 inputs.append(info_field)
 
-            if trans.app.config.enable_account_interface:
+            if trans.app.config.enable_account_interface and trans.app.config.enable_user_addresses:
                 address_inputs = [{"type": "hidden", "name": "id", "hidden": True}]
                 for field in AddressField.fields():
                     address_inputs.append({"type": "text", "name": field[0], "label": field[1], "help": field[2]})
@@ -978,38 +978,41 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         # Update values for extra user preference items
         self.service.save_extra_preferences(trans, user, payload)
 
-        # Update user addresses
-        address_dicts: dict[int, dict[str, Any]] = {}
-        address_count = 0
-        for item in payload:
-            match = re.match(r"^address_(?P<index>\d+)\|(?P<attribute>\S+)", item)
-            if match:
-                groups = match.groupdict()
-                index = int(groups["index"])
-                attribute = groups["attribute"]
-                address_dicts[index] = address_dicts.get(index) or {}
-                address_dicts[index][attribute] = payload[item]
-                address_count = max(address_count, index + 1)
-        user.addresses = []
-        for index in range(0, address_count):
-            d = address_dicts[index]
-            if d.get("id"):
-                try:
-                    user_address = trans.sa_session.get(UserAddress, trans.security.decode_id(d["id"]))
-                except Exception as e:
-                    raise exceptions.ObjectNotFound(f"Failed to access user address ({d['id']}). {e}")
-            else:
-                user_address = UserAddress()
-                trans.log_event("User address added")
-            for field in AddressField.fields():
-                if str(field[2]).lower() == "required" and not d.get(field[0]):
-                    raise exceptions.ObjectAttributeMissingException(
-                        f"Address {index + 1}: {field[1]} ({field[0]}) required."
-                    )
-                setattr(user_address, field[0], str(d.get(field[0], "")))
-            user_address.user = user
-            user.addresses.append(user_address)
-            trans.sa_session.add(user_address)
+        # Update user addresses. The whole block is gated, not just the parsing:
+        # it rebuilds user.addresses from the payload, so running it while the
+        # feature is off would silently discard whatever is stored.
+        if trans.app.config.enable_user_addresses:
+            address_dicts: dict[int, dict[str, Any]] = {}
+            address_count = 0
+            for item in payload:
+                match = re.match(r"^address_(?P<index>\d+)\|(?P<attribute>\S+)", item)
+                if match:
+                    groups = match.groupdict()
+                    index = int(groups["index"])
+                    attribute = groups["attribute"]
+                    address_dicts[index] = address_dicts.get(index) or {}
+                    address_dicts[index][attribute] = payload[item]
+                    address_count = max(address_count, index + 1)
+            user.addresses = []
+            for index in range(0, address_count):
+                d = address_dicts[index]
+                if d.get("id"):
+                    try:
+                        user_address = trans.sa_session.get(UserAddress, trans.security.decode_id(d["id"]))
+                    except Exception as e:
+                        raise exceptions.ObjectNotFound(f"Failed to access user address ({d['id']}). {e}")
+                else:
+                    user_address = UserAddress()
+                    trans.log_event("User address added")
+                for field in AddressField.fields():
+                    if str(field[2]).lower() == "required" and not d.get(field[0]):
+                        raise exceptions.ObjectAttributeMissingException(
+                            f"Address {index + 1}: {field[1]} ({field[0]}) required."
+                        )
+                    setattr(user_address, field[0], str(d.get(field[0], "")))
+                user_address.user = user
+                user.addresses.append(user_address)
+                trans.sa_session.add(user_address)
         trans.sa_session.add(user)
         trans.sa_session.commit()
         trans.log_event("User information added")


### PR DESCRIPTION
Adds `enable_user_addresses` (default `true`) gating postal address storage, and deletes two dead helpers.

`UserAddress` is a leftover. Nothing in Galaxy reads these addresses — they are written and read by exactly one place, the deprecated `information/inputs` endpoint. There is no manager, job, tool or quota that consults them. Galaxy's interface no longer offers them at all now that the Account page has replaced the generic form, so this option only affects that deprecated endpoint. It gives administrators a way to stop accepting addresses ahead of the table being dropped, and gives that removal a single line to flip.

The default is `true`, so nothing changes for API consumers today.

`save_widget_field` and `get_form_values` in `webapps/base/controller.py` have no callers anywhere in `lib` or `test`. `get_form_values` was the only code path that could create a `UserAddress` from a generic form, so removing it also removes the last writer outside the deprecated endpoint.

One detail worth a reviewer's eye: the gate wraps the **whole** address block, not just the payload parsing. The block rebuilds `user.addresses` from scratch on every save, so gating only the parsing would have left `user.addresses = []` running unconditionally, silently discarding stored addresses the first time anyone saved with the feature off.

Dropping the table itself needs team sign-off and is irreversible — it would remove `user_address`, `AddressField`, the `address` form-builder type, the GDPR redaction branch, and this option. It is blocked on `test_tools.py::test_model_attributes_sanitization`, which uses an address field as its vehicle for a string containing a double quote and asserts on the `model_attributes` tool's output; that needs a different field first.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `./run_tests.sh -api lib/galaxy_test/api/test_users.py -k information` and `./run_tests.sh -api lib/galaxy_test/api/test_tools.py -k model_attributes_sanitization` — both pass unchanged, which is the point of the `true` default.
  2. Default config: `PUT /api/users/{id}/information/inputs` with `{"address_0|desc": "home"}` still stores and returns the address.
  3. Set `enable_user_addresses: false` and restart. The same PUT no longer stores an address.
  4. **Data safety check:** with the option `false`, PUT an unrelated field (say `{"username": "..."}`) through that endpoint for a user who already has addresses stored, then read them back — they must still be there.
  5. `grep -rn "save_widget_field\|get_form_values" lib test` returns nothing outside the deleted definitions.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
