### PR TITLE
[26.1] Fix `WorkflowAnnotation` flex distribution

### DIFF
--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -14,6 +14,8 @@ import WorkflowIndicators from "@/components/Workflow/List/WorkflowIndicators.vu
 
 interface Props {
     workflowId: string;
+    /** The time the workflow run was invoked. This prop being set also
+     * decides that this is being rendered in the invocation view */
     invocationCreateTime?: string;
     historyId: string;
     showDetails?: boolean;
@@ -41,7 +43,9 @@ const workflowTags = computed(() => {
 
 <template>
     <div v-if="workflow" class="pb-2 pl-2">
-        <div class="d-flex justify-content-between align-items-center">
+        <div
+            class="d-flex justify-content-between align-items-center"
+            :class="{ 'has-annotation-middle': props.invocationCreateTime }">
             <div class="annotation-left">
                 <i v-if="timeElapsed" data-description="workflow annotation time info">
                     <FontAwesomeIcon :icon="faClock" class="mr-1" />
@@ -52,7 +56,7 @@ const workflowTags = computed(() => {
                 </i>
                 <TargetHistoryLink v-if="props.invocationCreateTime" :target-history-id="props.historyId" />
             </div>
-            <div class="annotation-middle">
+            <div v-if="props.invocationCreateTime" class="annotation-middle">
                 <slot name="middle-content" />
             </div>
             <div class="annotation-right">
@@ -71,10 +75,8 @@ const workflowTags = computed(() => {
 </template>
 
 <style scoped lang="scss">
-// Left column: 35% of the width
 .annotation-left {
     flex: 1 1 0;
-    max-width: 35%;
     min-width: 0;
     overflow: hidden;
 
@@ -103,17 +105,13 @@ const workflowTags = computed(() => {
     }
 }
 
-// Middle column: 30% of the width
 .annotation-middle {
     flex: 1 1 0;
-    max-width: 30%;
     min-width: 0;
 }
 
-// Right column: 35% of the width
 .annotation-right {
     flex: 1 1 0;
-    max-width: 35%;
     min-width: 0;
     overflow: hidden;
     justify-content: flex-end;
@@ -131,6 +129,22 @@ const workflowTags = computed(() => {
     :deep(.workflow-indicators) {
         flex-wrap: wrap;
         justify-content: flex-end;
+    }
+}
+
+// When the middle column is rendered (invocation view), give all
+// fixed widths so the progress bars in middle are not constrained
+.has-annotation-middle {
+    .annotation-left {
+        max-width: 35%;
+    }
+
+    .annotation-middle {
+        max-width: 30%;
+    }
+
+    .annotation-right {
+        max-width: 35%;
     }
 }
 </style>


### PR DESCRIPTION
Fixes a minor style again where in the run form header, where unlike the invocation view, we didn't have a middle part with progress bars but we were still constraining the right part of the `WorkflowAnnotation` component to wrap items for no reason (because we had a 35, 30 and 35 width distribution for the 3 side by side divs).

## 🔴 Before: Items wrapped on right needlessly:
<img width="1067" height="165" alt="Screenshot 2026-08-17 at 12 36 07 PM" src="https://github.com/user-attachments/assets/8f288325-2e19-460e-869e-1ee09d84bb14" />

## 🟢 After: No wrapping on right:
<img width="1067" height="147" alt="image" src="https://github.com/user-attachments/assets/47da804b-6874-4f4a-877d-5093894b57d3" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
