### PR TITLE
Refactor Kubernetes PV/PVC setup between integration test classes for reuse

### DIFF
--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -1,8 +1,6 @@
 """Integration tests for realtime tools."""
 
-import json
 import os
-import subprocess
 from typing import (
     Any,
 )
@@ -27,11 +25,10 @@ from .test_containerized_jobs import (
     DOCKERIZED_JOB_CONFIG_FILE,
 )
 from .test_kubernetes_runner import (
+    ingress_for_tool,
     job_config as kubernetes_job_config,
-    KubeSetupConfigTuple,
-    persistent_volume,
-    persistent_volume_claim,
-    TOOL_DIR,
+    KubernetesDatasetPopulator,
+    KubernetesVolumesMixin,
 )
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
@@ -242,7 +239,9 @@ class TestKubeInteractiveToolsRemoteProxyIntegration(AbstractTestCases.BaseInter
 
 
 @integration_util.skip_unless_kubernetes()
-class TestKubernetesNativeInteractiveToolsIntegration(AbstractTestCases.BaseInteractiveToolsTestCase):
+class TestKubernetesNativeInteractiveToolsIntegration(
+    KubernetesVolumesMixin, AbstractTestCases.BaseInteractiveToolsTestCase
+):
     """Interactive tools submitted through ``KubernetesJobRunner`` itself.
 
     ``TestKubeInteractiveToolsRemoteProxyIntegration`` covers interactive tools on
@@ -253,55 +252,29 @@ class TestKubernetesNativeInteractiveToolsIntegration(AbstractTestCases.BaseInte
     proxy and can run wherever a cluster is available.
     """
 
+    dataset_populator: KubernetesDatasetPopulator
     jobs_directory: str
-    persistent_volume_claims: list[KubeSetupConfigTuple]
-    persistent_volumes: list[KubeSetupConfigTuple]
+    claim_prefix = "it-"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config) -> None:
         cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
-        volumes = [
-            (cls.jobs_directory, "it-jobs-directory-volume", "it-jobs-directory-claim"),
-            (TOOL_DIR, "it-tool-directory-volume", "it-tool-directory-claim"),
-        ]
-        cls.persistent_volumes = []
-        cls.persistent_volume_claims = []
-        for path, volume, claim in volumes:
-            volume_obj = persistent_volume(path, volume)
-            volume_obj.setup()
-            cls.persistent_volumes.append(volume_obj)
-            claim_obj = persistent_volume_claim(volume, claim)
-            claim_obj.setup()
-            cls.persistent_volume_claims.append(claim_obj)
+        cls.setup_persistent_volumes(cls.jobs_directory)
         super().handle_galaxy_config_kwds(config)
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
-        config["job_config_file"] = kubernetes_job_config(
-            cls.jobs_directory,
-            jobs_directory_claim="it-jobs-directory-claim",
-            tool_directory_claim="it-tool-directory-claim",
-        ).path
+        config["job_config_file"] = kubernetes_job_config(cls.jobs_directory, claim_prefix=cls.claim_prefix).path
         config["default_job_shell"] = "/bin/sh"
         config["interactivetools_proxy_host"] = KUBERNETES_PROXY_HOST
 
     @classmethod
     def tearDownClass(cls) -> None:
-        for claim in cls.persistent_volume_claims:
-            claim.teardown()
-        for volume in cls.persistent_volumes:
-            volume.teardown()
+        cls.teardown_persistent_volumes()
         super().tearDownClass()
-
-    @staticmethod
-    def ingress_for_tool(tool_id: str) -> dict[str, Any]:
-        ingresses = json.loads(subprocess.check_output(["kubectl", "get", "ingress", "-o", "json"]))["items"]
-        matching = [
-            i
-            for i in ingresses
-            if (i["metadata"].get("annotations") or {}).get("app.galaxyproject.org/tool_id") == tool_id
-        ]
-        assert len(matching) == 1, f"Expected exactly one ingress for {tool_id}, got {matching}"
-        return matching[0]
 
     def test_entry_point_and_ingress(self, history_id: str) -> None:
         response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, history_id)
