### PR TITLE
[26.1] Restore tool submission error alert

### DIFF
--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -5,7 +5,7 @@ import { getLocalVue, injectTestRouter, suppressBootstrapVueWarnings } from "@te
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import MockCurrentHistory from "@/components/providers/MockCurrentHistory";
@@ -19,6 +19,13 @@ const { server, http } = useServerMock();
 const localVue = getLocalVue();
 const router = injectTestRouter(localVue);
 const pinia = createPinia();
+
+vi.mock("@/composables/userLocalStorageFromHashedId", async () => {
+    const { ref } = await import("vue");
+    return {
+        useUserLocalStorageFromHashId: (_key, initialValue) => ref(initialValue),
+    };
+});
 
 describe("ToolForm", () => {
     let wrapper;
@@ -110,5 +117,23 @@ describe("ToolForm", () => {
         await flushPromises();
 
         expect(userStore.recentTools).toEqual(["tool_id"]);
+    });
+    it("shows an error alert when tool submission returns an error message", async () => {
+        const errorMessage = "New identifier [duplicate] appears twice in resulting collection.";
+        server.use(
+            http.untyped.post("/api/tools", () => {
+                return HttpResponse.json({ err_msg: errorMessage }, { status: 400 });
+            }),
+        );
+        await flushPromises();
+        await wrapper.setData({ formData: {} });
+
+        const button = wrapper.find("[data-description='run tool button']");
+        await button.trigger("click");
+        await flushPromises();
+
+        expect(wrapper.vm.showError).toBe(true);
+        expect(wrapper.vm.errorMessage).toBe(errorMessage);
+        expect(wrapper.text()).toContain(errorMessage);
     });
 });

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -593,6 +593,9 @@ export default {
                 if (errorMsg) {
                     this.errorMessage = errorMsg;
                     this.submissionRequestFailed = true;
+                    this.showError = true;
+                    this.errorTitle = "Job submission failed.";
+                    this.errorContent = jobDef;
                     return;
                 }
 


### PR DESCRIPTION
## Summary

  - restore the tool submission error modal for failures that return an `err_msg` without field-level
  `err_data`
  - preserve the submitted job details in the modal, matching the behavior before the jobs API migration
  - add regression coverage for an HTTP 400 tool submission failure

## Root cause

The regression was introduced by commit b63b815474 in [PR #21842](https://github.com/galaxyproject/galaxy/pull/21842), whose revised error handler returned after capturing `err_msg` but before setting `showError`, leaving submission failures invisible.

As a result, errors such as duplicate collection identifiers were available in the API response but not displayed to users.

Fixes #23299.

## User impact

  Tool submission failures with a server-provided message once again open the existing error alert instead
  of appearing to do nothing.

  ## Testing

  - `pnpm test src/components/Tool/ToolForm.test.js`
  - targeted Prettier check
  - targeted ESLint check
  - repository pre-commit hooks


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. See issue.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
