### PR TITLE
Keep migration data fixes and their tests off the live ORM model

### DIFF
--- a/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
+++ b/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
@@ -44,7 +44,10 @@ class UsernameDeduplicator:
 
     def _generate_next_available_username(self, username):
         i = 1
-        while self.connection.execute(select(User).where(User.username == f"{username}-{i}")).first():
+        # Select a single column, not the whole model: this runs inside a migration,
+        # so the mapped model may carry columns that later revisions add and the
+        # schema at this point does not have.
+        while self.connection.execute(select(User.id).where(User.username == f"{username}-{i}")).first():
             i += 1
         return f"{username}-{i}"
 

--- a/test/unit/data/model/migration_fixes/conftest.py
+++ b/test/unit/data/model/migration_fixes/conftest.py
@@ -1,16 +1,30 @@
 import tempfile
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy import (
+    create_engine,
+    MetaData,
+    Table,
+)
+from sqlalchemy.orm import (
+    make_transient_to_detached,
+    Session,
+)
+from sqlalchemy.pool import NullPool
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
+from galaxy import model as m
 from galaxy.model.unittest_utils.model_testing_utils import (
     _generate_unique_database_name,
     _make_sqlite_db_url,
+)
+from galaxy.model.unittest_utils.utils import (
+    random_email,
+    random_str,
 )
 
 
@@ -33,9 +47,69 @@ def db_url(sqlite_url_factory):  # noqa: F811
 
 @pytest.fixture()
 def engine(db_url: str) -> "Engine":
-    return create_engine(db_url)
+    # NullPool so each operation opens a fresh connection. These tests run
+    # migrations in a separate process, and a pooled connection carries a cached
+    # schema across that DDL - harmless while the model and the schema agree, but
+    # it reads a stale table definition once a migration adds a column.
+    return create_engine(db_url, poolclass=NullPool)
 
 
 @pytest.fixture
 def session(engine: "Engine") -> Session:
-    return Session(engine)
+    # expire_on_commit is off because these tests hold instances across commits
+    # while the schema is deliberately behind the model: an expired instance would
+    # be re-SELECTed, naming columns the older schema does not have. The tests
+    # call expire_all() explicitly once the migration has run, which is the point
+    # at which a fresh read is wanted.
+    return Session(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def make_user(session):
+    """Create a user without the ORM naming columns the live schema may not have.
+
+    These tests downgrade the schema below the current model, and the ORM always
+    reflects the model at head. An ORM insert therefore names every mapped
+    column, including any added after the revision under test, and fails.
+
+    So the row is written through the reflected table - keeping the column list
+    in step with whatever revision is applied - and the resulting instance is
+    merged into the session with ``load=False``, which registers it as persistent
+    without issuing a SELECT. Callers get an ordinary ORM object whose attributes
+    are already populated, so assertions and relationship loads behave as before.
+
+    When a future migration adds a column to another table used here, the same
+    treatment will be needed for that table's fixture.
+    """
+
+    def f(**kwd):
+        kwd.setdefault("username", random_str())
+        kwd.setdefault("email", random_email())
+        kwd.setdefault("password", random_str())
+        now = datetime.utcnow()
+        kwd.setdefault("create_time", now)
+        kwd.setdefault("update_time", now)
+        kwd.setdefault("external", False)
+        kwd.setdefault("deleted", False)
+        kwd.setdefault("purged", False)
+        kwd.setdefault("active", False)
+
+        table = Table("galaxy_user", MetaData(), autoload_with=session.get_bind())
+        values = {key: value for key, value in kwd.items() if key in table.c}
+        result = session.execute(table.insert().values(**values))
+
+        user = m.User()
+        for key, value in values.items():
+            setattr(user, key, value)
+        user.id = result.inserted_primary_key[0]
+        # The row exists, so present the instance as detached rather than new;
+        # merge(load=False) refuses transient objects and would otherwise SELECT.
+        make_transient_to_detached(user)
+        merged = session.merge(user, load=False)
+        # Commit last, so no transaction is left open. These tests run migrations
+        # in a separate process, and a connection held open across that DDL would
+        # keep reading the pre-migration schema afterwards.
+        session.commit()
+        return merged
+
+    return f

--- a/test/unit/data/model/migration_fixes/conftest.py
+++ b/test/unit/data/model/migration_fixes/conftest.py
@@ -1,5 +1,4 @@
 import tempfile
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pytest
@@ -26,6 +25,7 @@ from galaxy.model.unittest_utils.utils import (
     random_email,
     random_str,
 )
+from galaxy.util import now
 
 
 @pytest.fixture(scope="module")
@@ -86,9 +86,9 @@ def make_user(session):
         kwd.setdefault("username", random_str())
         kwd.setdefault("email", random_email())
         kwd.setdefault("password", random_str())
-        now = datetime.utcnow()
-        kwd.setdefault("create_time", now)
-        kwd.setdefault("update_time", now)
+        created = now()
+        kwd.setdefault("create_time", created)
+        kwd.setdefault("update_time", created)
         kwd.setdefault("external", False)
         kwd.setdefault("deleted", False)
         kwd.setdefault("purged", False)


### PR DESCRIPTION
Two related fixes, both about migration code and migration tests reaching for the live ORM model.

### The bug

`UsernameDeduplicator._generate_next_available_username` finds the next free username with `select(User)`, which names **every mapped column**. It runs inside migration `d619fdfa6168`, so the model can carry columns that later revisions add and the schema at that point does not have — making the statement fail against the very database it is migrating.

The fault is latent today because nothing added to `galaxy_user` post-dates `d619fdfa6168`, and because the SELECT only runs when duplicate usernames actually exist — the loop is skipped entirely otherwise. The next column added to that table turns a real upgrade of any instance with duplicate usernames into a full rollback. Worse, the migration wrapper reports success while doing it: `manage_db.sh upgrade` exits 0, logs the first revision, and leaves `alembic_version` untouched.

Reproduced by hand: on a database downgraded to `d2d8f51ebb7e` with three duplicate-username users and one extra `galaxy_user` column in the model, `manage_db.sh upgrade` returns 0, applies nothing, and prints no error. With an empty `galaxy_user` the same upgrade applies 51 revisions and succeeds — which is exactly why this has gone unnoticed.

Selecting a single column is enough for an existence check and keeps the statement independent of the model.

### The tests

`test/unit/data/model/migration_fixes/test_migrations.py` initializes the database at head, downgrades below the revision under test, and then creates rows. Its user fixture used the ORM, so the INSERT named every mapped column and hit the same wall — any new `galaxy_user` column broke six of these eight tests.

The fixture now writes through the reflected table, keeping the column list in step with whatever revision is applied, and presents the row as a detached instance merged with `load=False` so no SELECT is issued. Callers still get an ordinary ORM object with populated attributes, so **the test bodies are unchanged**. Two supporting changes were needed: `expire_on_commit=False`, because these tests deliberately hold instances across commits while the schema is behind the model; and `NullPool`, because migrations run in a separate process and a pooled connection carries a cached schema across that DDL.

### Why this is its own PR

It is groundwork rather than a feature, it fixes a genuine upgrade bug on its own merits, and it unblocks any future column on `galaxy_user`. Keeping it separate also means the PRs above it stay about their own subject.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `./run_tests.sh -unit test/unit/data/model/migration_fixes/test_migrations.py` — 8 passed, unchanged from before.
  2. To see the bug this prevents, add any nullable column to `galaxy_user` in `lib/galaxy/model/__init__.py` plus a migration for it, then on a scratch database:
     ```
     sh manage_db.sh init
     sh manage_db.sh downgrade d2d8f51ebb7e
     # insert two or more galaxy_user rows sharing a username
     sh manage_db.sh upgrade
     ```
     Before this change: exit code 0, `alembic_version` still at `d2d8f51ebb7e`, no error printed. After it: the upgrade completes.
  3. The same column added on top of this PR keeps `test_migrations.py` at 8 passed; without it, six of the eight fail on the ORM insert.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