@@ -311,7 +284,7 @@ class TestKubernetesNativeInteractiveToolsIntegration(AbstractTestCases.BaseInte
 
         # interactivetool_simple declares requires_domain, so the runner routes it by
         # host and the ingress path stays at the root.
-        ingress = self.ingress_for_tool("interactivetool_simple")
+        ingress = ingress_for_tool("interactivetool_simple")
         rules = ingress["spec"]["rules"]
         assert len(rules) == 1, rules
         assert rules[0]["host"].endswith(f".{KUBERNETES_PROXY_HOST}"), rules[0]["host"]

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import time
 from typing import (
+    Any,
     Literal,
     overload,
 )
@@ -95,11 +96,31 @@ spec:
     return KubeSetupConfigTuple(path=volume_claim.name)
 
 
-def job_config(
-    jobs_directory: str,
-    jobs_directory_claim: str = "jobs-directory-claim",
-    tool_directory_claim: str = "tool-directory-claim",
-) -> Config:
+def kubectl_get(kind: str, name: str | None = None) -> dict[str, Any]:
+    """Return ``kubectl get <kind> [<name>] -o json``, parsed.
+
+    Tests observe the cluster through kubectl rather than through pykube_util so
+    that an assertion does not go through the same client the runner used to
+    create the object it is checking.
+    """
+    command = ["kubectl", "get", kind]
+    if name is not None:
+        command.append(name)
+    command += ["-o", "json"]
+    return json.loads(unicodify(subprocess.check_output(command)))
+
+
+def ingress_for_tool(tool_id: str) -> dict[str, Any]:
+    """The single ingress the Kubernetes runner created for ``tool_id``."""
+    ingresses = kubectl_get("ingress")["items"]
+    matching = [
+        i for i in ingresses if (i["metadata"].get("annotations") or {}).get("app.galaxyproject.org/tool_id") == tool_id
+    ]
+    assert len(matching) == 1, f"Expected exactly one ingress for {tool_id}, got {matching}"
+    return matching[0]
+
+
+def job_config(jobs_directory: str, claim_prefix: str = "") -> Config:
     job_conf_template = string.Template("""<job_conf>
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
@@ -143,9 +164,9 @@ def job_config(
 """)
     job_conf_str = job_conf_template.substitute(
         jobs_directory=jobs_directory,
-        jobs_directory_claim=jobs_directory_claim,
+        jobs_directory_claim=f"{claim_prefix}jobs-directory-claim",
         tool_directory=TOOL_DIR,
-        tool_directory_claim=tool_directory_claim,
+        tool_directory_claim=f"{claim_prefix}tool-directory-claim",
         k8s_config_path=integration_util.k8s_config_path(),
     )
     with tempfile.NamedTemporaryFile(suffix="_kubernetes_integration_job_conf.xml", mode="w", delete=False) as job_conf:
@@ -166,33 +187,24 @@ class KubernetesDatasetPopulator(DatasetPopulator):
             raise
 
 
-@integration_util.skip_unless_kubernetes()
-class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
-    dataset_populator: KubernetesDatasetPopulator
-    job_config: Config
-    jobs_directory: str
+class KubernetesVolumesMixin:
+    """Cluster-wide volumes and claims for the jobs and tool directories.
+
+    Mix in ahead of the integration test case, call :meth:`setup_persistent_volumes`
+    from ``handle_galaxy_config_kwds``, and pass ``claim_prefix`` on to
+    :func:`job_config` so the job config names the claims this created. Test classes
+    that may share a cluster give ``claim_prefix`` distinct values.
+    """
+
+    claim_prefix = ""
     persistent_volume_claims: list[KubeSetupConfigTuple]
     persistent_volumes: list[KubeSetupConfigTuple]
-    container_type = "docker"
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)
 
     @classmethod
