### PR TITLE
Tee-stream object-store downloads instead of pulling into the cache first

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -47,7 +47,8 @@ chronos-python==1.2.1
 pykube-ng==23.6.0
 
 # Cloud object store
-cloudbridge
+# 4.4.0 makes iter_content take a chunk_size, which the object store sets when streaming.
+cloudbridge>=4.4.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -26,7 +26,7 @@ certifi==2026.7.22
 cffi==2.1.1 ; (implementation_name != 'pypy' and os_name == 'nt') or platform_python_implementation != 'PyPy'
 charset-normalizer==3.4.9
 click==8.4.2
-cloudbridge==4.3.1
+cloudbridge==4.4.0
 codespell==2.4.3
 colorama==0.4.6 ; os_name == 'nt' or sys_platform == 'win32'
 colorlog==6.12.0

--- a/lib/galaxy/dependencies/pinned-test-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-test-requirements.txt
@@ -21,7 +21,7 @@ certifi==2026.7.22
 cffi==2.1.1 ; (implementation_name != 'pypy' and os_name == 'nt') or platform_python_implementation != 'PyPy'
 charset-normalizer==3.4.9
 click==8.4.2
-cloudbridge==4.3.1
+cloudbridge==4.4.0
 colorama==0.4.6 ; sys_platform == 'win32'
 colorlog==6.12.0
 contourpy==1.3.2 ; python_full_version < '3.11'

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -79,6 +79,21 @@ USER_OBJECTS_SCHEME = "user_objects://"
 log = logging.getLogger(__name__)
 
 
+class DataStream(Protocol):
+    """A stream of an object's bytes that owns the read it came from.
+
+    A consumer that does not exhaust the stream must ``close()`` it: the bytes may be arriving over a
+    connection the backing store holds open, and dropping the last reference only releases it
+    whenever the garbage collector gets there.
+    """
+
+    def __iter__(self) -> Iterator[bytes]: ...
+
+    def __next__(self) -> bytes: ...
+
+    def close(self) -> None: ...
+
+
 @dataclass(frozen=True)
 class ObjectStoreAuth:
     user: User | None = None