-    def tearDownClass(cls) -> None:
-        for claim in cls.persistent_volume_claims:
-            claim.teardown()
-        for volume in cls.persistent_volumes:
-            volume.teardown()
-        super().tearDownClass()
-
-    @classmethod
-    def handle_galaxy_config_kwds(cls, config) -> None:
-        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
+    def setup_persistent_volumes(cls, jobs_directory: str) -> None:
         volumes = [
-            (cls.jobs_directory, "jobs-directory-volume", "jobs-directory-claim"),
-            (TOOL_DIR, "tool-directory-volume", "tool-directory-claim"),
+            (jobs_directory, f"{cls.claim_prefix}jobs-directory-volume", f"{cls.claim_prefix}jobs-directory-claim"),
+            (TOOL_DIR, f"{cls.claim_prefix}tool-directory-volume", f"{cls.claim_prefix}tool-directory-claim"),
         ]
         cls.persistent_volumes = []
         cls.persistent_volume_claims = []
@@ -203,7 +215,36 @@ class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJob
             claim_obj = persistent_volume_claim(volume, claim)
             claim_obj.setup()
             cls.persistent_volume_claims.append(claim_obj)
-        cls.job_config = job_config(jobs_directory=cls.jobs_directory)
+
+    @classmethod
+    def teardown_persistent_volumes(cls) -> None:
+        for claim in cls.persistent_volume_claims:
+            claim.teardown()
+        for volume in cls.persistent_volumes:
+            volume.teardown()
+
+
+@integration_util.skip_unless_kubernetes()
+class TestKubernetesIntegration(KubernetesVolumesMixin, BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+    dataset_populator: KubernetesDatasetPopulator
+    job_config: Config
+    jobs_directory: str
+    container_type = "docker"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.teardown_persistent_volumes()
+        super().tearDownClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
+        cls.setup_persistent_volumes(cls.jobs_directory)
+        cls.job_config = job_config(cls.jobs_directory, claim_prefix=cls.claim_prefix)
         # TODO: implement metadata setting as separate job, as service or side-car
         super().handle_galaxy_config_kwds(config)
         config["jobs_directory"] = cls.jobs_directory
@@ -254,8 +295,7 @@ class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJob
 
             external_id = job.job_runner_external_id
             assert external_id
-            output = unicodify(subprocess.check_output(["kubectl", "get", "job", external_id, "-o", "json"]))
-            status = json.loads(output)
+            status = kubectl_get("job", external_id)
             assert status["status"]["active"] == 1
 
             delete_response = self.dataset_populator.cancel_job(job_dict["id"])
@@ -291,8 +331,7 @@ class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJob
 
             external_id = job.job_runner_external_id
             assert external_id
-            output = unicodify(subprocess.check_output(["kubectl", "get", "job", external_id, "-o", "json"]))
-            status = json.loads(output)
+            status = kubectl_get("job", external_id)
             assert status["status"]["active"] == 1
 
             output = unicodify(subprocess.check_output(["kubectl", "delete", "job", external_id, "-o", "name"]))


### PR DESCRIPTION
TestKubernetesNativeInteractiveToolsIntegration copied TestKubernetesIntegration's volume/claim setup and tearDownClass verbatim, differing only in three name strings. Extract KubernetesVolumesMixin so the next Kubernetes test class inherits it instead of copying it a third time.

The mixin's claim_prefix also replaces job_config()'s jobs_directory_claim and tool_directory_claim parameters - one name for the pair, and the job config can no longer name claims the class did not create. Generated job_conf XML is unchanged for both prefixes.

Also reuse what test_kubernetes_runner.py already exports:

- ingress_for_tool() moves there beside the other cluster helpers, and both it and the two "kubectl get job -o json" call sites go through a new kubectl_get().
- The interactive tools case uses KubernetesDatasetPopulator, which dumps "kubectl describe nodes" when a history wait fails.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