@@ -345,7 +360,7 @@ class ObjectStore(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_data_stream(self, obj) -> Iterator[bytes] | None:
+    def get_data_stream(self, obj) -> DataStream | None:
         """Return an iterator over the bytes of `obj` read straight from the backing store.
 
         Lets a caller start sending bytes to a client without first pulling the whole object into the
@@ -725,10 +740,10 @@ class BaseObjectStore(ObjectStore):
         # Stores that don't support direct download (or haven't opted in) get this no-op default.
         return None
 
-    def get_data_stream(self, obj) -> Iterator[bytes] | None:
+    def get_data_stream(self, obj) -> DataStream | None:
         return self._invoke("get_data_stream", obj)
 
-    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+    def _get_data_stream(self, obj, **kwargs) -> DataStream | None:
         # Stores that cannot stream their objects remotely (e.g. disk) get this no-op default.
         return None
 
@@ -1348,7 +1363,7 @@ class NestedObjectStore(BaseObjectStore):
             content_type=content_type,
         )
 
-    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+    def _get_data_stream(self, obj, **kwargs) -> DataStream | None:
         """For the first backend that has this `obj`, stream it from that backend."""
         return self._call_method("_get_data_stream", obj, None, False, **kwargs)
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -14,6 +14,7 @@ import random
 import shutil
 import threading
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -340,6 +341,18 @@ class ObjectStore(metaclass=abc.ABCMeta):
         ``enable_direct_download`` configuration flag. ``content_disposition`` and ``content_type``, when
         supported by the backend, are baked into the URL so the client receives the right download filename
         and content type.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_data_stream(self, obj) -> Iterator[bytes] | None:
+        """Return an iterator over the bytes of `obj` read straight from the backing store.
+
+        Lets a caller start sending bytes to a client without first pulling the whole object into the
+        local cache -- the first byte is available as soon as the store responds, and objects too big
+        for the cache can be served at all. Returns None when the store cannot stream the object (it
+        is local, already cached, or the backend has no streaming read), in which case the caller
+        falls back to pulling the object into the cache and serving it from there.
         """
         raise NotImplementedError()
 
@@ -710,6 +723,13 @@ class BaseObjectStore(ObjectStore):
 
     def _get_direct_download_url(self, obj, content_disposition=None, content_type=None) -> str | None:
         # Stores that don't support direct download (or haven't opted in) get this no-op default.
+        return None
+
+    def get_data_stream(self, obj) -> Iterator[bytes] | None:
+        return self._invoke("get_data_stream", obj)
+
+    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+        # Stores that cannot stream their objects remotely (e.g. disk) get this no-op default.
         return None
 
     def get_concrete_store_name(self, obj):
@@ -1327,6 +1347,10 @@ class NestedObjectStore(BaseObjectStore):
             content_disposition=content_disposition,
             content_type=content_type,
         )
+
+    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+        """For the first backend that has this `obj`, stream it from that backend."""
+        return self._call_method("_get_data_stream", obj, None, False, **kwargs)
 
     def _get_concrete_store_name(self, obj):
         return self._call_method("_get_concrete_store_name", obj, None, False)

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import shutil
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Any
+from uuid import uuid4
 
 from galaxy.exceptions import (
     ObjectInvalid,
@@ -24,6 +26,9 @@ from .caching import (
 )
 
 log = logging.getLogger(__name__)
+
+# Size of the chunks pulled from the backing store when tee-streaming an object to a client.
+STREAM_CHUNK_SIZE = 1024 * 1024
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
@@ -137,6 +142,62 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         content = data_file.read(count)
         data_file.close()
         return content
+
+    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+        rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
+        if self._in_cache(cache_path):
+            # Serve the cached copy instead: it supports range requests and X-Accel offload.
+            return None
+        try:
+            chunks = self._stream_remote(rel_path)
+            if chunks is None:
+                return None
+            remote_size = self._get_remote_size(rel_path)
+            if remote_size < 0:
+                # Backends report an unknown size as a negative number. Without it a stream cannot be
+                # checked for truncation, so leave this download to the pull path.
+                return None
+            cache_target = self._cache_shards.get_cache_target(object_id)
+            write_cache = cache_target.fits_in_cache(remote_size)
+        except Exception:
+            log.exception("Failed to open a remote stream for '%s', falling back to pulling into cache", rel_path)
+            return None
+        return self._tee_to_cache(chunks, cache_path, expected_size=remote_size, write_cache=write_cache)
+
+    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+        """Yield the bytes of the remote object, or None if this backend cannot stream them."""
+        return None
+
+    def _tee_to_cache(
+        self, chunks: Iterator[bytes], cache_path: str, *, expected_size: int, write_cache: bool
+    ) -> Iterator[bytes]:
+        """Yield the remote object's bytes, writing them into the cache on the way past.
+
+        The cache copy is published atomically once the whole object has been streamed, so a client
+        that disconnects (or a stream that errors) never leaves a truncated file behind to be served
+        as if it were complete -- and a stream that ends early is rejected rather than cached, since
+        a short read that raised nothing would otherwise poison the cache. Objects that do not fit
+        in the cache are streamed straight through.
+        """
+        if not write_cache:
+            yield from chunks
+            return
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with self._atomic_download(cache_path, unique_tmp=True) as tmp_path:
+            streamed_size = 0
+            with open(tmp_path, "wb") as tmp_file:
+                for chunk in chunks:
+                    tmp_file.write(chunk)
+                    streamed_size += len(chunk)
+                    yield chunk
+            if streamed_size != expected_size:
+                raise OSError(
+                    f"Streaming '{cache_path}' from the object store returned {streamed_size} bytes, "
+                    f"expected {expected_size}"
+                )
+        fix_permissions(self.config, os.path.dirname(cache_path))
 
     def _exists(self, obj, **kwargs) -> bool:
         in_cache = exists_remotely = False
@@ -423,15 +484,20 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         raise NotImplementedError()
 
     @contextmanager
-    def _atomic_download(self, cache_path):
+    def _atomic_download(self, cache_path, *, unique_tmp: bool = False):
         """Download to a temp file then atomically rename to prevent serving partial files.
 
         Usage::
 
             with self._atomic_download(local_destination) as tmp_path:
                 do_download(tmp_path)
+
+        Pass ``unique_tmp`` when several downloads of the same object can be in flight at once (as
+        with tee-streaming, where every concurrent client opens its own stream): each writes its own
+        temp file, so they cannot truncate each other's, and whichever finishes last publishes a
+        complete copy.
         """
-        tmp_path = cache_path + ".tmp"
+        tmp_path = f"{cache_path}.{uuid4().hex}.tmp" if unique_tmp else f"{cache_path}.tmp"
         try:
             yield tmp_path
             os.rename(tmp_path, cache_path)

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,8 +1,14 @@
 import logging
 import os
 import shutil
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import (
+    Callable,
+    Iterator,
+)
+from contextlib import (
+    AbstractContextManager,
+    contextmanager,
+)
 from datetime import datetime
 from typing import Any
 from uuid import uuid4
@@ -29,6 +35,22 @@ log = logging.getLogger(__name__)
 
 # Size of the chunks pulled from the backing store when tee-streaming an object to a client.
 STREAM_CHUNK_SIZE = 1024 * 1024
+
+
+@contextmanager
+def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterator[Iterator[bytes]]:
+    """Pair an open read of a remote object with the call that releases it.
+
+    Backends hand back the SDK's own close rather than leaving it to the chunk iterator, because
+    closing the iterator is not the same thing: botocore's ``iter_chunks`` is a plain generator over
+    ``StreamingBody.read``, so closing it ends the loop but leaves the HTTP response open and its
+    connection out of the pool. Abandoning a read part way is the normal case on this path, not the
+    rare one -- it exists for large downloads, which are the ones clients cancel.
+    """
+    try:
+        yield chunks
+    finally:
+        close()
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
@@ -151,9 +173,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             # Serve the cached copy instead: it supports range requests and X-Accel offload.
             return None
         try:
-            chunks = self._stream_remote(rel_path)
-            if chunks is None:
-                return None
             remote_size = self._get_remote_size(rel_path)
             if remote_size < 0:
                 # Backends report an unknown size as a negative number. Without it a stream cannot be
@@ -161,17 +180,32 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 return None
             cache_target = self._cache_shards.get_cache_target(object_id)
             write_cache = cache_target.fits_in_cache(remote_size)
+            # Opening the remote read comes last: everything that can decide against streaming has
+            # already decided, so no bail-out below leaves an open connection with no owner.
+            stream = self._stream_remote(rel_path)
+            if stream is None:
+                return None
         except Exception:
             log.exception("Failed to open a remote stream for '%s', falling back to pulling into cache", rel_path)
             return None
-        return self._tee_to_cache(chunks, cache_path, expected_size=remote_size, write_cache=write_cache)
+        return self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
-        """Yield the bytes of the remote object, or None if this backend cannot stream them."""
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        """Open a read of the remote object, or None if this backend cannot stream it.
+
+        The context manager owns the read: leaving it releases the connection whether the client took
+        every byte, hung up part way, or the stream errored. :func:`closing_stream` builds one from a
+        chunk iterator and the SDK call that releases it.
+        """
         return None
 
     def _tee_to_cache(
-        self, chunks: Iterator[bytes], cache_path: str, *, expected_size: int, write_cache: bool
+        self,
+        stream: AbstractContextManager[Iterator[bytes]],
+        cache_path: str,
+        *,
+        expected_size: int,
+        write_cache: bool,
     ) -> Iterator[bytes]:
         """Yield the remote object's bytes, writing them into the cache on the way past.
 
@@ -181,23 +215,24 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         a short read that raised nothing would otherwise poison the cache. Objects that do not fit
         in the cache are streamed straight through.
         """
-        if not write_cache:
-            yield from chunks
-            return
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with self._atomic_download(cache_path) as tmp_path:
-            streamed_size = 0
-            with open(tmp_path, "wb") as tmp_file:
-                for chunk in chunks:
-                    tmp_file.write(chunk)
-                    streamed_size += len(chunk)
-                    yield chunk
-            if streamed_size != expected_size:
-                raise OSError(
-                    f"Streaming '{cache_path}' from the object store returned {streamed_size} bytes, "
-                    f"expected {expected_size}"
-                )
-        fix_permissions(self.config, os.path.dirname(cache_path))
+        with stream as chunks:
+            if not write_cache:
+                yield from chunks
+                return
+            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+            with self._atomic_download(cache_path) as tmp_path:
+                streamed_size = 0
+                with open(tmp_path, "wb") as tmp_file:
+                    for chunk in chunks:
+                        tmp_file.write(chunk)
+                        streamed_size += len(chunk)
+                        yield chunk
+                if streamed_size != expected_size:
+                    raise OSError(
+                        f"Streaming '{cache_path}' from the object store returned {streamed_size} bytes, "
+                        f"expected {expected_size}"
+                    )
+            fix_permissions(self.config, os.path.dirname(cache_path))
 
     def _exists(self, obj, **kwargs) -> bool:
         in_cache = exists_remotely = False

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -185,7 +185,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             yield from chunks
             return
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with self._atomic_download(cache_path, unique_tmp=True) as tmp_path:
+        with self._atomic_download(cache_path) as tmp_path:
             streamed_size = 0
             with open(tmp_path, "wb") as tmp_file:
                 for chunk in chunks:
@@ -484,7 +484,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         raise NotImplementedError()
 
     @contextmanager
-    def _atomic_download(self, cache_path, *, unique_tmp: bool = False):
+    def _atomic_download(self, cache_path):
         """Download to a temp file then atomically rename to prevent serving partial files.
 
         Usage::
@@ -492,12 +492,13 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             with self._atomic_download(local_destination) as tmp_path:
                 do_download(tmp_path)
 
-        Pass ``unique_tmp`` when several downloads of the same object can be in flight at once (as
-        with tee-streaming, where every concurrent client opens its own stream): each writes its own
-        temp file, so they cannot truncate each other's, and whichever finishes last publishes a
-        complete copy.
+        The temp file is unique per download because several downloads of the same object can be in
+        flight at once -- two clients downloading an uncached object, or a pull racing a stream. A
+        shared temp name lets one truncate what another is still writing and then publish the result
+        as a complete object; with one temp file each they cannot interfere, and whichever finishes
+        last publishes a complete copy.
         """
-        tmp_path = f"{cache_path}.{uuid4().hex}.tmp" if unique_tmp else f"{cache_path}.tmp"
+        tmp_path = f"{cache_path}.{uuid4().hex}.tmp"
         try:
             yield tmp_path
             os.rename(tmp_path, cache_path)

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from collections.abc import (
     Callable,
+    Generator,
     Iterator,
 )
 from contextlib import (
@@ -67,14 +68,10 @@ class RemoteDataStream(AbstractContextManager[Iterator[bytes]]):
             self._close()
 
 
-def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> RemoteDataStream:
-    return RemoteDataStream(chunks, close)
-
-
 class _ClosingIterator(Iterator[bytes]):
     """An iterator whose owner can release resources before the first ``next`` call."""
 
-    def __init__(self, iterator: Iterator[bytes], close: Callable[[], None]) -> None:
+    def __init__(self, iterator: Generator[bytes, None, None], close: Callable[[], None]) -> None:
         self.iterator = iterator
         self._close = close
         self._closed = False
@@ -92,9 +89,9 @@ class _ClosingIterator(Iterator[bytes]):
         if not self._closed:
             self._closed = True
             try:
-                close_iterator = getattr(self.iterator, "close", None)
-                if callable(close_iterator):
-                    close_iterator()
+                # Unwinds the tee: whatever the generator was part way through -- a temp file, the
+                # ``with`` around the remote read -- gets its cleanup run.
+                self.iterator.close()
             finally:
                 self._close()
 
@@ -244,8 +241,8 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         """Open a read of the remote object, or None if this backend cannot stream it.
 
         The context manager owns the read: leaving it releases the connection whether the client took
-        every byte, hung up part way, or the stream errored. :func:`closing_stream` builds one from a
-        chunk iterator and the SDK call that releases it.
+        every byte, hung up part way, or the stream errored: build one from a chunk iterator and the
+        SDK call that releases it.
         """
         return None
 
@@ -256,7 +253,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         *,
         expected_size: int,
         write_cache: bool,
-    ) -> Iterator[bytes]:
+    ) -> Generator[bytes, None, None]:
         """Yield the remote object's bytes, writing them into the cache on the way past.
 
         The cache copy is published atomically once the whole object has been streamed, so a client

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -37,8 +37,7 @@ log = logging.getLogger(__name__)
 STREAM_CHUNK_SIZE = 1024 * 1024
 
 
-@contextmanager
-def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterator[Iterator[bytes]]:
+class RemoteDataStream(AbstractContextManager[Iterator[bytes]]):
     """Pair an open read of a remote object with the call that releases it.
 
     Backends hand back the SDK's own close rather than leaving it to the chunk iterator, because
@@ -47,10 +46,57 @@ def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> Iterat
     connection out of the pool. Abandoning a read part way is the normal case on this path, not the
     rare one -- it exists for large downloads, which are the ones clients cancel.
     """
-    try:
-        yield chunks
-    finally:
-        close()
+
+    def __init__(self, chunks: Iterator[bytes], close: Callable[[], None]) -> None:
+        self.chunks = chunks
+        self._close = close
+        self._closed = False
+
+    def __enter__(self) -> Iterator[bytes]:
+        if self._closed:
+            raise RuntimeError("Cannot consume a closed remote data stream")
+        return self.chunks
+
+    def __exit__(self, *_args: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release the read even if its chunks were never consumed."""
+        if not self._closed:
+            self._closed = True
+            self._close()
+
+
+def closing_stream(chunks: Iterator[bytes], close: Callable[[], None]) -> RemoteDataStream:
+    return RemoteDataStream(chunks, close)
+
+
+class _ClosingIterator(Iterator[bytes]):
+    """An iterator whose owner can release resources before the first ``next`` call."""
+
+    def __init__(self, iterator: Iterator[bytes], close: Callable[[], None]) -> None:
+        self.iterator = iterator
+        self._close = close
+        self._closed = False
+
+    def __next__(self) -> bytes:
+        if self._closed:
+            raise StopIteration
+        try:
+            return next(self.iterator)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            try:
+                close_iterator = getattr(self.iterator, "close", None)
+                if callable(close_iterator):
+                    close_iterator()
+            finally:
+                self._close()
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
@@ -188,9 +234,13 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         except Exception:
             log.exception("Failed to open a remote stream for '%s', falling back to pulling into cache", rel_path)
             return None
-        return self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
+        iterator = self._tee_to_cache(stream, cache_path, expected_size=remote_size, write_cache=write_cache)
+        # The generator above does not enter ``stream`` until its first next() call. Give the
+        # response an explicit close that owns the already-open remote read even if the client goes
+        # away while response headers are being sent and the generator is never started.
+        return _ClosingIterator(iterator, stream.close)
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         """Open a read of the remote object, or None if this backend cannot stream it.
 
         The context manager owns the read: leaving it releases the connection whether the client took
@@ -201,7 +251,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     def _tee_to_cache(
         self,
-        stream: AbstractContextManager[Iterator[bytes]],
+        stream: RemoteDataStream,
         cache_path: str,
         *,
         expected_size: int,

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -18,7 +18,10 @@ from galaxy.exceptions import (
     ObjectInvalid,
     ObjectNotFound,
 )
-from galaxy.objectstore import ConcreteObjectStore
+from galaxy.objectstore import (
+    ConcreteObjectStore,
+    DataStream,
+)
 from galaxy.util import (
     directory_hash_id,
     unlink,
@@ -208,7 +211,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         data_file.close()
         return content
 
-    def _get_data_stream(self, obj, **kwargs) -> Iterator[bytes] | None:
+    def _get_data_stream(self, obj, **kwargs) -> DataStream | None:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
         cache_path = self._get_cache_path(rel_path, object_id)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -5,6 +5,10 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 import logging
 import os
 from collections.abc import Iterator
+from contextlib import (
+    AbstractContextManager,
+    nullcontext,
+)
 from datetime import timedelta
 
 try:
@@ -261,8 +265,10 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
         with open(local_destination, "wb") as f:
             self._blob_client(rel_path).download_blob().download_to_stream(f, **kwd)
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
-        return self._blob_client(rel_path).download_blob().chunks()
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        # Nothing to release: the downloader pulls each chunk with its own ranged request rather
+        # than holding one response open, and exposes no close of its own.
+        return nullcontext(self._blob_client(rel_path).download_blob().chunks())
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -19,7 +19,6 @@ except ImportError:
 from galaxy.util import now
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
 )
 from .caching import (
@@ -267,7 +266,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
     def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         # Nothing to release: the downloader pulls each chunk with its own ranged request rather
         # than holding one response open, and exposes no close of its own.
-        return closing_stream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
+        return RemoteDataStream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -4,11 +4,6 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 
 import logging
 import os
-from collections.abc import Iterator
-from contextlib import (
-    AbstractContextManager,
-    nullcontext,
-)
 from datetime import timedelta
 
 try:
@@ -22,7 +17,11 @@ except ImportError:
     BlobServiceClient = None  # type: ignore[assignment,unused-ignore,misc]
 
 from galaxy.util import now
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+    RemoteDataStream,
+)
 from .caching import (
     CacheShardManager,
     CacheTarget,
@@ -265,10 +264,10 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
         with open(local_destination, "wb") as f:
             self._blob_client(rel_path).download_blob().download_to_stream(f, **kwd)
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         # Nothing to release: the downloader pulls each chunk with its own ranged request rather
         # than holding one response open, and exposes no close of its own.
-        return nullcontext(self._blob_client(rel_path).download_blob().chunks())
+        return closing_stream(self._blob_client(rel_path).download_blob().chunks(), lambda: None)
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -4,6 +4,7 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 
 import logging
 import os
+from collections.abc import Iterator
 from datetime import timedelta
 
 try:
@@ -259,6 +260,9 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
             kwd["max_concurrency"] = max_concurrency
         with open(local_destination, "wb") as f:
             self._blob_client(rel_path).download_blob().download_to_stream(f, **kwd)
+
+    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+        return self._blob_client(rel_path).download_blob().chunks()
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         blobs = self._blobs_from(rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -9,6 +9,7 @@ import os.path
 from ._caching_base import (
     CachingConcreteObjectStore,
     RemoteDataStream,
+    STREAM_CHUNK_SIZE,
 )
 from ._util import UsesAxel
 from .caching import (
@@ -267,7 +268,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
         key = self.bucket.objects.get(rel_path)
         if key is None:
             return None
-        content = key.iter_content()
+        content = key.iter_content(chunk_size=STREAM_CHUNK_SIZE)
         # cloudbridge promises an iterable and nothing more, and what it hands back differs per
         # provider -- a wrapper around the S3 body, a swift generator, a BytesIO -- so release it
         # only if it knows how.

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -8,7 +8,6 @@ import os.path
 
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
 )
 from ._util import UsesAxel
@@ -272,7 +271,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
         # cloudbridge promises an iterable and nothing more, and what it hands back differs per
         # provider -- a wrapper around the S3 body, a swift generator, a BytesIO -- so release it
         # only if it knows how.
-        return closing_stream(iter(content), getattr(content, "close", lambda: None))
+        return RemoteDataStream(iter(content), getattr(content, "close", lambda: None))
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         objects = self.bucket.objects.list(prefix=rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -5,6 +5,7 @@ Object Store plugin for Cloud storage.
 import logging
 import os
 import os.path
+from collections.abc import Iterator
 
 from ._caching_base import CachingConcreteObjectStore
 from ._util import UsesAxel
@@ -259,6 +260,12 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
         except Exception:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
+
+    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+        key = self.bucket.objects.get(rel_path)
+        if key is None:
+            return None
+        return key.iter_content()
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         objects = self.bucket.objects.list(prefix=rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -5,12 +5,11 @@ Object Store plugin for Cloud storage.
 import logging
 import os
 import os.path
-from collections.abc import Iterator
-from contextlib import AbstractContextManager
 
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
 )
 from ._util import UsesAxel
 from .caching import (
@@ -265,7 +264,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         key = self.bucket.objects.get(rel_path)
         if key is None:
             return None

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -6,8 +6,12 @@ import logging
 import os
 import os.path
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+)
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
@@ -261,11 +265,15 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
         key = self.bucket.objects.get(rel_path)
         if key is None:
             return None
-        return key.iter_content()
+        content = key.iter_content()
+        # cloudbridge promises an iterable and nothing more, and what it hands back differs per
+        # provider -- a wrapper around the S3 body, a swift generator, a BytesIO -- so release it
+        # only if it knows how.
+        return closing_stream(iter(content), getattr(content, "close", lambda: None))
 
     def _download_directory_into_cache(self, rel_path, cache_path):
         objects = self.bucket.objects.list(prefix=rel_path)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -19,7 +19,6 @@ except ImportError:
 from galaxy.util import string_as_bool
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
@@ -339,7 +338,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             return None
         # fast=True: a client that hung up should not make Galaxy read the rest of the object off
         # the wire before the connection can be released.
-        return closing_stream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
+        return RemoteDataStream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
 
     def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -5,8 +5,6 @@ Object Store plugin for the Amazon Simple Storage Service (S3)
 import logging
 import os
 import time
-from collections.abc import Iterator
-from contextlib import AbstractContextManager
 from datetime import datetime
 
 try:
@@ -22,6 +20,7 @@ from galaxy.util import string_as_bool
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from ._util import UsesAxel
@@ -334,7 +333,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         key = self._bucket.get_key(rel_path)
         if key is None:
             return None

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -5,6 +5,8 @@ Object Store plugin for the Amazon Simple Storage Service (S3)
 import logging
 import os
 import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from datetime import datetime
 
 try:
@@ -17,7 +19,11 @@ except ImportError:
     boto = None  # type: ignore[assignment]
 
 from galaxy.util import string_as_bool
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    closing_stream,
+    STREAM_CHUNK_SIZE,
+)
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
@@ -327,6 +333,14 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
         except S3ResponseError:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
+
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+        key = self._bucket.get_key(rel_path)
+        if key is None:
+            return None
+        # fast=True: a client that hung up should not make Galaxy read the rest of the object off
+        # the wire before the connection can be released.
+        return closing_stream(iter(lambda: key.read(STREAM_CHUNK_SIZE), b""), lambda: key.close(fast=True))
 
     def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -6,6 +6,7 @@ from collections.abc import (
     Callable,
     Iterator,
 )
+from contextlib import AbstractContextManager
 from typing import (
     Any,
     Literal,
@@ -35,6 +36,7 @@ from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
+    closing_stream,
     STREAM_CHUNK_SIZE,
 )
 from .caching import (
@@ -342,9 +344,9 @@ class S3ObjectStore(CachingConcreteObjectStore):
             log.exception("Failed to download file from S3")
         return False
 
-    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
-        return body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE)
+        return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -2,7 +2,10 @@
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import (
+    Callable,
+    Iterator,
+)
 from typing import (
     Any,
     Literal,
@@ -30,7 +33,10 @@ except ImportError:
 
 from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
-from ._caching_base import CachingConcreteObjectStore
+from ._caching_base import (
+    CachingConcreteObjectStore,
+    STREAM_CHUNK_SIZE,
+)
 from .caching import (
     CacheShardManager,
     CacheTarget,
@@ -335,6 +341,10 @@ class S3ObjectStore(CachingConcreteObjectStore):
         except ClientError:
             log.exception("Failed to download file from S3")
         return False
+
+    def _stream_remote(self, rel_path: str) -> Iterator[bytes] | None:
+        body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
+        return body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -32,7 +32,6 @@ from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
-    closing_stream,
     RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
@@ -343,7 +342,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
 
     def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
-        return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
+        return RemoteDataStream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -2,11 +2,7 @@
 
 import logging
 import os
-from collections.abc import (
-    Callable,
-    Iterator,
-)
-from contextlib import AbstractContextManager
+from collections.abc import Callable
 from typing import (
     Any,
     Literal,
@@ -37,6 +33,7 @@ from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import (
     CachingConcreteObjectStore,
     closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from .caching import (
@@ -344,7 +341,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
             log.exception("Failed to download file from S3")
         return False
 
-    def _stream_remote(self, rel_path: str) -> AbstractContextManager[Iterator[bytes]] | None:
+    def _stream_remote(self, rel_path: str) -> RemoteDataStream | None:
         body = self._client.get_object(Bucket=self.bucket, Key=rel_path)["Body"]
         return closing_stream(body.iter_chunks(chunk_size=STREAM_CHUNK_SIZE), body.close)
 

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -251,6 +251,10 @@ class GalaxyStreamingResponse(StreamingResponse):
       lazily loads an ORM relationship, issues a query, or commits, it trips the
       FOOTGUN below.
 
+    RESOURCE OWNERSHIP: If synchronous response content exposes ``close()``,
+      this response calls it after streaming or when response setup/sending
+      fails, including failures before the content's first iteration.
+
     FOOTGUN: the request-id ``ContextVar`` that keys the ``scoped_session`` is
       still set while the body streams (same asyncio task). If body code touches
       ``app.model.session`` after we close it, ``scoped_session`` will SILENTLY
@@ -265,7 +269,15 @@ class GalaxyStreamingResponse(StreamingResponse):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        content = kwargs.get("content", args[0] if args else None)
+        close_content = getattr(content, "close", None)
+        self._close_content = close_content if callable(close_content) else None
+        try:
+            super().__init__(*args, **kwargs)
+        except BaseException:
+            if self._close_content is not None:
+                self._close_content()
+            raise
         # Capture concrete, already-open request-scoped sessions NOW, while we
         # are guaranteed to be in the request's asyncio task (so the request-id
         # ContextVar resolves). We never call the scoped proxy, which would
@@ -274,7 +286,11 @@ class GalaxyStreamingResponse(StreamingResponse):
 
     async def stream_response(self, send: "Send") -> None:
         _release_request_sessions(self._sessions_to_release)
-        await super().stream_response(send)
+        try:
+            await super().stream_response(send)
+        finally:
+            if self._close_content is not None:
+                self._close_content()
 
 
 def add_sentry_middleware(app: FastAPI) -> None:

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -144,6 +144,15 @@ DisplayChunkSizeQueryParam = Query(
 )
 
 
+def _allows_stream(request: Request) -> bool:
+    """Whether this request can be answered by streaming the object straight from the backing store.
+
+    A HEAD wants headers only, and a Range request needs random access -- both are served from a
+    file in the cache instead, so neither may consume a forward-only stream.
+    """
+    return request.method == "GET" and "range" not in request.headers
+
+
 @router.cbv
 class FastAPIDatasets:
     service: DatasetsService = depends(DatasetsService)
@@ -436,7 +445,7 @@ class FastAPIDatasets:
         ck_size: int | None = None,
     ):
         extra_params = get_query_parameters_from_request_excluding(
-            request, {"preview", "filename", "to_ext", "raw", "dataset", "ck_size", "offset"}
+            request, {"preview", "filename", "to_ext", "raw", "dataset", "ck_size", "offset", "allow_stream"}
         )
         display_data, headers = self.service.display(
             trans,
@@ -447,6 +456,7 @@ class FastAPIDatasets:
             raw=raw,
             offset=offset,
             ck_size=ck_size,
+            allow_stream=_allows_stream(request),
             **extra_params,
         )
         if isinstance(display_data, IOBase):

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -4,7 +4,6 @@ API operations on the contents of a history dataset.
 
 import logging
 import os
-from collections.abc import Iterator
 from enum import Enum
 from typing import (
     Any,
@@ -52,7 +51,10 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     resolve_job_markdown,
 )
-from galaxy.objectstore import ObjectStoreAuth
+from galaxy.objectstore import (
+    DataStream,
+    ObjectStoreAuth,
+)
 from galaxy.objectstore.badges import BadgeDict
 from galaxy.schema import (
     FilterQueryParams,
@@ -716,7 +718,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         to_ext: str | None,
         offset: int | None,
         ck_size: int | None,
-    ) -> tuple[Iterator[bytes], dict[str, str]] | None:
+    ) -> tuple[DataStream, dict[str, str]] | None:
         """Proxy a whole-file download straight from the backing store, warming the cache on the way.
 
         Returns None -- meaning the caller should pull the object into the cache and serve it from
@@ -744,9 +746,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         try:
             trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
         except BaseException:
-            close_stream = getattr(stream, "close", None)
-            if callable(close_stream):
-                close_stream()
+            stream.close()
             raise
         return stream, headers
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -4,6 +4,7 @@ API operations on the contents of a history dataset.
 
 import logging
 import os
+from collections.abc import Iterator
 from enum import Enum
 from typing import (
     Any,
@@ -707,6 +708,40 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                 headers["Content-Length"] = str(size)
         return headers
 
+    def _stream_from_object_store(
+        self,
+        trans: ProvidesHistoryContext,
+        dataset_instance,
+        filename: str | None,
+        to_ext: str | None,
+        offset: int | None,
+        ck_size: int | None,
+    ) -> tuple[Iterator[bytes], dict[str, str]] | None:
+        """Proxy a whole-file download straight from the backing store, warming the cache on the way.
+
+        Returns None -- meaning the caller should pull the object into the cache and serve it from
+        there -- when the request is not a plain whole-file download, or when the store has no
+        streaming read (a disk store, or an object already in the cache).
+        """
+        datatype = dataset_instance.datatype
+        is_archive = datatype.is_archive_download(trans.app.datatypes_registry, dataset_instance.extension)
+        if not is_direct_download_candidate(filename, to_ext, False, offset, ck_size, is_archive):
+            return None
+        stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
+        if stream is None:
+            return None
+        headers = {
+            # Force octet-stream so Safari doesn't append mime extensions to the filename.
+            "content-type": "application/octet-stream",
+            "Content-Disposition": datatype.download_content_disposition(dataset_instance, to_ext),
+        }
+        size = trans.app.object_store.size(dataset_instance.dataset)
+        if size:
+            # Known up front from the store's metadata, so clients still get a progress bar.
+            headers["Content-Length"] = str(size)
+        trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
+        return stream, headers
+
     def display(
         self,
         trans: ProvidesHistoryContext,
@@ -718,6 +753,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         raw: bool = False,
         offset: int | None = None,
         ck_size: int | None = None,
+        allow_stream: bool = False,
         **kwd,
     ):
         """
@@ -726,6 +762,12 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         The query parameter 'raw' should be considered experimental and may be dropped at
         some point in the future without warning. Generally, data should be processed by its
         datatype prior to display (the default if raw is unspecified or explicitly false.
+
+        ``allow_stream`` says the caller can consume a forward-only stream of the whole object (a
+        plain GET with no Range header). Whole-file downloads are then proxied straight from the
+        backing store, so the client gets its first byte immediately instead of waiting for the
+        object to be pulled into the cache. Callers that need a seekable file -- HEAD and Range
+        requests, and every legacy controller -- leave it False and get today's behavior.
         """
         headers: dict[str, str] = {}
         rval: Any = ""
@@ -736,6 +778,10 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             if filename and filename.startswith("/"):
                 # Path needs to relative to extra files path
                 filename = filename.lstrip("/")
+            if allow_stream and not raw:
+                streamed = self._stream_from_object_store(trans, dataset_instance, filename, to_ext, offset, ck_size)
+                if streamed is not None:
+                    return streamed
             if raw:
                 if filename and filename != "index":
                     object_store = trans.app.object_store

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -727,9 +727,6 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         is_archive = datatype.is_archive_download(trans.app.datatypes_registry, dataset_instance.extension)
         if not is_direct_download_candidate(filename, to_ext, False, offset, ck_size, is_archive):
             return None
-        stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
-        if stream is None:
-            return None
         headers = {
             # Force octet-stream so Safari doesn't append mime extensions to the filename.
             "content-type": "application/octet-stream",
@@ -739,6 +736,11 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         if size:
             # Known up front from the store's metadata, so clients still get a progress bar.
             headers["Content-Length"] = str(size)
+        # Opened last so that nothing between here and the response can fail with a read already in
+        # flight: an open stream is only released once something starts consuming it.
+        stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
+        if stream is None:
+            return None
         trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
         return stream, headers
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -741,7 +741,13 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         stream = trans.app.object_store.get_data_stream(dataset_instance.dataset)
         if stream is None:
             return None
-        trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
+        try:
+            trans.log_event(f"Download dataset id: {str(dataset_instance.id)}")
+        except BaseException:
+            close_stream = getattr(stream, "close", None)
+            if callable(close_stream):
+                close_stream()
+            raise
         return stream, headers
 
     def display(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ test = [
     "ase>=3.18.1",
     "axe-selenium-python",
     "boto3",
-    "cloudbridge",
+    "cloudbridge>=4.4.0",
     "cwltest>=2.5.20240906231108",  # Python 3.13 support
     "fluent-logger",
     "gcsfs",

--- a/test/integration/objectstore/test_tee_streaming.py
+++ b/test/integration/objectstore/test_tee_streaming.py
@@ -1,0 +1,211 @@
+"""Integration test for tee-streaming dataset downloads from a remote object store.
+
+An uncached whole-file download is proxied straight from the backing store to the client while the
+bytes are written into Galaxy's cache on the way past, so the client gets its first byte immediately
+instead of waiting for the whole object to be pulled in -- and objects too big for the cache can be
+downloaded at all. Requests that need random access (Range, HEAD) still get a cached file. Runs
+against a boto3 object store and a cloudbridge (cloud) object store, each backed by a disposable
+minio container.
+"""
+
+import os
+import string
+
+import requests
+
+from galaxy_test.base.populators import DatasetPopulator
+from galaxy_test.driver import integration_util
+from galaxy_test.driver.integration_util import docker_rm
+from ._base import (
+    BaseObjectStoreIntegrationTestCase,
+    files_count,
+    OBJECT_STORE_ACCESS_KEY,
+    OBJECT_STORE_HOST,
+    OBJECT_STORE_PORT,
+    OBJECT_STORE_SECRET_KEY,
+    start_minio,
+)
+
+BOTO3_TEE_STREAMING_CONFIG = string.Template("""
+<object_store type="boto3">
+    <auth access_key="${access_key}" secret_key="${secret_key}" />
+    <bucket name="galaxy" />
+    <connection endpoint_url="http://${host}:${port}" />
+    <cache path="${temp_directory}/object_store_cache" size="1000" />
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_boto3"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp_boto3"/>
+</object_store>
+""")
+
+CLOUD_TEE_STREAMING_CONFIG = string.Template("""
+<object_store type="cloud" provider="aws">
+    <auth access_key="${access_key}" secret_key="${secret_key}" />
+    <bucket name="galaxy" use_reduced_redundancy="False" />
+    <connection endpoint_url="http://${host}:${port}" />
+    <cache path="${temp_directory}/object_store_cache" size="1000" />
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_cloud"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp_cloud"/>
+</object_store>
+""")
+
+# ~107 bytes of cache: smaller than the datasets this test downloads through it.
+BOTO3_TINY_CACHE_CONFIG = string.Template("""
+<object_store type="boto3">
+    <auth access_key="${access_key}" secret_key="${secret_key}" />
+    <bucket name="galaxy" />
+    <connection endpoint_url="http://${host}:${port}" />
+    <cache path="${temp_directory}/object_store_cache" size="0.0000001" />
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_tiny"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp_tiny"/>
+</object_store>
+""")
+
+
+class TeeStreamingIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+    container_name: str
+    object_store_cache_path: str
+
+    @classmethod
+    def setUpClass(cls):
+        cls.container_name = f"{cls.__name__}_container"
+        start_minio(cls.container_name)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        docker_rm(cls.container_name)
+        super().tearDownClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        temp_directory = cls._test_driver.mkdtemp()
+        cls.object_stores_parent = temp_directory
+        cls.object_store_cache_path = os.path.join(temp_directory, "object_store_cache")
+        config_path = os.path.join(temp_directory, "object_store_conf.xml")
+        config["object_store_store_by"] = "uuid"
+        with open(config_path, "w") as f:
+            f.write(
+                cls.object_store_config.safe_substitute(
+                    {
+                        "temp_directory": temp_directory,
+                        "host": OBJECT_STORE_HOST,
+                        "port": OBJECT_STORE_PORT,
+                        "access_key": OBJECT_STORE_ACCESS_KEY,
+                        "secret_key": OBJECT_STORE_SECRET_KEY,
+                    }
+                )
+            )
+        config["object_store_config_file"] = config_path
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def _display_url(self, hda_id, **params):
+        return self._api_url(f"datasets/{hda_id}/display", params=params, use_key=True)
+
+    def _reset_cache(self):
+        for root, _, files in os.walk(self.object_store_cache_path):
+            for file_ in files:
+                os.remove(os.path.join(root, file_))
+
+
+@integration_util.skip_unless_docker()
+class TestTeeStreamingIntegration(TeeStreamingIntegrationTestCase):
+    object_store_config = BOTO3_TEE_STREAMING_CONFIG
+
+    def test_uncached_download_streams_and_warms_cache(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="tee-me", wait=True)
+
+        self._reset_cache()
+        assert files_count(self.object_store_cache_path) == 0
+
+        response = requests.get(self._display_url(hda["id"], to_ext="txt"))
+
+        assert response.status_code == 200
+        assert response.content == b"tee-me\n"
+        # Streamed from the store, not served off disk: a one-shot stream cannot answer ranges.
+        assert "accept-ranges" not in response.headers
+        # The size is known from the store's metadata, so the client still gets a progress bar.
+        assert response.headers["Content-Length"] == str(len(b"tee-me\n"))
+        # The bytes were written into the cache on their way to the client.
+        assert files_count(self.object_store_cache_path) == 1
+
+    def test_cached_download_is_served_from_the_cache(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="cache-me", wait=True)
+
+        self._reset_cache()
+        url = self._display_url(hda["id"], to_ext="txt")
+        first = requests.get(url)
+        assert first.status_code == 200
+        assert "accept-ranges" not in first.headers
+
+        second = requests.get(url)
+
+        assert second.status_code == 200
+        assert second.content == b"cache-me\n"
+        # Now served from the warmed cache file, which does support ranges.
+        assert second.headers["accept-ranges"] == "bytes"
+
+    def test_range_request_is_served_from_the_cache(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="0123456789", wait=True)
+
+        self._reset_cache()
+        response = requests.get(self._display_url(hda["id"], to_ext="txt"), headers={"Range": "bytes=0-3"})
+
+        # A range request needs random access, so it falls back to pulling the object into the cache.
+        assert response.status_code == 206
+        assert response.content == b"0123"
+        assert files_count(self.object_store_cache_path) == 1
+
+    def test_head_request_does_not_stream_the_object(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="head-me", wait=True)
+
+        self._reset_cache()
+        response = requests.head(self._display_url(hda["id"], to_ext="txt"))
+
+        # A HEAD wants headers only -- consuming a stream to throw the bytes away would be waste.
+        assert response.status_code == 200
+        assert response.headers["accept-ranges"] == "bytes"
+
+    def test_preview_is_not_streamed(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="preview-me", wait=True)
+
+        self._reset_cache()
+        response = requests.get(self._display_url(hda["id"], preview="True"))
+
+        # A preview is processed by the datatype, so it needs the object on disk.
+        assert response.status_code == 200
+        assert "preview-me" in response.text
+
+
+@integration_util.skip_unless_docker()
+class TestCloudTeeStreamingIntegration(TestTeeStreamingIntegration):
+    object_store_config = CLOUD_TEE_STREAMING_CONFIG
+
+
+@integration_util.skip_unless_docker()
+class TestTeeStreamingBiggerThanCacheIntegration(TeeStreamingIntegrationTestCase):
+    object_store_config = BOTO3_TINY_CACHE_CONFIG
+
+    def test_download_bigger_than_cache_succeeds_without_writing_the_cache(self):
+        history_id = self.dataset_populator.new_history()
+        content = "x" * 500
+        hda = self.dataset_populator.new_dataset(history_id, content=content, wait=True)
+
+        self._reset_cache()
+        assert files_count(self.object_store_cache_path) == 0
+
+        response = requests.get(self._display_url(hda["id"], to_ext="txt"))
+
+        # Too big for the cache to hold: before tee-streaming this download failed outright.
+        assert response.status_code == 200
+        assert response.content == f"{content}\n".encode()
+        # Streamed straight through -- nothing was written to the cache it does not fit in.
+        assert files_count(self.object_store_cache_path) == 0

--- a/test/integration/objectstore/test_tee_streaming.py
+++ b/test/integration/objectstore/test_tee_streaming.py
@@ -62,6 +62,7 @@ BOTO3_TINY_CACHE_CONFIG = string.Template("""
 
 
 class TeeStreamingIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+    object_store_config: string.Template
     container_name: str
     object_store_cache_path: str
 

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -790,6 +790,249 @@ def test_get_direct_download_url_disk_store_returns_none():
         assert url is None
 
 
+BOTO3_TEE_STREAMING_TEST_CONFIG_YAML = """
+type: boto3
+auth:
+  access_key: access_moo
+  secret_key: secret_cow
+
+bucket:
+  name: unique_bucket_name_all_lowercase
+
+cache:
+  path: "${temp_directory}/object_store_cache"
+  size: 1000
+
+extra_dirs:
+- type: job_work
+  path: "${temp_directory}/job_working_directory_s3"
+- type: temp
+  path: "${temp_directory}/tmp_s3"
+"""
+
+
+def _cache_path_for(object_store, dataset):
+    rel_path = object_store._construct_path(dataset)
+    return object_store._get_cache_path(rel_path, object_store._get_object_id(dataset))
+
+
+def _leftover_temp_files(cache_path):
+    cache_dir = os.path.dirname(cache_path)
+    if not os.path.exists(cache_dir):
+        return []
+    return [name for name in os.listdir(cache_dir) if name.endswith(".tmp")]
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_tees_remote_bytes_into_cache():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        with (
+            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(dataset)
+            assert stream is not None
+            assert b"".join(stream) == b"chunk1chunk2"
+
+        cache_path = _cache_path_for(object_store, dataset)
+        with open(cache_path, "rb") as f:
+            assert f.read() == b"chunk1chunk2"
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_discards_partial_cache_when_client_disconnects():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        with (
+            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(dataset)
+            assert stream is not None
+            assert next(stream) == b"chunk1"
+            # A client disconnecting mid-download closes the generator.
+            stream.close()
+
+        cache_path = _cache_path_for(object_store, dataset)
+        assert not os.path.exists(cache_path)
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_discards_partial_cache_when_remote_read_fails():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+
+        def failing_chunks():
+            yield b"chunk1"
+            raise OSError("connection reset by the object store")
+
+        with (
+            patch.object(object_store, "_stream_remote", return_value=failing_chunks()),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(dataset)
+            assert stream is not None
+            with pytest.raises(OSError):
+                b"".join(stream)
+
+        cache_path = _cache_path_for(object_store, dataset)
+        assert not os.path.exists(cache_path)
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_bypasses_cache_when_object_is_bigger_than_cache():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        one_terabyte = 1024**4
+        with (
+            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_get_remote_size", return_value=one_terabyte),
+        ):
+            stream = object_store.get_data_stream(dataset)
+            assert stream is not None
+            assert b"".join(stream) == b"chunk1chunk2"
+
+        cache_path = _cache_path_for(object_store, dataset)
+        assert not os.path.exists(cache_path)
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_does_not_cache_a_truncated_object():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        # The store says the object is 12 bytes but the stream ends after 6.
+        with (
+            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(dataset)
+            assert stream is not None
+            with pytest.raises(OSError):
+                b"".join(stream)
+
+        cache_path = _cache_path_for(object_store, dataset)
+        # Publishing it would poison the cache: every later download would serve half an object.
+        assert not os.path.exists(cache_path)
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_returns_none_when_remote_size_is_unknown():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        # Backends report an unknown size as a negative number; without a size there is nothing to
+        # check a streamed object against, so fall back to pulling it into the cache.
+        with (
+            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_get_remote_size", return_value=-1),
+        ):
+            assert object_store.get_data_stream(MockDataset(1)) is None
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_returns_none_when_already_cached():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        cache_path = _cache_path_for(object_store, dataset)
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with open(cache_path, "wb") as f:
+            f.write(b"already cached")
+
+        with patch.object(object_store, "_stream_remote") as stream_remote:
+            # Cached objects are served from disk so that ranges and X-Accel still work.
+            assert object_store.get_data_stream(dataset) is None
+            stream_remote.assert_not_called()
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_returns_none_when_backend_cannot_stream():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        with patch.object(object_store, "_stream_remote", return_value=None):
+            assert object_store.get_data_stream(MockDataset(1)) is None
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_returns_none_when_opening_remote_stream_fails():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        # Failing to open the stream must fall back to the pull path, not raise.
+        with patch.object(object_store, "_stream_remote", side_effect=OSError("no such key")):
+            assert object_store.get_data_stream(MockDataset(1)) is None
+
+
+def test_get_data_stream_disk_store_returns_none():
+    with TestConfig(DISK_TEST_CONFIG) as (directory, object_store):
+        assert object_store.get_data_stream(MockDataset(1)) is None
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_concurrent_streams_do_not_corrupt_cache():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        with (
+            patch.object(object_store, "_stream_remote", side_effect=lambda rel_path: iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            first = object_store.get_data_stream(dataset)
+            second = object_store.get_data_stream(dataset)
+            assert first is not None and second is not None
+            # Interleave the two downloads of the same uncached object.
+            assert next(first) == b"chunk1"
+            assert next(second) == b"chunk1"
+            assert b"".join(first) == b"chunk2"
+            assert b"".join(second) == b"chunk2"
+
+        cache_path = _cache_path_for(object_store, dataset)
+        with open(cache_path, "rb") as f:
+            assert f.read() == b"chunk1chunk2"
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_boto3_reads_object_body_in_chunks():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        body = MagicMock()
+        body.iter_chunks.return_value = iter([b"chunk1", b"chunk2"])
+        object_store._client = MagicMock()
+        object_store._client.get_object.return_value = {"Body": body}
+
+        chunks = object_store._stream_remote("000/dataset_1.dat")
+
+        assert list(chunks) == [b"chunk1", b"chunk2"]
+        _, call_kwargs = object_store._client.get_object.call_args
+        assert call_kwargs["Bucket"] == object_store.bucket
+        assert call_kwargs["Key"] == "000/dataset_1.dat"
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_azure_reads_blob_in_chunks():
+    with TestConfig(get_example("azure_simple.yml")) as (directory, object_store):
+        blob_client = MagicMock()
+        blob_client.download_blob.return_value.chunks.return_value = iter([b"chunk1", b"chunk2"])
+        with patch.object(object_store, "_blob_client", return_value=blob_client) as blob_client_for:
+            chunks = object_store._stream_remote("000/dataset_1.dat")
+
+            assert list(chunks) == [b"chunk1", b"chunk2"]
+            blob_client_for.assert_called_once_with("000/dataset_1.dat")
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_cloud_reads_object_content_in_chunks():
+    with TestConfig(get_example("cloud_aws_simple.yml")) as (directory, object_store):
+        key = MagicMock()
+        key.iter_content.return_value = iter([b"chunk1", b"chunk2"])
+        object_store.bucket = MagicMock()
+        object_store.bucket.objects.get.return_value = key
+
+        chunks = object_store._stream_remote("000/dataset_1.dat")
+
+        assert list(chunks) == [b"chunk1", b"chunk2"]
+        object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
+
+
 @patch_object_stores_to_skip_initialize
 def test_config_parse_boto3_custom_connection():
     for config_str in [get_example("boto3_custom_connection.xml"), get_example("boto3_custom_connection.yml")]:

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -7,6 +7,7 @@ from tempfile import (
     mkstemp,
 )
 from unittest.mock import (
+    call,
     MagicMock,
     patch,
 )
@@ -20,7 +21,10 @@ from galaxy.objectstore import (
     ObjectStoreAuth,
     persist_extra_files_for_dataset,
 )
-from galaxy.objectstore._caching_base import closing_stream
+from galaxy.objectstore._caching_base import (
+    closing_stream,
+    STREAM_CHUNK_SIZE,
+)
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -1161,6 +1165,34 @@ def test_stream_remote_cloud_reads_object_content_in_chunks():
 
         object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
         content.close.assert_called_once_with()
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_s3_reads_key_in_chunks():
+    # boto2 backs both aws_s3 and generic_s3; #19255 reports generic_s3 truncating 4GB downloads to
+    # 3GB, which the tee's size check turns into a failure instead of a corrupt file.
+    with TestConfig(S3_TEST_CONFIG_YAML) as (directory, object_store):
+        key = MagicMock()
+        key.read.side_effect = [b"chunk1", b"chunk2", b""]
+        object_store._bucket = MagicMock()
+        object_store._bucket.get_key.return_value = key
+
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
+
+        object_store._bucket.get_key.assert_called_once_with("000/dataset_1.dat")
+        assert key.read.call_args_list == [call(STREAM_CHUNK_SIZE)] * 3
+        # fast=True, or releasing an abandoned key would first read the rest of the object.
+        key.close.assert_called_once_with(fast=True)
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_s3_returns_none_for_a_missing_key():
+    with TestConfig(S3_TEST_CONFIG_YAML) as (directory, object_store):
+        object_store._bucket = MagicMock()
+        object_store._bucket.get_key.return_value = None
+
+        assert object_store._stream_remote("000/dataset_1.dat") is None
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -992,6 +992,28 @@ def test_get_data_stream_concurrent_streams_do_not_corrupt_cache():
 
 
 @patch_object_stores_to_skip_initialize
+def test_atomic_download_concurrent_downloads_do_not_share_a_temp_file():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        dataset = MockDataset(1)
+        cache_path = _cache_path_for(object_store, dataset)
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+
+        # Two downloads of the same uncached object overlap: sharing one temp file lets the second
+        # truncate what the first is still writing, publishing a corrupt object into the cache.
+        with object_store._atomic_download(cache_path) as first_tmp:
+            with object_store._atomic_download(cache_path) as second_tmp:
+                assert first_tmp != second_tmp
+                with open(second_tmp, "wb") as f:
+                    f.write(b"a complete object")
+            with open(first_tmp, "wb") as f:
+                f.write(b"a complete object")
+
+        with open(cache_path, "rb") as f:
+            assert f.read() == b"a complete object"
+        assert _leftover_temp_files(cache_path) == []
+
+
+@patch_object_stores_to_skip_initialize
 def test_stream_remote_boto3_reads_object_body_in_chunks():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         body = MagicMock()

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1184,6 +1184,9 @@ def test_stream_remote_cloud_reads_object_content_in_chunks():
             assert list(chunks) == [b"chunk1", b"chunk2"]
 
         object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
+        # Chunk size is the caller's to set (cloudbridge >= 4.4.0); left to the provider it was
+        # 4 KiB on AWS, which costs a threadpool hop per 4 KiB of a multi-GB download.
+        key.iter_content.assert_called_once_with(chunk_size=STREAM_CHUNK_SIZE)
         content.close.assert_called_once_with()
 
 

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -20,6 +20,7 @@ from galaxy.objectstore import (
     ObjectStoreAuth,
     persist_extra_files_for_dataset,
 )
+from galaxy.objectstore._caching_base import closing_stream
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -823,12 +824,17 @@ def _leftover_temp_files(cache_path):
     return [name for name in os.listdir(cache_dir) if name.endswith(".tmp")]
 
 
+def _remote_stream(chunks, on_close=None):
+    """Build what `_stream_remote` returns: an open read, plus the call that releases it."""
+    return closing_stream(iter(chunks), on_close or (lambda: None))
+
+
 @patch_object_stores_to_skip_initialize
 def test_get_data_stream_tees_remote_bytes_into_cache():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -846,7 +852,7 @@ def test_get_data_stream_discards_partial_cache_when_client_disconnects():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -870,7 +876,7 @@ def test_get_data_stream_discards_partial_cache_when_remote_read_fails():
             raise OSError("connection reset by the object store")
 
         with (
-            patch.object(object_store, "_stream_remote", return_value=failing_chunks()),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream(failing_chunks())),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -889,7 +895,7 @@ def test_get_data_stream_bypasses_cache_when_object_is_bigger_than_cache():
         dataset = MockDataset(1)
         one_terabyte = 1024**4
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1", b"chunk2"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1", b"chunk2"])),
             patch.object(object_store, "_get_remote_size", return_value=one_terabyte),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -907,7 +913,7 @@ def test_get_data_stream_does_not_cache_a_truncated_object():
         dataset = MockDataset(1)
         # The store says the object is 12 bytes but the stream ends after 6.
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_stream_remote", return_value=_remote_stream([b"chunk1"])),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             stream = object_store.get_data_stream(dataset)
@@ -927,10 +933,90 @@ def test_get_data_stream_returns_none_when_remote_size_is_unknown():
         # Backends report an unknown size as a negative number; without a size there is nothing to
         # check a streamed object against, so fall back to pulling it into the cache.
         with (
-            patch.object(object_store, "_stream_remote", return_value=iter([b"chunk1"])),
+            patch.object(object_store, "_stream_remote") as stream_remote,
             patch.object(object_store, "_get_remote_size", return_value=-1),
         ):
             assert object_store.get_data_stream(MockDataset(1)) is None
+            # Deciding against streaming after opening the read would strand the connection: nobody
+            # owns it once None is returned in its place.
+            stream_remote.assert_not_called()
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_does_not_open_a_read_it_cannot_hand_over():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        # Same reason, for the other way the decision can go wrong: a size lookup that raises.
+        with (
+            patch.object(object_store, "_stream_remote") as stream_remote,
+            patch.object(object_store, "_get_remote_size", side_effect=OSError("no such key")),
+        ):
+            assert object_store.get_data_stream(MockDataset(1)) is None
+            stream_remote.assert_not_called()
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_the_client_disconnects():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            assert next(stream) == b"chunk1"
+            stream.close()
+            # An abandoned read has to hand its connection back, or a cancelled download costs one
+            # from the pool for as long as the store keeps the response open.
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_it_errors():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+
+        def failing_chunks():
+            yield b"chunk1"
+            raise OSError("connection reset by the object store")
+
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream(failing_chunks(), on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            with pytest.raises(OSError):
+                b"".join(stream)
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_when_it_is_not_cached():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        one_terabyte = 1024**4
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=one_terabyte),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            # The bigger-than-cache path skips the tee entirely; it still owns the read.
+            assert b"".join(stream) == b"chunk1chunk2"
+            assert closed == [True]
 
 
 @patch_object_stores_to_skip_initialize
@@ -973,7 +1059,9 @@ def test_get_data_stream_concurrent_streams_do_not_corrupt_cache():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         dataset = MockDataset(1)
         with (
-            patch.object(object_store, "_stream_remote", side_effect=lambda rel_path: iter([b"chunk1", b"chunk2"])),
+            patch.object(
+                object_store, "_stream_remote", side_effect=lambda rel_path: _remote_stream([b"chunk1", b"chunk2"])
+            ),
             patch.object(object_store, "_get_remote_size", return_value=12),
         ):
             first = object_store.get_data_stream(dataset)
@@ -1021,12 +1109,29 @@ def test_stream_remote_boto3_reads_object_body_in_chunks():
         object_store._client = MagicMock()
         object_store._client.get_object.return_value = {"Body": body}
 
-        chunks = object_store._stream_remote("000/dataset_1.dat")
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
 
-        assert list(chunks) == [b"chunk1", b"chunk2"]
         _, call_kwargs = object_store._client.get_object.call_args
         assert call_kwargs["Bucket"] == object_store.bucket
         assert call_kwargs["Key"] == "000/dataset_1.dat"
+
+
+@patch_object_stores_to_skip_initialize
+def test_stream_remote_boto3_closes_the_response_body_not_just_the_chunk_iterator():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        body = MagicMock()
+        # botocore builds iter_chunks as a plain generator over StreamingBody.read, so closing it
+        # ends the loop and leaves the response -- and its pooled connection -- open.
+        body.iter_chunks.return_value = iter([b"chunk1", b"chunk2"])
+        object_store._client = MagicMock()
+        object_store._client.get_object.return_value = {"Body": body}
+
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert next(chunks) == b"chunk1"
+            body.close.assert_not_called()
+
+        body.close.assert_called_once_with()
 
 
 @patch_object_stores_to_skip_initialize
@@ -1035,9 +1140,9 @@ def test_stream_remote_azure_reads_blob_in_chunks():
         blob_client = MagicMock()
         blob_client.download_blob.return_value.chunks.return_value = iter([b"chunk1", b"chunk2"])
         with patch.object(object_store, "_blob_client", return_value=blob_client) as blob_client_for:
-            chunks = object_store._stream_remote("000/dataset_1.dat")
+            with object_store._stream_remote("000/dataset_1.dat") as chunks:
+                assert list(chunks) == [b"chunk1", b"chunk2"]
 
-            assert list(chunks) == [b"chunk1", b"chunk2"]
             blob_client_for.assert_called_once_with("000/dataset_1.dat")
 
 
@@ -1045,14 +1150,17 @@ def test_stream_remote_azure_reads_blob_in_chunks():
 def test_stream_remote_cloud_reads_object_content_in_chunks():
     with TestConfig(get_example("cloud_aws_simple.yml")) as (directory, object_store):
         key = MagicMock()
-        key.iter_content.return_value = iter([b"chunk1", b"chunk2"])
+        content = MagicMock()
+        content.__iter__.return_value = iter([b"chunk1", b"chunk2"])
+        key.iter_content.return_value = content
         object_store.bucket = MagicMock()
         object_store.bucket.objects.get.return_value = key
 
-        chunks = object_store._stream_remote("000/dataset_1.dat")
+        with object_store._stream_remote("000/dataset_1.dat") as chunks:
+            assert list(chunks) == [b"chunk1", b"chunk2"]
 
-        assert list(chunks) == [b"chunk1", b"chunk2"]
         object_store.bucket.objects.get.assert_called_once_with("000/dataset_1.dat")
+        content.close.assert_called_once_with()
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -980,6 +980,26 @@ def test_get_data_stream_releases_the_remote_read_when_the_client_disconnects():
 
 
 @patch_object_stores_to_skip_initialize
+def test_get_data_stream_releases_the_remote_read_before_the_first_chunk():
+    with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
+        closed = []
+        with (
+            patch.object(
+                object_store,
+                "_stream_remote",
+                return_value=_remote_stream([b"chunk1", b"chunk2"], on_close=lambda: closed.append(True)),
+            ),
+            patch.object(object_store, "_get_remote_size", return_value=12),
+        ):
+            stream = object_store.get_data_stream(MockDataset(1))
+            assert stream is not None
+            stream.close()
+            # A client can disappear while response headers are being sent, before Starlette asks
+            # the iterator for its first chunk. The already-open read must still be released.
+            assert closed == [True]
+
+
+@patch_object_stores_to_skip_initialize
 def test_get_data_stream_releases_the_remote_read_when_it_errors():
     with TestConfig(BOTO3_TEE_STREAMING_TEST_CONFIG_YAML) as (directory, object_store):
         closed = []

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -22,7 +22,7 @@ from galaxy.objectstore import (
     persist_extra_files_for_dataset,
 )
 from galaxy.objectstore._caching_base import (
-    closing_stream,
+    RemoteDataStream,
     STREAM_CHUNK_SIZE,
 )
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
@@ -830,7 +830,7 @@ def _leftover_temp_files(cache_path):
 
 def _remote_stream(chunks, on_close=None):
     """Build what `_stream_remote` returns: an open read, plus the call that releases it."""
-    return closing_stream(iter(chunks), on_close or (lambda: None))
+    return RemoteDataStream(iter(chunks), on_close or (lambda: None))
 
 
 @patch_object_stores_to_skip_initialize

--- a/test/unit/webapps/galaxy/services/test_datasets_service.py
+++ b/test/unit/webapps/galaxy/services/test_datasets_service.py
@@ -1,6 +1,11 @@
+from unittest.mock import MagicMock
+
 import pytest
 
-from galaxy.webapps.galaxy.services.datasets import is_direct_download_candidate
+from galaxy.webapps.galaxy.services.datasets import (
+    DatasetsService,
+    is_direct_download_candidate,
+)
 
 
 @pytest.mark.parametrize(
@@ -25,3 +30,99 @@ from galaxy.webapps.galaxy.services.datasets import is_direct_download_candidate
 )
 def test_is_direct_download_candidate(filename, to_ext, raw, offset, ck_size, is_archive, expected):
     assert is_direct_download_candidate(filename, to_ext, raw, offset, ck_size, is_archive) is expected
+
+
+def _service_for_display(
+    *,
+    data_stream=None,
+    is_archive: bool = False,
+    remote_size: int = 4,
+):
+    """Build a DatasetsService whose object store yields ``data_stream`` for the dataset."""
+    service = DatasetsService(*(MagicMock() for _ in range(10)))
+    dataset_instance = MagicMock()
+    dataset_instance.datatype.is_archive_download.return_value = is_archive
+    dataset_instance.datatype.download_content_disposition.return_value = 'attachment; filename="Galaxy1.txt"'
+    dataset_instance.datatype.display_data.return_value = ("display-data", {})
+    service.hda_manager.get_accessible.return_value = dataset_instance
+
+    trans = MagicMock()
+    trans.app.object_store.get_data_stream.return_value = data_stream
+    trans.app.object_store.size.return_value = remote_size
+    return service, trans, dataset_instance
+
+
+def test_display_streams_whole_file_download_from_object_store():
+    chunks = iter([b"chun", b"ked"])
+    service, trans, dataset_instance = _service_for_display(data_stream=chunks, remote_size=7)
+
+    rval, headers = service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    # The object-store stream is handed back untouched -- no pull into cache, no datatype processing.
+    assert rval is chunks
+    dataset_instance.datatype.display_data.assert_not_called()
+    assert headers["content-type"] == "application/octet-stream"
+    assert headers["Content-Disposition"] == 'attachment; filename="Galaxy1.txt"'
+    # Content-Length comes from the store so the client can show download progress.
+    assert headers["Content-Length"] == "7"
+    # A forward-only stream cannot answer range requests, so it must not claim it can.
+    assert "accept-ranges" not in headers
+
+
+def test_display_omits_content_length_when_object_store_size_is_unknown():
+    chunks = iter([b"data"])
+    service, trans, _ = _service_for_display(data_stream=chunks, remote_size=0)
+
+    _, headers = service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    assert "Content-Length" not in headers
+
+
+def test_display_does_not_stream_when_caller_needs_random_access():
+    service, trans, dataset_instance = _service_for_display(data_stream=iter([b"data"]))
+
+    # allow_stream=False is how a HEAD or Range request (and every legacy caller) asks for a
+    # seekable file rather than a one-shot stream.
+    rval, _ = service.display(trans, 1, to_ext="txt", allow_stream=False)
+
+    trans.app.object_store.get_data_stream.assert_not_called()
+    dataset_instance.datatype.display_data.assert_called_once()
+    assert rval == "display-data"
+
+
+def test_display_falls_back_when_object_store_cannot_stream():
+    service, trans, dataset_instance = _service_for_display(data_stream=None)
+
+    rval, _ = service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    trans.app.object_store.get_data_stream.assert_called_once()
+    dataset_instance.datatype.display_data.assert_called_once()
+    assert rval == "display-data"
+
+
+def test_display_does_not_stream_previews():
+    service, trans, dataset_instance = _service_for_display(data_stream=iter([b"data"]))
+
+    # No to_ext: a preview is processed by the datatype, not served as stored bytes.
+    service.display(trans, 1, allow_stream=True)
+
+    trans.app.object_store.get_data_stream.assert_not_called()
+    dataset_instance.datatype.display_data.assert_called_once()
+
+
+def test_display_does_not_stream_archive_downloads():
+    service, trans, dataset_instance = _service_for_display(data_stream=iter([b"data"]), is_archive=True)
+
+    # Composite/archived datatypes are zipped on the fly, so the stored object is not what is served.
+    service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    trans.app.object_store.get_data_stream.assert_not_called()
+    dataset_instance.datatype.display_data.assert_called_once()
+
+
+def test_display_does_not_stream_raw_requests():
+    service, trans, _ = _service_for_display(data_stream=iter([b"data"]))
+
+    service.display(trans, 1, to_ext="txt", raw=True, allow_stream=True)
+
+    trans.app.object_store.get_data_stream.assert_not_called()

--- a/test/unit/webapps/galaxy/services/test_datasets_service.py
+++ b/test/unit/webapps/galaxy/services/test_datasets_service.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -44,7 +45,7 @@ def _service_for_display(
     dataset_instance.datatype.is_archive_download.return_value = is_archive
     dataset_instance.datatype.download_content_disposition.return_value = 'attachment; filename="Galaxy1.txt"'
     dataset_instance.datatype.display_data.return_value = ("display-data", {})
-    service.hda_manager.get_accessible.return_value = dataset_instance
+    cast(MagicMock, service.hda_manager).get_accessible.return_value = dataset_instance
 
     trans = MagicMock()
     trans.app.object_store.get_data_stream.return_value = data_stream

--- a/test/unit/webapps/galaxy/services/test_datasets_service.py
+++ b/test/unit/webapps/galaxy/services/test_datasets_service.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from galaxy.exceptions import InternalServerError
 from galaxy.webapps.galaxy.services.datasets import (
     DatasetsService,
     is_direct_download_candidate,
@@ -68,6 +69,27 @@ def test_display_streams_whole_file_download_from_object_store():
     assert headers["Content-Length"] == "7"
     # A forward-only stream cannot answer range requests, so it must not claim it can.
     assert "accept-ranges" not in headers
+
+
+def test_display_closes_object_store_stream_when_logging_fails():
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+    service, trans, _ = _service_for_display(data_stream=body)
+    trans.log_event.side_effect = RuntimeError("could not log download")
+
+    with pytest.raises(InternalServerError):
+        service.display(trans, 1, to_ext="txt", allow_stream=True)
+
+    assert body.closed is True
 
 
 def test_display_omits_content_length_when_object_store_size_is_unknown():

--- a/test/unit/webapps/test_streaming_response.py
+++ b/test/unit/webapps/test_streaming_response.py
@@ -10,6 +10,10 @@ objects, and assert the sessions are closed *before* the first body byte.
 
 from types import SimpleNamespace
 
+import pytest
+from starlette.requests import ClientDisconnect
+from starlette.responses import StreamingResponse
+
 from galaxy.webapps.base.api import (
     GalaxyFileResponse,
     GalaxyStreamingResponse,
@@ -118,6 +122,59 @@ async def test_streaming_no_app_bound_is_noop(monkeypatch):
     messages: list = []
     await response.stream_response(await _collect(messages))
     assert any(m["type"] == "http.response.body" for m in messages)
+
+
+async def test_streaming_closes_sync_body_when_client_disconnects_before_first_chunk(monkeypatch):
+    _install_fake_app(monkeypatch, app_present=False)
+
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+    response = GalaxyStreamingResponse(body)
+
+    async def send(_message):
+        # ASGI 2.4 reports a disconnect as an OSError from send. This happens while Starlette is
+        # sending http.response.start, before it advances the synchronous body iterator.
+        raise OSError("client disconnected")
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    with pytest.raises(ClientDisconnect):
+        await response({"type": "http", "method": "GET", "asgi": {"spec_version": "2.4"}}, receive, send)
+
+    assert body.closed is True
+
+
+def test_streaming_closes_sync_body_when_response_construction_fails(monkeypatch):
+    class ClosableBody:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter([b"data"])
+
+        def close(self):
+            self.closed = True
+
+    body = ClosableBody()
+
+    def fail_to_construct(*_args, **_kwargs):
+        raise RuntimeError("could not construct response")
+
+    monkeypatch.setattr(StreamingResponse, "__init__", fail_to_construct)
+    with pytest.raises(RuntimeError, match="could not construct response"):
+        GalaxyStreamingResponse(body)
+
+    assert body.closed is True
 
 
 async def test_file_response_releases_before_response_start(monkeypatch, tmp_path):


### PR DESCRIPTION
Serving a dataset from a remote object store pulls the **whole object into the local cache before sending a single byte**. For large datasets that has two failure modes, both reported in #19255:

1. **504 time-to-first-byte timeouts.** The client gets nothing until an 8–10 GB object has been pulled, so any large download behind a proxy fails.
2. **Bigger-than-cache downloads fail outright.** `_caching_allowed` refuses to pull an object larger than the cache, so it can never be downloaded at all.

This PR adds *tee-streaming*: Galaxy proxies the object's bytes straight to the client while writing them into the cache on the way past, publishing the cache copy atomically once the whole object has streamed. First byte is immediate, the cache is warmed for free, and objects too big for the cache stream straight through with no cache write.

It is the complement to the presigned-URL redirect (#22895), which only helps object stores whose URLs a client can reach directly. Tee-streaming covers the internal/private backends where the bytes have to flow through Galaxy — and the `/display` route, which by design never redirects.

## How it works

**Object-store layer.** `ObjectStore` grows `get_data_stream(obj) -> Iterator[bytes] | None`, dispatched exactly like `get_direct_download_url`, with a no-op default (disk, Pulsar, `generic_s3`, …) and `NestedObjectStore` routing to the backend holding the object. The tee itself lives in `CachingConcreteObjectStore`, so a backend only has to supply a raw chunk iterator:

- `s3_boto3`: `get_object(...)["Body"].iter_chunks()`
- `s3` (boto2, backing both `aws_s3` and `generic_s3`): `Key.read()` in chunks
- `azure_blob`: `download_blob().chunks()`
- `cloud`: `objects.get(...).iter_content(chunk_size=...)`

`generic_s3` matters here: it is the third backend in #19255, and the one the reporter calls unusable — 4GB+ downloads succeed but arrive silently truncated to about 3GB. The tee compares streamed bytes against the store's size, so that becomes a loud failure rather than a corrupt cached object.

Every other store transparently keeps today's pull-then-serve.

A backend hands back a `RemoteDataStream` — the chunk iterator paired with the SDK call that releases the read — because closing the iterator is not the same thing. botocore's `iter_chunks` is a plain generator over `StreamingBody.read`, so closing it ends the loop and leaves the HTTP response, and its pooled connection, open. Abandoning a read part way is the normal case on this path, not the rare one: it exists for large downloads, which are the ones clients cancel. `get_data_stream` returns a `DataStream` protocol so that obligation is in the type rather than in a comment.

**Serving layer.** `DatasetsService.display()` gains an `allow_stream` parameter and a branch gated on the existing `is_direct_download_candidate` check. The stream falls through to the existing `GalaxyStreamingResponse`, so there is no new response type, route, or schema change. `Content-Length` comes from the store's metadata (clients still get a progress bar); `accept-ranges` is deliberately not advertised on this path.

`allow_stream` is set by the API layer for a plain `GET` with no `Range` header. So these keep their current behavior:

- **Range requests** need random access → pull + `GalaxyFileResponse` (206 from the cached file).
- **HEAD** wants headers only → consuming a stream to discard the bytes would be pure waste (`StreamingResponse` has no HEAD short-circuit, only `FileResponse` does).
- **Previews, chunked display, extra-files access, `raw=True`, and archive/composite downloads** are not whole-file downloads of the stored object.
- **Legacy callers** of `display()` leave `allow_stream` False and are unaffected.
- **Already-cached objects** return `None` from `get_data_stream` and are served from disk, so ranges and X-Accel offload still work.

## Correctness details worth reviewing

- **Truncated streams are never cached.** A chunk iterator can end early without raising; the tee compares the streamed byte count against the object's remote size and refuses to publish on mismatch, so a short read cannot poison the cache with a partial object served as complete. A backend that reports an unknown size (negative) falls back to the pull path rather than streaming bytes it cannot verify.
- **Client disconnects and mid-stream errors** discard the temp file (`_atomic_download` already cleans up on `BaseException`, which covers `GeneratorExit`).
- **Concurrent downloads of the same object no longer share a temp file.** `_atomic_download` named its temp file after the object, so two downloads of the same uncached object wrote to one path: the second's `open()` truncated what the first was still writing, and whichever renamed first published a corrupt object into the cache as if it were complete. Tee-streaming would have widened that race (every client opens its own stream), so it is fixed for all downloads rather than worked around: each gets its own temp file, and whichever finishes last publishes a complete copy. This fixes the same latent race in the existing `_pull_into_cache` path. Temp files orphaned by a hard kill are reaped by the cache monitor like any other cache file.

- **Abandoned streams release their connection.** The tee generator does not enter its `with` until the first `next()`, so three pieces cover the gap: `RemoteDataStream.close()` is idempotent whether or not the manager was entered, `get_data_stream` wraps the tee in an iterator whose `close()` unwinds both, and `GalaxyStreamingResponse` closes synchronous response content on completion, on send failure, and on setup failure. **That last one is worth a second pair of eyes: it applies to every streaming endpoint, not just this feature.** The SSE endpoints (`api/events.py`, `api/plugins.py`) and `api/proxy.py` pass async generators, which expose `aclose` rather than `close`, so they are untouched; what it does reach is `zipstream.response()` behind three `history_contents` archive routes, and the `BytesIO`/`StringIO` buffers behind page PDFs, invocation report PDFs, `serve_workbook` and datasets — all locally built and not read afterwards.

## Notes

- **Default-on, no new config flag.** Tee-streaming applies automatically to caching backends that can stream. It is strictly better than pull-then-serve on time-to-first-byte and thread occupancy, and it fixes bigger-than-cache downloads that fail today. Happy to gate it behind a per-store flag if reviewers prefer.
- **Throughput trade-off.** The pull path uses boto3's `TransferConfig` (parallel multipart); a tee is a single sequential read. TTFB drops to ~0, but aggregate throughput on a fast LAN may be lower. For the multi-GB WAN downloads this targets, the client is the bottleneck.
- Behavior deltas on the first (uncached) whole-file download: no `accept-ranges` header, and `Content-Length` now comes from store metadata rather than the cached file.
- **Requires cloudbridge 4.4.0** for the `cloud` backend. `iter_content()` previously chose the read size itself — 4 KiB on AWS, inherited from a 2017 boto2 shim — which is 2.6 million reads for a 10 GB download, each a threadpool hop. 4.4.0 takes a `chunk_size`, so the backend streams at the same 1 MiB as the others. The version floor is declared in `pyproject.toml` and `conditional-requirements.txt`.
- The remote read is opened last in both `_get_data_stream` and `_stream_from_object_store`, so no path decides against streaming while holding an open connection nobody owns. The cost: a store that cannot stream now pays a remote size lookup before saying so, and `object_store.size()` runs before we know streaming applies. Both are metadata calls in front of a full object pull.
- **One claim I could not verify:** `azure_blob` releases nothing, on the reading that `StorageStreamDownloader` exposes no close and that `chunks()` pulls each chunk with its own ranged request rather than holding one response open. That matches the SDK's documented shape but was not checked against an install. Confirmation welcome.

## Testing

- Unit (`test/unit/objectstore/test_objectstore.py`): cache-warm, disconnect-discard, mid-stream error, truncated stream, unknown remote size, bigger-than-cache bypass, already-cached, backend-cannot-stream, concurrent interleaved streams, the four backend chunk readers, and connection release on disconnect, on error, before the first chunk, on the bigger-than-cache path, and for the two orderings that used to strand an open read.
- Unit (`test/unit/webapps/test_streaming_response.py`): content is closed when the client disconnects before the first chunk, and when response construction fails.
- Unit (`test/unit/webapps/galaxy/services/test_datasets_service.py`): the `display()` branch — headers, `Content-Length` omission when size is unknown, and the fallbacks for `allow_stream=False`, non-streaming stores, previews, archives, and `raw`.
- Integration (`test/integration/objectstore/test_tee_streaming.py`, minio-backed, boto3 and cloud): uncached download streams and warms the cache, the second download is served from the cache with `accept-ranges`, a Range request falls back to 206, HEAD does not stream, previews are not streamed, and a dataset larger than a ~107-byte cache downloads successfully with the cache left empty.

Closes #19255

