### PR TITLE
Share HTCondor mechanics with Pulsar via util/condor

### DIFF
--- a/doc/source/lib/galaxy.jobs.runners.util.condor.rst
+++ b/doc/source/lib/galaxy.jobs.runners.util.condor.rst
@@ -5,3 +5,22 @@ galaxy.jobs.runners.util.condor package
    :members:
    :undoc-members:
    :show-inheritance:
+
+Submodules
+----------
+
+galaxy.jobs.runners.util.condor.htcondor module
+-----------------------------------------------
+
+.. automodule:: galaxy.jobs.runners.util.condor.htcondor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+galaxy.jobs.runners.util.condor.htcondor\_helper module
+-------------------------------------------------------
+
+.. automodule:: galaxy.jobs.runners.util.condor.htcondor_helper
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/lib/galaxy/jobs/runners/htcondor.py
+++ b/lib/galaxy/jobs/runners/htcondor.py
@@ -32,7 +32,9 @@ from galaxy.jobs.runners.util.condor.htcondor import (
     DEFAULT_MAX_HELD_COUNT,
     FAILURE_EXECUTABLE_ERROR,
     FAILURE_MESSAGES,
+    HELD_GRACE_SECONDS,
     held_message,
+    HELD_TOO_LONG_MESSAGE,
     HOLD_MESSAGES,
     HOLD_REASON_MEMORY_LIMIT,
     HOLD_REASON_WALLTIME,
@@ -65,12 +67,21 @@ HTCONDOR_DESTINATION_KEYS = (
     "htcondor_config",
     "request_walltime",
     "max_held_count",
+    "held_grace_seconds",
     "embed_metadata_in_job",
 )
 HTCONDOR_REMOVE_REASON = "Galaxy job stop request"
 # Module attribute rather than a re-export of the shared default so that tests
 # can redirect the helper subprocess at a stub module.
 HTCONDOR_HELPER_MODULE = htcondor_helper.__name__
+# Galaxy's job model needs a runner_state per hold reason so that the
+# resubmission handler can act on it. Pulsar has no equivalent today; when it
+# grows one (galaxyproject/pulsar#492) this mapping belongs in the shared
+# module alongside HOLD_MESSAGES.
+_HOLD_RUNNER_STATES = {
+    HOLD_REASON_MEMORY_LIMIT: runner_states.MEMORY_LIMIT_REACHED,
+    HOLD_REASON_WALLTIME: runner_states.WALLTIME_REACHED,
+}
 
 
 class HTCondorJobState(AsynchronousJobState, HTCondorEventLogTracker):
@@ -102,6 +113,7 @@ class HTCondorJobState(AsynchronousJobState, HTCondorEventLogTracker):
         )
         HTCondorEventLogTracker.__init__(self, user_log)
         self.failed = False
+        self.held = False
 
 
 class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
@@ -333,9 +345,16 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                 continue
             cjs.clear_missing_log()
 
-            if summary.job_released and cjs.held_count > 0:
-                log.debug(f"({galaxy_id_tag}/{job_id}) job released, resetting held_count from {cjs.held_count} to 0")
-                cjs.held_count = 0
+            if summary.job_released:
+                if cjs.held_count > 0:
+                    log.debug(
+                        f"({galaxy_id_tag}/{job_id}) job released, resetting held_count from {cjs.held_count} to 0"
+                    )
+                    cjs.held_count = 0
+                # A release restarts the grace window - the pool is retrying the
+                # job, possibly against raised resources.
+                cjs.held = False
+                cjs.clear_held()
 
             if job_running:
                 cjs.job_wrapper.check_for_entry_points()
@@ -380,45 +399,58 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                     model.Job.states.DELETED,
                     model.Job.states.STOPPED,
                 ):
-                    # Classify the hold by HoldReasonCode before applying the
-                    # generic held_count escalation logic.
-                    hold_reason = classify_hold(hold_reason_code)
-                    if hold_reason == HOLD_REASON_MEMORY_LIMIT:
-                        log.info(
-                            f"({galaxy_id_tag}/{job_id}) job held for memory limit (HoldReasonCode={hold_reason_code})"
+                    # A hold is not by itself terminal: the pool may release the
+                    # job on its own, and sites commonly configure
+                    # periodic_release to retry a held job - sometimes against a
+                    # raised request_memory. Failing on the hold reason alone
+                    # would pre-empt that policy, so escalate on how long the
+                    # hold lasts and on how often it recurs instead.
+                    cjs.held = True
+                    if summary.job_held_event:
+                        cjs.held_count += 1
+                        # max_held_count: destination parameter, counts distinct
+                        # JOB_HELD events (default 3, 0 = disabled). Bounds
+                        # hold/release thrashing, which the grace window below
+                        # cannot catch because each release restarts it.
+                        max_held_count = int(
+                            cjs.job_wrapper.job_destination.params.get("max_held_count", DEFAULT_MAX_HELD_COUNT)
                         )
-                        cjs.fail_message = HOLD_MESSAGES[hold_reason]
-                        cjs.runner_state = runner_states.MEMORY_LIMIT_REACHED
-                        cjs.close_event_log()
-                        self.work_queue.put((self.fail_job, cjs))
-                        continue
-                    if hold_reason == HOLD_REASON_WALLTIME:
-                        log.info(f"({galaxy_id_tag}/{job_id}) job held by periodic_hold expression (walltime)")
-                        cjs.fail_message = HOLD_MESSAGES[hold_reason]
-                        cjs.runner_state = runner_states.WALLTIME_REACHED
-                        cjs.close_event_log()
-                        self.work_queue.put((self.fail_job, cjs))
-                        continue
-                    cjs.held_count += 1
-                    # max_held_count: destination parameter, counts distinct JOB_HELD events (default 3, 0 = disabled)
-                    max_held_count = int(
-                        cjs.job_wrapper.job_destination.params.get("max_held_count", DEFAULT_MAX_HELD_COUNT)
+                        if max_held_count > 0 and cjs.held_count >= max_held_count:
+                            log.warning(
+                                f"({galaxy_id_tag}/{job_id}) Job held {cjs.held_count} "
+                                "times without release, failing permanently"
+                            )
+                            cjs.fail_message = held_message(cjs.held_count)
+                            cjs.runner_state = runner_states.UNKNOWN_ERROR
+                            cjs.close_event_log()
+                            self.work_queue.put((self.fail_job, cjs))
+                            continue
+                    held_grace_seconds = float(
+                        cjs.job_wrapper.job_destination.params.get("held_grace_seconds", HELD_GRACE_SECONDS)
                     )
-                    if max_held_count > 0 and cjs.held_count >= max_held_count:
-                        log.warning(
-                            f"({galaxy_id_tag}/{job_id}) Job held {cjs.held_count} "
-                            "times without release, failing permanently"
+                    elapsed = cjs.note_held(hold_reason_code)
+                    if elapsed >= held_grace_seconds:
+                        hold_reason = classify_hold(cjs.held_reason_code)
+                        log.info(
+                            f"({galaxy_id_tag}/{job_id}) job held {elapsed:.0f}s without release "
+                            f"(HoldReasonCode={cjs.held_reason_code}), failing"
                         )
-                        cjs.fail_message = held_message(cjs.held_count)
-                        cjs.runner_state = runner_states.UNKNOWN_ERROR
+                        cjs.fail_message = HOLD_MESSAGES.get(hold_reason, HELD_TOO_LONG_MESSAGE)
+                        cjs.runner_state = _HOLD_RUNNER_STATES.get(hold_reason, runner_states.UNKNOWN_ERROR)
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
                         continue
+                    log.debug(
+                        f"({galaxy_id_tag}/{job_id}) job held {elapsed:.0f}s of {held_grace_seconds:.0f}s "
+                        f"(HoldReasonCode={cjs.held_reason_code}), held count {cjs.held_count}"
+                    )
                     cjs.job_wrapper.change_state(model.Job.states.QUEUED)
                 cjs.running = False
                 new_watched.append(cjs)
                 continue
             cjs.running = job_running
+            cjs.held = False
+            cjs.clear_held()
             new_watched.append(cjs)
         self.watched = new_watched
 
@@ -469,7 +501,7 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
     def _summarize_event_log(self, cjs: HTCondorJobState):
         if cjs.job_id is None:
             raise RuntimeError("Missing HTCondor job_id while summarizing event log.")
-        return cjs.summarize(self.htcondor, int(cjs.job_id), cjs.running)
+        return cjs.summarize(self.htcondor, int(cjs.job_id), cjs.running, cjs.held)
 
     def _apply_failure_event(self, cjs: HTCondorJobState, failure_event: int) -> None:
         """Set fail_message and runner_state on cjs based on the HTCondor failure event type."""

--- a/lib/galaxy/jobs/runners/htcondor.py
+++ b/lib/galaxy/jobs/runners/htcondor.py
@@ -1,34 +1,53 @@
 """Job control via the HTCondor DRM using the htcondor2 Python API.
 
+The HTCondor mechanics — the htcondor2 import, schedd clients, event-log
+parsing and hold/failure classification — live in
+:mod:`galaxy.jobs.runners.util.condor.htcondor`, which is shared with Pulsar.
+This module maps that vocabulary onto Galaxy's job model.
+
 See the Galaxy cluster documentation (doc/source/admin/cluster.md) for
 configuration, architecture details, and testing instructions.
 """
 
-import json
 import logging
 import os
-import select
 import shlex
 import subprocess
-import sys
-import threading
-from collections import deque
-from typing import (
-    Any,
-    NamedTuple,
-    TYPE_CHECKING,
-)
+from typing import TYPE_CHECKING
 
 from galaxy import model
 from galaxy.jobs.runners import (
     AsynchronousJobRunner,
     AsynchronousJobState,
 )
-from galaxy.jobs.runners.htcondor_helper import _locate_schedd
 from galaxy.jobs.runners.util import runner_states
 from galaxy.jobs.runners.util.condor import (
     build_submit_description,
+    htcondor_helper,
     submission_params,
+)
+from galaxy.jobs.runners.util.condor.htcondor import (
+    classify_failure_event,
+    classify_hold,
+    DEFAULT_MAX_HELD_COUNT,
+    FAILURE_EXECUTABLE_ERROR,
+    FAILURE_MESSAGES,
+    held_message,
+    HOLD_MESSAGES,
+    HOLD_REASON_MEMORY_LIMIT,
+    HOLD_REASON_WALLTIME,
+    HTCondorClientCache,
+    HTCondorEventLogTracker,
+    import_htcondor,
+    MISSING_LOG_GRACE_SECONDS,
+    MISSING_LOG_MESSAGE,
+    normalize_condor_config,
+    parse_memory_mb,
+    parse_walltime_seconds,
+    periodic_hold_expression,
+    SIGKILL,
+    SIGKILL_MESSAGE,
+    STATUS_ERROR_GRACE_SECONDS,
 )
 from galaxy.util import asbool
 
@@ -48,328 +67,13 @@ HTCONDOR_DESTINATION_KEYS = (
     "max_held_count",
     "embed_metadata_in_job",
 )
-HTCONDOR_HELPER_MODULE = "galaxy.jobs.runners.htcondor_helper"
-HTCONDOR_HELPER_TIMEOUT = 30
-# Number of consecutive status-check errors before a job is failed.  A small
-# count absorbs transient filesystem hiccups (e.g. NFS timeouts reading the
-# event log) without masking genuine persistent failures.
-MAX_STATUS_ERROR_COUNT = 3
-# Number of consecutive monitor cycles in which the event log is absent before
-# a job is failed.  Covers the case where the log was never written (e.g.
-# filesystem full at submit time) or was lost after Galaxy restarted.
-MAX_MISSING_LOG_COUNT = 5
-
-# HTCondor HoldReasonCode values that indicate the job was held because it
-# exceeded its memory allocation.  Code 26 is the cgroup-based OOM code used in
-# older HTCondor releases; code 34 ("memory limit exceeded") was introduced in
-# newer releases (~9.x).  Both are defined in condor_holdcodes.h in the HTCondor
-# source tree.  If your cluster reports a different code for OOM holds, add it
-# here and open a PR.
-_HOLD_CODE_MEMORY = frozenset((26, 34))
-# Code 16 ("PeriodicHoldTrue") means a periodic_hold ClassAd expression evaluated
-# to True.  This code has been stable since at least HTCondor 7.x.  Galaxy injects
-# "periodic_hold = (JobDurationSeconds >= N)" when request_walltime is set.
-_HOLD_CODE_PERIODIC = 16
-# SIGKILL from the OS OOM killer appears as a JOB_TERMINATED event with
-# TerminatedNormally=False and TermSignal=9.
-_SIGKILL = 9
-
-_MEMORY_LIMIT_HOLD_MSG = (
-    "This job was held by HTCondor because it exceeded its requested memory. "
-    "Consider increasing request_memory or routing to a destination with more memory."
-)
-_WALLTIME_HOLD_MSG = (
-    "This job was held by HTCondor because it exceeded its maximum run time. "
-    "Consider increasing the walltime or routing to a destination with a longer time limit."
-)
-_SIGKILL_MSG = (
-    "This job was killed because it used more memory than it was allocated. Consider increasing request_memory."
-)
+HTCONDOR_REMOVE_REASON = "Galaxy job stop request"
+# Module attribute rather than a re-export of the shared default so that tests
+# can redirect the helper subprocess at a stub module.
+HTCONDOR_HELPER_MODULE = htcondor_helper.__name__
 
 
-class _EventLogSummary(NamedTuple):
-    job_running: bool
-    job_complete: bool
-    failure_event: int | None
-    job_held: bool
-    term_signal: int | None  # signal that killed the process (e.g. 9), None if normal exit
-    hold_reason_code: int  # HoldReasonCode from JOB_HELD ClassAd, 0 if absent
-    log_missing: bool = False  # True when the event log file does not exist
-    job_released: bool = False  # True when a JOB_RELEASED event was seen this cycle
-
-
-def _parse_memory_mb(value: str) -> int | None:
-    """Parse an HTCondor request_memory value to whole MB.
-
-    HTCondor's default unit is MB.  Recognises the K/M/G/T suffixes (case-
-    insensitive) and their two-letter forms (KB/MB/GB/TB).  Returns None for
-    values that cannot be parsed (e.g. ClassAd expressions).
-    """
-    value = value.strip()
-    _UNITS: dict[str, float] = {"K": 1 / 1024, "M": 1, "G": 1024, "T": 1024 * 1024}
-    upper = value.upper()
-    for suffix, factor in _UNITS.items():
-        for variant in (suffix + "B", suffix):
-            if upper.endswith(variant):
-                numeric = value[: -len(variant)]
-                try:
-                    return max(1, int(float(numeric) * factor))
-                except ValueError:
-                    return None
-    try:
-        return int(float(value))
-    except ValueError:
-        return None
-
-
-def _parse_walltime_seconds(value: str) -> int | None:
-    """Parse a walltime string to a whole number of seconds.
-
-    Accepted formats (matching SLURM's --time convention):
-      seconds          "3600"
-      MM:SS            "90:00"
-      HH:MM:SS         "1:00:00"
-      D-HH:MM:SS       "1-0:00:00"
-
-    Returns None if the value cannot be parsed.
-    """
-    value = value.strip()
-    days = 0
-    if "-" in value:
-        day_part, value = value.split("-", 1)
-        try:
-            days = int(day_part)
-        except ValueError:
-            return None
-    parts = value.split(":")
-    try:
-        if len(parts) == 1:
-            return days * 86400 + int(parts[0])
-        if len(parts) == 2:
-            return days * 86400 + int(parts[0]) * 60 + int(parts[1])
-        if len(parts) == 3:
-            return days * 86400 + int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-    except ValueError:
-        pass
-    return None
-
-
-def _normalize_condor_config(condor_config: str | None) -> str | None:
-    if not condor_config:
-        return None
-    return os.path.realpath(os.path.expanduser(condor_config))
-
-
-class _HTCondorClient:
-    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
-        raise NotImplementedError()
-
-    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
-        raise NotImplementedError()
-
-    def shutdown(self) -> None:
-        pass
-
-
-class _HTCondorInProcessClient(_HTCondorClient):
-    def __init__(self, htcondor):
-        self.htcondor = htcondor
-        self._schedd_cache: dict = {}
-        self._schedd_lock = threading.Lock()
-
-    def _schedd(self, collector: str | None, schedd_name: str | None):
-        return _locate_schedd(self.htcondor, self._schedd_cache, self._schedd_lock, collector, schedd_name)
-
-    def _evict_schedd(self, collector: str | None, schedd_name: str | None) -> None:
-        with self._schedd_lock:
-            self._schedd_cache.pop((collector, schedd_name), None)
-
-    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
-        try:
-            submit_result = self._schedd(collector, schedd_name).submit(self.htcondor.Submit(submit_description))
-            return str(submit_result.cluster())
-        except Exception:
-            self._evict_schedd(collector, schedd_name)
-            raise
-
-    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
-        try:
-            self._schedd(collector, schedd_name).act(
-                self.htcondor.JobAction.Remove, job_spec, reason="Galaxy job stop request"
-            )
-        except Exception:
-            self._evict_schedd(collector, schedd_name)
-            raise
-
-
-class _HTCondorSubprocessClient(_HTCondorClient):
-    def __init__(self, condor_config: str):
-        self.condor_config = condor_config
-        self._lock = threading.Lock()
-        self._process: subprocess.Popen[str] | None = None
-        # Rolling buffer of recent stderr lines for error messages.
-        # Written by the drain thread; read (without the lock) in error paths.
-        self._stderr_lines: deque = deque(maxlen=50)
-
-    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
-        response = self._request(
-            dict(
-                command="submit",
-                collector=collector,
-                schedd_name=schedd_name,
-                submit_description=submit_description,
-            )
-        )
-        return str(response["cluster"])
-
-    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
-        self._request(
-            dict(
-                command="remove",
-                collector=collector,
-                schedd_name=schedd_name,
-                job_spec=job_spec,
-            )
-        )
-
-    def shutdown(self) -> None:
-        with self._lock:
-            process = self._process
-            if process is None:
-                return
-            try:
-                stdin = process.stdin
-                if stdin is not None and not stdin.closed:
-                    stdin.write(json.dumps(dict(command="shutdown")) + "\n")
-                    stdin.flush()
-            except Exception:
-                pass
-            finally:
-                if process.stdin is not None and not process.stdin.closed:
-                    process.stdin.close()
-
-            try:
-                process.wait(timeout=HTCONDOR_HELPER_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=HTCONDOR_HELPER_TIMEOUT)
-            finally:
-                if process.stdout is not None:
-                    process.stdout.close()
-                if process.stderr is not None:
-                    process.stderr.close()
-                self._process = None
-
-    def _request(self, payload):
-        with self._lock:
-            process = self._ensure_process_locked()
-            stdin = process.stdin
-            stdout = process.stdout
-            if stdin is None or stdout is None:
-                raise RuntimeError("HTCondor helper process is missing stdio pipes")
-            try:
-                stdin.write(json.dumps(payload) + "\n")
-                stdin.flush()
-            except Exception as exc:
-                raise RuntimeError(self._helper_failure_message_locked("Failed to write to HTCondor helper")) from exc
-
-            ready, _, _ = select.select([stdout], [], [], HTCONDOR_HELPER_TIMEOUT)
-            if not ready:
-                self._terminate_process_locked(process)
-                raise RuntimeError(
-                    f"HTCondor helper did not respond within {HTCONDOR_HELPER_TIMEOUT}s — killed and will respawn"
-                )
-            line = stdout.readline()
-            if not line:
-                raise RuntimeError(self._helper_failure_message_locked("HTCondor helper exited unexpectedly"))
-            try:
-                response = json.loads(line)
-            except Exception as exc:
-                raise RuntimeError(f"Invalid response from HTCondor helper: {line.rstrip()}") from exc
-            if not response.get("ok"):
-                raise RuntimeError(response.get("error", "Unknown HTCondor helper error"))
-            return response
-
-    def _terminate_process_locked(self, process: "subprocess.Popen[str]") -> None:
-        """Kill a stale/hung helper process and clean up its pipes. Must be called with self._lock held."""
-        try:
-            process.kill()
-            process.wait(timeout=5)
-        except Exception:
-            pass
-        finally:
-            for pipe in (process.stdin, process.stdout, process.stderr):
-                if pipe is not None:
-                    try:
-                        pipe.close()
-                    except Exception:
-                        pass
-            if self._process is process:
-                self._process = None
-
-    def _ensure_process_locked(self):
-        process = self._process
-        if process is not None and process.poll() is None:
-            return process
-        if process is not None:
-            if process.stdin is not None and not process.stdin.closed:
-                process.stdin.close()
-            if process.stdout is not None:
-                process.stdout.close()
-            if process.stderr is not None:
-                process.stderr.close()
-
-        env = os.environ.copy()
-        env["CONDOR_CONFIG"] = self.condor_config
-        env.setdefault("PYTHONUNBUFFERED", "1")
-        # Build PYTHONPATH from sys.path, then append any entries from the existing
-        # PYTHONPATH that are not already present (e.g. paths added only via env var).
-        sys_paths = list(dict.fromkeys(path for path in sys.path if path))
-        for p in os.environ.get("PYTHONPATH", "").split(os.pathsep):
-            if p and p not in sys_paths:
-                sys_paths.append(p)
-        env["PYTHONPATH"] = os.pathsep.join(sys_paths)
-        self._process = subprocess.Popen(
-            [sys.executable, "-m", HTCONDOR_HELPER_MODULE],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-            close_fds=True,
-            env=env,
-        )
-        self._start_stderr_drain(self._process)
-        return self._process
-
-    def _start_stderr_drain(self, process: "subprocess.Popen[str]") -> None:
-        """Drain the helper's stderr into _stderr_lines and the Galaxy log.
-
-        Runs as a daemon thread so HTCondor warnings (e.g. credential expiry)
-        surface in Galaxy's log rather than being silently discarded.
-        """
-
-        def _drain() -> None:
-            try:
-                for line in process.stderr:  # type: ignore[union-attr]
-                    stripped = line.rstrip()
-                    if stripped:
-                        self._stderr_lines.append(stripped)
-                        log.warning("HTCondor helper: %s", stripped)
-            except Exception:
-                pass
-
-        t = threading.Thread(target=_drain, daemon=True, name="htcondor-helper-stderr")
-        t.start()
-
-    def _helper_failure_message_locked(self, message: str) -> str:
-        # Stderr is consumed by the drain thread and buffered in _stderr_lines.
-        if recent := "\n".join(list(self._stderr_lines)[-10:]).strip():
-            return f"{message}: {recent}"
-        return message
-
-
-class HTCondorJobState(AsynchronousJobState):
+class HTCondorJobState(AsynchronousJobState, HTCondorEventLogTracker):
     def __init__(
         self,
         job_wrapper: "MinimalJobWrapper",
@@ -384,7 +88,8 @@ class HTCondorJobState(AsynchronousJobState):
         exit_code_file=None,
         job_name=None,
     ) -> None:
-        super().__init__(
+        AsynchronousJobState.__init__(
+            self,
             job_wrapper,
             job_destination,
             files_dir=files_dir,
@@ -395,25 +100,8 @@ class HTCondorJobState(AsynchronousJobState):
             exit_code_file=exit_code_file,
             job_name=job_name,
         )
+        HTCondorEventLogTracker.__init__(self, user_log)
         self.failed = False
-        self.user_log = user_log
-        self._event_log: Any = None
-        self.status_error_count = 0
-        self.held_count = 0
-        self.missing_log_count = 0
-
-    def event_log(self, htcondor):
-        if self._event_log is None:
-            self._event_log = htcondor.JobEventLog(self.user_log)
-        return self._event_log
-
-    def close_event_log(self) -> None:
-        if self._event_log is not None:
-            try:
-                self._event_log.close()
-            except Exception:
-                pass
-            self._event_log = None
 
 
 class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
@@ -434,16 +122,12 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
         kwargs["runner_param_specs"].update(runner_param_specs)
 
         super().__init__(app, nworkers, **kwargs)
-        try:
-            import htcondor2
-        except Exception as exc:
-            raise ImportError(
-                "The htcondor2 Python package is required to use this feature, please install it or correct the "
-                f"following error:\n{exc.__class__.__name__}: {str(exc)}"
-            ) from exc
-        self.htcondor = htcondor2
-        self._client_cache: dict = {}
-        self._client_lock = threading.Lock()
+        self.htcondor = import_htcondor()
+        self._clients = HTCondorClientCache(
+            self.htcondor,
+            helper_module=HTCONDOR_HELPER_MODULE,
+            remove_reason=HTCONDOR_REMOVE_REASON,
+        )
 
     def shutdown(self):
         try:
@@ -452,14 +136,7 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
             self._shutdown_clients()
 
     def _shutdown_clients(self) -> None:
-        with self._client_lock:
-            clients = list(self._client_cache.values())
-            self._client_cache.clear()
-        for client in clients:
-            try:
-                client.shutdown()
-            except Exception:
-                log.exception("Failed to shut down HTCondor client")
+        self._clients.shutdown()
 
     def _htcondor_params(self, job_destination: "JobDestination | None"):
         """Resolve collector/schedd/config parameters from the destination or runner defaults."""
@@ -467,19 +144,11 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
         collector = params.get("htcondor_collector", None) or self.runner_params.htcondor_collector
         schedd_name = params.get("htcondor_schedd", None) or self.runner_params.htcondor_schedd
         condor_config = params.get("htcondor_config", None) or self.runner_params.htcondor_config
-        return collector, schedd_name, _normalize_condor_config(condor_config)
+        return collector, schedd_name, normalize_condor_config(condor_config)
 
     def _client_for_destination(self, job_destination: "JobDestination | None"):
         _, _, condor_config = self._htcondor_params(job_destination)
-        with self._client_lock:
-            client = self._client_cache.get(condor_config)
-            if client is None:
-                if condor_config is None:
-                    client = _HTCondorInProcessClient(self.htcondor)
-                else:
-                    client = _HTCondorSubprocessClient(condor_config)
-                self._client_cache[condor_config] = client
-        return client
+        return self._clients.client_for_config(condor_config)
 
     def _submit_params(self, job_destination: "JobDestination"):
         """Map destination params to submit params, excluding htcondor_* keys."""
@@ -518,7 +187,7 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
 
         galaxy_memory_statement = ""
         if request_memory := query_params.get("request_memory", None):
-            memory_mb = _parse_memory_mb(str(request_memory))
+            memory_mb = parse_memory_mb(str(request_memory))
             if memory_mb is not None:
                 slots = int(query_params.get("request_cpus", 1) or 1)
                 per_slot = memory_mb // max(1, slots)
@@ -528,9 +197,9 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                 )
 
         if request_walltime := job_destination.params.get("request_walltime", None):
-            walltime_seconds = _parse_walltime_seconds(str(request_walltime))
+            walltime_seconds = parse_walltime_seconds(str(request_walltime))
             if walltime_seconds is not None and "periodic_hold" not in query_params:
-                query_params["periodic_hold"] = f"(JobDurationSeconds >= {walltime_seconds})"
+                query_params["periodic_hold"] = periodic_hold_expression(walltime_seconds)
 
         cjs = HTCondorJobState(
             job_wrapper=job_wrapper,
@@ -613,18 +282,17 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                 continue
             try:
                 summary = self._summarize_event_log(cjs)
-                cjs.status_error_count = 0
+                cjs.clear_status_errors()
             except Exception:
-                cjs.status_error_count += 1
-                if cjs.status_error_count < MAX_STATUS_ERROR_COUNT:
+                elapsed = cjs.note_status_error()
+                if elapsed < STATUS_ERROR_GRACE_SECONDS:
                     log.warning(
-                        f"({galaxy_id_tag}/{job_id}) Transient error checking job status "
-                        f"(attempt {cjs.status_error_count}/{MAX_STATUS_ERROR_COUNT}), "
-                        "will retry next cycle"
+                        f"({galaxy_id_tag}/{job_id}) Transient error checking job status, "
+                        f"will retry until it has persisted for {STATUS_ERROR_GRACE_SECONDS}s"
                     )
                     new_watched.append(cjs)
                     continue
-                log.exception(f"({galaxy_id_tag}/{job_id}) Unable to check job status")
+                log.exception(f"({galaxy_id_tag}/{job_id}) Unable to check job status for {elapsed:.0f}s")
                 log.warning(f"({galaxy_id_tag}/{job_id}) job will now be errored")
                 cjs.fail_message = "Cluster could not complete job"
                 cjs.runner_state = runner_states.UNKNOWN_ERROR
@@ -649,28 +317,21 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                 ):
                     log.debug(f"({galaxy_id_tag}/{job_id}) job {job_state} while log was missing, stopping watch")
                     continue
-                cjs.missing_log_count += 1
-                if cjs.missing_log_count >= MAX_MISSING_LOG_COUNT:
-                    log.warning(
-                        f"({galaxy_id_tag}/{job_id}) event log absent for "
-                        f"{cjs.missing_log_count} consecutive cycles, failing job"
-                    )
-                    cjs.fail_message = (
-                        "This job's HTCondor event log could not be found. "
-                        "Galaxy cannot determine the job outcome — the job may have "
-                        "been removed from the queue while Galaxy was unavailable."
-                    )
+                elapsed = cjs.note_missing_log()
+                if elapsed >= MISSING_LOG_GRACE_SECONDS:
+                    log.warning(f"({galaxy_id_tag}/{job_id}) event log absent for {elapsed:.0f}s, failing job")
+                    cjs.fail_message = MISSING_LOG_MESSAGE
                     cjs.runner_state = runner_states.UNKNOWN_ERROR
                     cjs.close_event_log()
                     self.work_queue.put((self.fail_job, cjs))
                     continue
                 log.debug(
                     f"({galaxy_id_tag}/{job_id}) event log not yet available "
-                    f"(cycle {cjs.missing_log_count}/{MAX_MISSING_LOG_COUNT})"
+                    f"(absent for {elapsed:.0f}s of {MISSING_LOG_GRACE_SECONDS}s)"
                 )
                 new_watched.append(cjs)
                 continue
-            cjs.missing_log_count = 0
+            cjs.clear_missing_log()
 
             if summary.job_released and cjs.held_count > 0:
                 log.debug(f"({galaxy_id_tag}/{job_id}) job released, resetting held_count from {cjs.held_count} to 0")
@@ -689,9 +350,9 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
             if job_complete or job_state == model.Job.states.STOPPED:
                 if job_state != model.Job.states.DELETED:
                     # A SIGKILL on a non-user-stopped job is most likely an OOM kill.
-                    if term_signal == _SIGKILL and job_state != model.Job.states.STOPPED:
+                    if term_signal == SIGKILL and job_state != model.Job.states.STOPPED:
                         log.info(f"({galaxy_id_tag}/{job_id}) job killed by signal 9, likely OOM")
-                        cjs.fail_message = _SIGKILL_MSG
+                        cjs.fail_message = SIGKILL_MESSAGE
                         cjs.runner_state = runner_states.MEMORY_LIMIT_REACHED
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
@@ -721,34 +382,34 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                 ):
                     # Classify the hold by HoldReasonCode before applying the
                     # generic held_count escalation logic.
-                    if hold_reason_code in _HOLD_CODE_MEMORY:
+                    hold_reason = classify_hold(hold_reason_code)
+                    if hold_reason == HOLD_REASON_MEMORY_LIMIT:
                         log.info(
                             f"({galaxy_id_tag}/{job_id}) job held for memory limit (HoldReasonCode={hold_reason_code})"
                         )
-                        cjs.fail_message = _MEMORY_LIMIT_HOLD_MSG
+                        cjs.fail_message = HOLD_MESSAGES[hold_reason]
                         cjs.runner_state = runner_states.MEMORY_LIMIT_REACHED
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
                         continue
-                    if hold_reason_code == _HOLD_CODE_PERIODIC:
+                    if hold_reason == HOLD_REASON_WALLTIME:
                         log.info(f"({galaxy_id_tag}/{job_id}) job held by periodic_hold expression (walltime)")
-                        cjs.fail_message = _WALLTIME_HOLD_MSG
+                        cjs.fail_message = HOLD_MESSAGES[hold_reason]
                         cjs.runner_state = runner_states.WALLTIME_REACHED
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
                         continue
                     cjs.held_count += 1
                     # max_held_count: destination parameter, counts distinct JOB_HELD events (default 3, 0 = disabled)
-                    max_held_count = int(cjs.job_wrapper.job_destination.params.get("max_held_count", 3))
+                    max_held_count = int(
+                        cjs.job_wrapper.job_destination.params.get("max_held_count", DEFAULT_MAX_HELD_COUNT)
+                    )
                     if max_held_count > 0 and cjs.held_count >= max_held_count:
                         log.warning(
                             f"({galaxy_id_tag}/{job_id}) Job held {cjs.held_count} "
                             "times without release, failing permanently"
                         )
-                        cjs.fail_message = (
-                            f"This job was held by HTCondor {cjs.held_count} time"
-                            f"{'s' if cjs.held_count != 1 else ''} without being released."
-                        )
+                        cjs.fail_message = held_message(cjs.held_count)
                         cjs.runner_state = runner_states.UNKNOWN_ERROR
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
@@ -805,91 +466,19 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
             cjs.running = False
             self.monitor_queue.put(cjs)
 
-    def _summarize_event_log(self, cjs: HTCondorJobState) -> _EventLogSummary:
-        job_running = cjs.running
-        job_complete = False
-        failure_event: int | None = None
-        job_held = False
-        term_signal: int | None = None
-        hold_reason_code: int = 0
-
+    def _summarize_event_log(self, cjs: HTCondorJobState):
         if cjs.job_id is None:
             raise RuntimeError("Missing HTCondor job_id while summarizing event log.")
-        cluster_id = int(cjs.job_id)
-
-        if not os.path.exists(cjs.user_log):
-            return _EventLogSummary(cjs.running, False, None, False, None, 0, log_missing=True)
-
-        event_log = cjs.event_log(self.htcondor)
-        job_released = False
-
-        for event in event_log.events(stop_after=0):
-            if event.cluster != cluster_id or event.proc != 0:
-                continue
-            event_type = event.type
-            if event_type == self.htcondor.JobEventType.EXECUTE:
-                job_running = True
-                job_held = False
-            elif event_type in (
-                self.htcondor.JobEventType.JOB_EVICTED,
-                self.htcondor.JobEventType.JOB_SUSPENDED,
-            ):
-                job_running = False
-            elif event_type == self.htcondor.JobEventType.JOB_UNSUSPENDED:
-                job_running = True
-            elif event_type == self.htcondor.JobEventType.JOB_TERMINATED:
-                job_complete = True
-                if not event.get("TerminatedNormally", True):
-                    term_signal = int(event.get("TermSignal", 0)) or None
-            elif event_type == self.htcondor.JobEventType.JOB_HELD:
-                job_running = False
-                job_held = True
-                hold_reason_code = int(event.get("HoldReasonCode", 0))
-            elif event_type == self.htcondor.JobEventType.JOB_RELEASED:
-                job_held = False
-                job_running = False
-                hold_reason_code = 0
-                job_released = True
-            elif event_type in (
-                self.htcondor.JobEventType.JOB_ABORTED,
-                self.htcondor.JobEventType.CLUSTER_REMOVE,
-                self.htcondor.JobEventType.SHADOW_EXCEPTION,
-                self.htcondor.JobEventType.EXECUTABLE_ERROR,
-            ):
-                failure_event = event_type
-
-        return _EventLogSummary(
-            job_running,
-            job_complete,
-            failure_event,
-            job_held,
-            term_signal,
-            hold_reason_code,
-            job_released=job_released,
-        )
+        return cjs.summarize(self.htcondor, int(cjs.job_id), cjs.running)
 
     def _apply_failure_event(self, cjs: HTCondorJobState, failure_event: int) -> None:
         """Set fail_message and runner_state on cjs based on the HTCondor failure event type."""
-        htc = self.htcondor.JobEventType
-        if failure_event == htc.SHADOW_EXCEPTION:
-            cjs.fail_message = (
-                "This job failed due to an HTCondor shadow exception, which typically "
-                "indicates a transient error in the execution environment."
-            )
-            cjs.runner_state = runner_states.UNKNOWN_ERROR
-        elif failure_event == htc.JOB_ABORTED:
-            cjs.fail_message = "This job was removed from the HTCondor queue."
-            cjs.runner_state = runner_states.UNKNOWN_ERROR
-        elif failure_event == htc.CLUSTER_REMOVE:
-            cjs.fail_message = "The HTCondor cluster was removed."
-            cjs.runner_state = runner_states.UNKNOWN_ERROR
-        elif failure_event == htc.EXECUTABLE_ERROR:
+        failure = classify_failure_event(self.htcondor, failure_event)
+        cjs.fail_message = FAILURE_MESSAGES[failure]
+        if failure != FAILURE_EXECUTABLE_ERROR:
             # Executable errors are configuration problems, not transient.  runner_state is
             # intentionally left unset (None) so the resubmission framework never fires for
             # this case — only UNKNOWN_ERROR triggers resubmission handlers.
-            cjs.fail_message = "This job could not start because the job script could not be found or executed."
-        else:
-            cjs.fail_message = "Cluster could not complete job"
             cjs.runner_state = runner_states.UNKNOWN_ERROR
 
     def _condor_remove(self, external_id, job_destination: "JobDestination | None" = None):

--- a/lib/galaxy/jobs/runners/util/condor/htcondor.py
+++ b/lib/galaxy/jobs/runners/util/condor/htcondor.py
@@ -1,0 +1,672 @@
+"""HTCondor support built on the htcondor2 (Python bindings version 2) API.
+
+This module should contain functionality shared between Galaxy and the Pulsar.
+It deliberately knows nothing about either application's job model — callers
+map the vocabulary defined here (``EventLogSummary``, the ``HOLD_REASON_*`` and
+``FAILURE_*`` keys) onto their own job states.
+
+``from __future__ import annotations`` is required: Pulsar still supports
+Python 3.7, so the ``X | None`` annotations below must not be evaluated at
+runtime.  For the same reason this module must avoid the walrus operator and
+any other syntax newer than 3.7.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import select
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from typing import (
+    Any,
+    NamedTuple,
+)
+
+from .htcondor_helper import locate_schedd
+
+log = logging.getLogger(__name__)
+
+__all__ = (
+    "EventLogSummary",
+    "HTCondorClient",
+    "HTCondorClientCache",
+    "HTCondorEventLogTracker",
+    "HTCondorInProcessClient",
+    "HTCondorSubprocessClient",
+    "classify_failure_event",
+    "classify_hold",
+    "held_message",
+    "import_htcondor",
+    "normalize_condor_config",
+    "parse_memory_mb",
+    "parse_walltime_seconds",
+    "periodic_hold_expression",
+)
+
+# Resolved against whichever package root loaded this module so that the helper
+# subprocess can be started as ``python -m <module>`` from either Galaxy
+# (galaxy.jobs.runners.util.condor) or Pulsar (pulsar.managers.util.condor).
+HTCONDOR_HELPER_MODULE = f"{__package__}.htcondor_helper"
+HTCONDOR_HELPER_TIMEOUT = 30
+DEFAULT_REMOVE_REASON = "Job stop request"
+
+# Escalation thresholds for conditions that are usually transient.  These are
+# wall-clock seconds rather than poll counts because the polling interval is
+# configurable in both applications (and a Pulsar job is polled by both the
+# Pulsar monitor and Galaxy), so a count of cycles has no fixed meaning.
+#
+# How long status checks may keep failing - absorbs transient filesystem
+# hiccups (e.g. NFS timeouts reading the event log) without masking genuine
+# persistent failures.
+STATUS_ERROR_GRACE_SECONDS = 30.0
+# How long the event log may be absent.  Covers a log not yet visible after
+# submission (NFS attribute caching defaults to 60s) as well as one that was
+# never written or was lost while the application was down.
+MISSING_LOG_GRACE_SECONDS = 60.0
+# Number of distinct JOB_HELD events tolerated before a job is failed
+# permanently.  0 disables the escalation.
+DEFAULT_MAX_HELD_COUNT = 3
+
+# HTCondor HoldReasonCode values that indicate the job was held because it
+# exceeded its memory allocation.  Code 26 is the cgroup-based OOM code used in
+# older HTCondor releases; code 34 ("memory limit exceeded") was introduced in
+# newer releases (~9.x).  Both are defined in condor_holdcodes.h in the HTCondor
+# source tree.  If your cluster reports a different code for OOM holds, add it
+# here and open a PR.
+HOLD_CODE_MEMORY = frozenset((26, 34))
+# Code 16 ("PeriodicHoldTrue") means a periodic_hold ClassAd expression evaluated
+# to True.  This code has been stable since at least HTCondor 7.x.  Callers inject
+# "periodic_hold = (JobDurationSeconds >= N)" when a walltime is requested.
+HOLD_CODE_PERIODIC = 16
+# SIGKILL from the OS OOM killer appears as a JOB_TERMINATED event with
+# TerminatedNormally=False and TermSignal=9.
+SIGKILL = 9
+
+HOLD_REASON_MEMORY_LIMIT = "memory_limit"
+HOLD_REASON_WALLTIME = "walltime"
+HOLD_REASON_OTHER = "other"
+
+FAILURE_SHADOW_EXCEPTION = "shadow_exception"
+FAILURE_JOB_ABORTED = "job_aborted"
+FAILURE_CLUSTER_REMOVED = "cluster_removed"
+FAILURE_EXECUTABLE_ERROR = "executable_error"
+FAILURE_UNKNOWN = "unknown"
+
+MEMORY_LIMIT_HOLD_MESSAGE = (
+    "This job was held by HTCondor because it exceeded its requested memory. "
+    "Consider increasing request_memory or routing to a destination with more memory."
+)
+WALLTIME_HOLD_MESSAGE = (
+    "This job was held by HTCondor because it exceeded its maximum run time. "
+    "Consider increasing the walltime or routing to a destination with a longer time limit."
+)
+SIGKILL_MESSAGE = (
+    "This job was killed because it used more memory than it was allocated. Consider increasing request_memory."
+)
+MISSING_LOG_MESSAGE = (
+    "This job's HTCondor event log could not be found. The job outcome cannot be "
+    "determined — the job may have been removed from the queue while the job "
+    "manager was unavailable."
+)
+UNKNOWN_FAILURE_MESSAGE = "Cluster could not complete job"
+
+HOLD_MESSAGES = {
+    HOLD_REASON_MEMORY_LIMIT: MEMORY_LIMIT_HOLD_MESSAGE,
+    HOLD_REASON_WALLTIME: WALLTIME_HOLD_MESSAGE,
+}
+
+FAILURE_MESSAGES = {
+    FAILURE_SHADOW_EXCEPTION: (
+        "This job failed due to an HTCondor shadow exception, which typically "
+        "indicates a transient error in the execution environment."
+    ),
+    FAILURE_JOB_ABORTED: "This job was removed from the HTCondor queue.",
+    FAILURE_CLUSTER_REMOVED: "The HTCondor cluster was removed.",
+    FAILURE_EXECUTABLE_ERROR: "This job could not start because the job script could not be found or executed.",
+    FAILURE_UNKNOWN: UNKNOWN_FAILURE_MESSAGE,
+}
+
+
+def import_htcondor():
+    """Import and return the htcondor2 module, raising a helpful ImportError."""
+    try:
+        import htcondor2
+    except Exception as exc:
+        raise ImportError(
+            "The htcondor2 Python package is required to use this feature, please install it or correct the "
+            f"following error:\n{exc.__class__.__name__}: {str(exc)}"
+        ) from exc
+    return htcondor2
+
+
+def held_message(held_count: int) -> str:
+    plural = "s" if held_count != 1 else ""
+    return f"This job was held by HTCondor {held_count} time{plural} without being released."
+
+
+def parse_memory_mb(value: str) -> int | None:
+    """Parse an HTCondor request_memory value to whole MB.
+
+    HTCondor's default unit is MB.  Recognises the K/M/G/T suffixes (case-
+    insensitive) and their two-letter forms (KB/MB/GB/TB).  Returns None for
+    values that cannot be parsed (e.g. ClassAd expressions).
+
+    >>> parse_memory_mb("2048")
+    2048
+    >>> parse_memory_mb("4 GB")
+    4096
+    >>> parse_memory_mb("(Target.Memory)") is None
+    True
+    """
+    value = value.strip()
+    units: dict[str, float] = {"K": 1 / 1024, "M": 1, "G": 1024, "T": 1024 * 1024}
+    upper = value.upper()
+    for suffix, factor in units.items():
+        for variant in (suffix + "B", suffix):
+            if upper.endswith(variant):
+                numeric = value[: -len(variant)]
+                try:
+                    return max(1, int(float(numeric) * factor))
+                except ValueError:
+                    return None
+    try:
+        return int(float(value))
+    except ValueError:
+        return None
+
+
+def parse_walltime_seconds(value: str) -> int | None:
+    """Parse a walltime string to a whole number of seconds.
+
+    Accepted formats (matching SLURM's --time convention):
+      seconds          "3600"
+      MM:SS            "90:00"
+      HH:MM:SS         "1:00:00"
+      D-HH:MM:SS       "1-0:00:00"
+
+    Returns None if the value cannot be parsed.
+
+    >>> parse_walltime_seconds("90:00")
+    5400
+    >>> parse_walltime_seconds("1-0:00:00")
+    86400
+    >>> parse_walltime_seconds("forever") is None
+    True
+    """
+    value = value.strip()
+    days = 0
+    if "-" in value:
+        day_part, value = value.split("-", 1)
+        try:
+            days = int(day_part)
+        except ValueError:
+            return None
+    parts = value.split(":")
+    try:
+        if len(parts) == 1:
+            return days * 86400 + int(parts[0])
+        if len(parts) == 2:
+            return days * 86400 + int(parts[0]) * 60 + int(parts[1])
+        if len(parts) == 3:
+            return days * 86400 + int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+    except ValueError:
+        pass
+    return None
+
+
+def periodic_hold_expression(walltime_seconds: int) -> str:
+    """ClassAd expression holding a job once it has run for walltime_seconds."""
+    return f"(JobDurationSeconds >= {walltime_seconds})"
+
+
+def normalize_condor_config(condor_config: str | None) -> str | None:
+    if not condor_config:
+        return None
+    return os.path.realpath(os.path.expanduser(condor_config))
+
+
+def classify_hold(hold_reason_code: int) -> str:
+    """Map an HTCondor HoldReasonCode onto one of the HOLD_REASON_* keys."""
+    if hold_reason_code in HOLD_CODE_MEMORY:
+        return HOLD_REASON_MEMORY_LIMIT
+    if hold_reason_code == HOLD_CODE_PERIODIC:
+        return HOLD_REASON_WALLTIME
+    return HOLD_REASON_OTHER
+
+
+def classify_failure_event(htcondor, event_type: int) -> str:
+    """Map an HTCondor JobEventType onto one of the FAILURE_* keys."""
+    event_types = htcondor.JobEventType
+    if event_type == event_types.SHADOW_EXCEPTION:
+        return FAILURE_SHADOW_EXCEPTION
+    if event_type == event_types.JOB_ABORTED:
+        return FAILURE_JOB_ABORTED
+    if event_type == event_types.CLUSTER_REMOVE:
+        return FAILURE_CLUSTER_REMOVED
+    if event_type == event_types.EXECUTABLE_ERROR:
+        return FAILURE_EXECUTABLE_ERROR
+    return FAILURE_UNKNOWN
+
+
+class EventLogSummary(NamedTuple):
+    job_running: bool
+    job_complete: bool
+    failure_event: int | None
+    job_held: bool
+    term_signal: int | None  # signal that killed the process (e.g. 9), None if normal exit
+    hold_reason_code: int  # HoldReasonCode from JOB_HELD ClassAd, 0 if absent
+    log_missing: bool = False  # True when the event log file does not exist
+    job_released: bool = False  # True when a JOB_RELEASED event was seen this cycle
+
+
+class _EventState:
+    """Mutable accumulator used while replaying a batch of event-log entries."""
+
+    def __init__(self, running: bool) -> None:
+        self.job_running = running
+        self.job_complete = False
+        self.failure_event: int | None = None
+        self.job_held = False
+        self.term_signal: int | None = None
+        self.hold_reason_code = 0
+        self.job_released = False
+
+    def summary(self) -> EventLogSummary:
+        return EventLogSummary(
+            self.job_running,
+            self.job_complete,
+            self.failure_event,
+            self.job_held,
+            self.term_signal,
+            self.hold_reason_code,
+            job_released=self.job_released,
+        )
+
+
+def _apply_event(htcondor, state: _EventState, event) -> None:
+    event_types = htcondor.JobEventType
+    event_type = event.type
+    if event_type == event_types.EXECUTE:
+        state.job_running = True
+        state.job_held = False
+    elif event_type in (event_types.JOB_EVICTED, event_types.JOB_SUSPENDED):
+        state.job_running = False
+    elif event_type == event_types.JOB_UNSUSPENDED:
+        state.job_running = True
+    elif event_type == event_types.JOB_TERMINATED:
+        state.job_complete = True
+        if not event.get("TerminatedNormally", True):
+            state.term_signal = int(event.get("TermSignal", 0)) or None
+    elif event_type == event_types.JOB_HELD:
+        state.job_running = False
+        state.job_held = True
+        state.hold_reason_code = int(event.get("HoldReasonCode", 0))
+    elif event_type == event_types.JOB_RELEASED:
+        state.job_held = False
+        state.job_running = False
+        state.hold_reason_code = 0
+        state.job_released = True
+    elif event_type in (
+        event_types.JOB_ABORTED,
+        event_types.CLUSTER_REMOVE,
+        event_types.SHADOW_EXCEPTION,
+        event_types.EXECUTABLE_ERROR,
+    ):
+        state.failure_event = event_type
+
+
+def summarize_event_log(htcondor, event_log, cluster_id: int, running: bool = False) -> EventLogSummary:
+    """Replay the events appended to event_log since the last call.
+
+    ``running`` seeds the summary so that a cycle producing no new events
+    reports the state the caller already believed the job to be in.
+    """
+    state = _EventState(running)
+    for event in event_log.events(stop_after=0):
+        if event.cluster != cluster_id or event.proc != 0:
+            continue
+        _apply_event(htcondor, state, event)
+    return state.summary()
+
+
+class HTCondorEventLogTracker:
+    """Per-job event-log handle plus the counters driving failure escalation.
+
+    Designed to be mixed into an application's job-state object (Galaxy's
+    ``HTCondorJobState``, Pulsar's manager-side job state) so that both sides
+    share the escalation bookkeeping as well as the parsing.
+    """
+
+    def __init__(self, user_log: str, clock=time.monotonic) -> None:
+        self.user_log = user_log
+        self._event_log: Any = None
+        self.held_count = 0
+        # Injectable so tests can drive escalation without sleeping.
+        self.clock = clock
+        self.status_error_since: float | None = None
+        self.missing_log_since: float | None = None
+
+    def note_status_error(self) -> float:
+        """Record a failed status check, returning seconds since the first one."""
+        now = self.clock()
+        if self.status_error_since is None:
+            self.status_error_since = now
+        return now - self.status_error_since
+
+    def clear_status_errors(self) -> None:
+        self.status_error_since = None
+
+    def note_missing_log(self) -> float:
+        """Record an absent event log, returning seconds since it went missing."""
+        now = self.clock()
+        if self.missing_log_since is None:
+            self.missing_log_since = now
+        return now - self.missing_log_since
+
+    def clear_missing_log(self) -> None:
+        self.missing_log_since = None
+
+    def event_log(self, htcondor):
+        if self._event_log is None:
+            self._event_log = htcondor.JobEventLog(self.user_log)
+        return self._event_log
+
+    def close_event_log(self) -> None:
+        if self._event_log is not None:
+            try:
+                self._event_log.close()
+            except Exception:
+                pass
+            self._event_log = None
+
+    def summarize(self, htcondor, cluster_id: int, running: bool = False) -> EventLogSummary:
+        """Summarize new event-log entries, reporting log_missing if absent."""
+        if not os.path.exists(self.user_log):
+            return EventLogSummary(running, False, None, False, None, 0, log_missing=True)
+        return summarize_event_log(htcondor, self.event_log(htcondor), cluster_id, running)
+
+
+class HTCondorClient:
+    """Submits to and removes jobs from a schedd."""
+
+    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
+        raise NotImplementedError()
+
+    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
+        raise NotImplementedError()
+
+    def shutdown(self) -> None:
+        pass
+
+
+class HTCondorInProcessClient(HTCondorClient):
+    """Talks to the schedd directly, using the process-wide HTCondor config."""
+
+    def __init__(self, htcondor, remove_reason: str = DEFAULT_REMOVE_REASON):
+        self.htcondor = htcondor
+        self.remove_reason = remove_reason
+        self._schedd_cache: dict = {}
+        self._schedd_lock = threading.Lock()
+
+    def _schedd(self, collector: str | None, schedd_name: str | None):
+        return locate_schedd(self.htcondor, self._schedd_cache, self._schedd_lock, collector, schedd_name)
+
+    def _evict_schedd(self, collector: str | None, schedd_name: str | None) -> None:
+        with self._schedd_lock:
+            self._schedd_cache.pop((collector, schedd_name), None)
+
+    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
+        try:
+            submit_result = self._schedd(collector, schedd_name).submit(self.htcondor.Submit(submit_description))
+            return str(submit_result.cluster())
+        except Exception:
+            self._evict_schedd(collector, schedd_name)
+            raise
+
+    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
+        try:
+            self._schedd(collector, schedd_name).act(
+                self.htcondor.JobAction.Remove, job_spec, reason=self.remove_reason
+            )
+        except Exception:
+            self._evict_schedd(collector, schedd_name)
+            raise
+
+
+class HTCondorSubprocessClient(HTCondorClient):
+    """Talks to a schedd through a helper subprocess with its own CONDOR_CONFIG.
+
+    htcondor2 reads its configuration once per process, so a destination that
+    overrides CONDOR_CONFIG cannot share the parent process with any other
+    configuration.
+    """
+
+    def __init__(
+        self,
+        condor_config: str,
+        helper_module: str = HTCONDOR_HELPER_MODULE,
+        remove_reason: str = DEFAULT_REMOVE_REASON,
+    ):
+        self.condor_config = condor_config
+        self.helper_module = helper_module
+        self.remove_reason = remove_reason
+        self._lock = threading.Lock()
+        self._process: subprocess.Popen[str] | None = None
+        # Rolling buffer of recent stderr lines for error messages.
+        # Written by the drain thread; read (without the lock) in error paths.
+        self._stderr_lines: deque = deque(maxlen=50)
+
+    def submit(self, submit_description: str, collector: str | None, schedd_name: str | None) -> str:
+        response = self._request(
+            dict(
+                command="submit",
+                collector=collector,
+                schedd_name=schedd_name,
+                submit_description=submit_description,
+            )
+        )
+        return str(response["cluster"])
+
+    def remove(self, job_spec: int | str, collector: str | None, schedd_name: str | None) -> None:
+        self._request(
+            dict(
+                command="remove",
+                collector=collector,
+                schedd_name=schedd_name,
+                job_spec=job_spec,
+                reason=self.remove_reason,
+            )
+        )
+
+    def shutdown(self) -> None:
+        with self._lock:
+            process = self._process
+            if process is None:
+                return
+            try:
+                stdin = process.stdin
+                if stdin is not None and not stdin.closed:
+                    stdin.write(json.dumps(dict(command="shutdown")) + "\n")
+                    stdin.flush()
+            except Exception:
+                pass
+            finally:
+                if process.stdin is not None and not process.stdin.closed:
+                    process.stdin.close()
+
+            try:
+                process.wait(timeout=HTCONDOR_HELPER_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=HTCONDOR_HELPER_TIMEOUT)
+            finally:
+                if process.stdout is not None:
+                    process.stdout.close()
+                if process.stderr is not None:
+                    process.stderr.close()
+                self._process = None
+
+    def _request(self, payload):
+        with self._lock:
+            process = self._ensure_process_locked()
+            stdin = process.stdin
+            stdout = process.stdout
+            if stdin is None or stdout is None:
+                raise RuntimeError("HTCondor helper process is missing stdio pipes")
+            try:
+                stdin.write(json.dumps(payload) + "\n")
+                stdin.flush()
+            except Exception as exc:
+                raise RuntimeError(self._helper_failure_message_locked("Failed to write to HTCondor helper")) from exc
+
+            ready, _, _ = select.select([stdout], [], [], HTCONDOR_HELPER_TIMEOUT)
+            if not ready:
+                self._terminate_process_locked(process)
+                raise RuntimeError(
+                    f"HTCondor helper did not respond within {HTCONDOR_HELPER_TIMEOUT}s — killed and will respawn"
+                )
+            line = stdout.readline()
+            if not line:
+                raise RuntimeError(self._helper_failure_message_locked("HTCondor helper exited unexpectedly"))
+            try:
+                response = json.loads(line)
+            except Exception as exc:
+                raise RuntimeError(f"Invalid response from HTCondor helper: {line.rstrip()}") from exc
+            if not response.get("ok"):
+                raise RuntimeError(response.get("error", "Unknown HTCondor helper error"))
+            return response
+
+    def _terminate_process_locked(self, process: subprocess.Popen[str]) -> None:
+        """Kill a stale/hung helper process and clean up its pipes. Must be called with self._lock held."""
+        try:
+            process.kill()
+            process.wait(timeout=5)
+        except Exception:
+            pass
+        finally:
+            for pipe in (process.stdin, process.stdout, process.stderr):
+                if pipe is not None:
+                    try:
+                        pipe.close()
+                    except Exception:
+                        pass
+            if self._process is process:
+                self._process = None
+
+    def _ensure_process_locked(self):
+        process = self._process
+        if process is not None and process.poll() is None:
+            return process
+        if process is not None:
+            if process.stdin is not None and not process.stdin.closed:
+                process.stdin.close()
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+
+        env = os.environ.copy()
+        env["CONDOR_CONFIG"] = self.condor_config
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        # Build PYTHONPATH from sys.path, then append any entries from the existing
+        # PYTHONPATH that are not already present (e.g. paths added only via env var).
+        sys_paths = list(dict.fromkeys(path for path in sys.path if path))
+        for path in os.environ.get("PYTHONPATH", "").split(os.pathsep):
+            if path and path not in sys_paths:
+                sys_paths.append(path)
+        env["PYTHONPATH"] = os.pathsep.join(sys_paths)
+        self._process = subprocess.Popen(
+            [sys.executable, "-m", self.helper_module],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            close_fds=True,
+            env=env,
+        )
+        self._start_stderr_drain(self._process)
+        return self._process
+
+    def _start_stderr_drain(self, process: subprocess.Popen[str]) -> None:
+        """Drain the helper's stderr into _stderr_lines and the application log.
+
+        Runs as a daemon thread so HTCondor warnings (e.g. credential expiry)
+        surface in the log rather than being silently discarded.
+        """
+
+        def _drain() -> None:
+            try:
+                for line in process.stderr:  # type: ignore[union-attr]
+                    stripped = line.rstrip()
+                    if stripped:
+                        self._stderr_lines.append(stripped)
+                        log.warning("HTCondor helper: %s", stripped)
+            except Exception:
+                pass
+
+        drain_thread = threading.Thread(target=_drain, daemon=True, name="htcondor-helper-stderr")
+        drain_thread.start()
+
+    def _helper_failure_message_locked(self, message: str) -> str:
+        # Stderr is consumed by the drain thread and buffered in _stderr_lines.
+        recent = "\n".join(list(self._stderr_lines)[-10:]).strip()
+        if recent:
+            return f"{message}: {recent}"
+        return message
+
+
+class HTCondorClientCache:
+    """Clients keyed by normalized CONDOR_CONFIG path.
+
+    A ``None`` key means "use the configuration this process was started with"
+    and is served in-process; every other key gets its own helper subprocess.
+    """
+
+    def __init__(
+        self,
+        htcondor,
+        helper_module: str = HTCONDOR_HELPER_MODULE,
+        remove_reason: str = DEFAULT_REMOVE_REASON,
+    ) -> None:
+        self.htcondor = htcondor
+        self.helper_module = helper_module
+        self.remove_reason = remove_reason
+        self._clients: dict = {}
+        self._lock = threading.Lock()
+
+    def client_for_config(self, condor_config: str | None) -> HTCondorClient:
+        condor_config = normalize_condor_config(condor_config)
+        with self._lock:
+            client = self._clients.get(condor_config)
+            if client is None:
+                if condor_config is None:
+                    client = HTCondorInProcessClient(self.htcondor, remove_reason=self.remove_reason)
+                else:
+                    client = HTCondorSubprocessClient(
+                        condor_config,
+                        helper_module=self.helper_module,
+                        remove_reason=self.remove_reason,
+                    )
+                self._clients[condor_config] = client
+        return client
+
+    def clients(self) -> list:
+        """Snapshot of the currently cached clients."""
+        with self._lock:
+            return list(self._clients.values())
+
+    def shutdown(self) -> None:
+        with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+        for client in clients:
+            try:
+                client.shutdown()
+            except Exception:
+                log.exception("Failed to shut down HTCondor client")

--- a/lib/galaxy/jobs/runners/util/condor/htcondor.py
+++ b/lib/galaxy/jobs/runners/util/condor/htcondor.py
@@ -68,8 +68,17 @@ STATUS_ERROR_GRACE_SECONDS = 30.0
 # submission (NFS attribute caching defaults to 60s) as well as one that was
 # never written or was lost while the application was down.
 MISSING_LOG_GRACE_SECONDS = 60.0
+# How long a job may sit held before it is failed.  A hold is not by itself
+# terminal: a pool may release the job on its own, and sites commonly configure
+# periodic_release to retry a held job - sometimes against a raised
+# request_memory, so that the retry can succeed where the first attempt was
+# held.  Failing on the hold reason alone would pre-empt that policy, so the
+# job is failed only once it has stayed held for this long without a release.
+HELD_GRACE_SECONDS = 300.0
 # Number of distinct JOB_HELD events tolerated before a job is failed
-# permanently.  0 disables the escalation.
+# permanently.  This bounds hold/release thrashing, which the grace window
+# above cannot catch because each release restarts it.  0 disables the
+# escalation.
 DEFAULT_MAX_HELD_COUNT = 3
 
 # HTCondor HoldReasonCode values that indicate the job was held because it
@@ -114,6 +123,11 @@ MISSING_LOG_MESSAGE = (
     "manager was unavailable."
 )
 UNKNOWN_FAILURE_MESSAGE = "Cluster could not complete job"
+
+HELD_TOO_LONG_MESSAGE = (
+    "This job was held by HTCondor and stayed held without being released. "
+    "It may be waiting on a resource the pool cannot satisfy."
+)
 
 HOLD_MESSAGES = {
     HOLD_REASON_MEMORY_LIMIT: MEMORY_LIMIT_HOLD_MESSAGE,
@@ -257,24 +271,26 @@ class EventLogSummary(NamedTuple):
     job_running: bool
     job_complete: bool
     failure_event: int | None
-    job_held: bool
+    job_held: bool  # level: the job is held as of now, seeded from the prior cycle
     term_signal: int | None  # signal that killed the process (e.g. 9), None if normal exit
     hold_reason_code: int  # HoldReasonCode from JOB_HELD ClassAd, 0 if absent
     log_missing: bool = False  # True when the event log file does not exist
     job_released: bool = False  # True when a JOB_RELEASED event was seen this cycle
+    job_held_event: bool = False  # edge: a JOB_HELD event was seen this cycle
 
 
 class _EventState:
     """Mutable accumulator used while replaying a batch of event-log entries."""
 
-    def __init__(self, running: bool) -> None:
+    def __init__(self, running: bool, held: bool = False) -> None:
         self.job_running = running
         self.job_complete = False
         self.failure_event: int | None = None
-        self.job_held = False
+        self.job_held = held
         self.term_signal: int | None = None
         self.hold_reason_code = 0
         self.job_released = False
+        self.job_held_event = False
 
     def summary(self) -> EventLogSummary:
         return EventLogSummary(
@@ -285,6 +301,7 @@ class _EventState:
             self.term_signal,
             self.hold_reason_code,
             job_released=self.job_released,
+            job_held_event=self.job_held_event,
         )
 
 
@@ -305,6 +322,7 @@ def _apply_event(htcondor, state: _EventState, event) -> None:
     elif event_type == event_types.JOB_HELD:
         state.job_running = False
         state.job_held = True
+        state.job_held_event = True
         state.hold_reason_code = int(event.get("HoldReasonCode", 0))
     elif event_type == event_types.JOB_RELEASED:
         state.job_held = False
@@ -320,13 +338,18 @@ def _apply_event(htcondor, state: _EventState, event) -> None:
         state.failure_event = event_type
 
 
-def summarize_event_log(htcondor, event_log, cluster_id: int, running: bool = False) -> EventLogSummary:
+def summarize_event_log(
+    htcondor, event_log, cluster_id: int, running: bool = False, held: bool = False
+) -> EventLogSummary:
     """Replay the events appended to event_log since the last call.
 
-    ``running`` seeds the summary so that a cycle producing no new events
-    reports the state the caller already believed the job to be in.
+    ``running`` and ``held`` seed the summary so that a cycle producing no new
+    events reports the state the caller already believed the job to be in.
+    Seeding ``held`` is what makes ``job_held`` a level signal: a job held once
+    and never released emits a single JOB_HELD event, so without the seed it
+    would appear un-held on every later cycle.
     """
-    state = _EventState(running)
+    state = _EventState(running, held)
     for event in event_log.events(stop_after=0):
         if event.cluster != cluster_id or event.proc != 0:
             continue
@@ -350,6 +373,8 @@ class HTCondorEventLogTracker:
         self.clock = clock
         self.status_error_since: float | None = None
         self.missing_log_since: float | None = None
+        self.held_since: float | None = None
+        self.held_reason_code = 0
 
     def note_status_error(self) -> float:
         """Record a failed status check, returning seconds since the first one."""
@@ -371,6 +396,25 @@ class HTCondorEventLogTracker:
     def clear_missing_log(self) -> None:
         self.missing_log_since = None
 
+    def note_held(self, hold_reason_code: int = 0) -> float:
+        """Record that the job is held, returning seconds since it first was.
+
+        The reason code is remembered from the JOB_HELD event that opened the
+        hold.  Later cycles produce no new events, so the summary reports a
+        reason code of 0 by then, yet the caller still needs to know which
+        limit to name when the grace window expires.
+        """
+        now = self.clock()
+        if self.held_since is None:
+            self.held_since = now
+        if hold_reason_code:
+            self.held_reason_code = hold_reason_code
+        return now - self.held_since
+
+    def clear_held(self) -> None:
+        self.held_since = None
+        self.held_reason_code = 0
+
     def event_log(self, htcondor):
         if self._event_log is None:
             self._event_log = htcondor.JobEventLog(self.user_log)
@@ -384,11 +428,11 @@ class HTCondorEventLogTracker:
                 pass
             self._event_log = None
 
-    def summarize(self, htcondor, cluster_id: int, running: bool = False) -> EventLogSummary:
+    def summarize(self, htcondor, cluster_id: int, running: bool = False, held: bool = False) -> EventLogSummary:
         """Summarize new event-log entries, reporting log_missing if absent."""
         if not os.path.exists(self.user_log):
-            return EventLogSummary(running, False, None, False, None, 0, log_missing=True)
-        return summarize_event_log(htcondor, self.event_log(htcondor), cluster_id, running)
+            return EventLogSummary(running, False, None, held, None, 0, log_missing=True)
+        return summarize_event_log(htcondor, self.event_log(htcondor), cluster_id, running, held)
 
 
 class HTCondorClient:

--- a/lib/galaxy/jobs/runners/util/condor/htcondor_helper.py
+++ b/lib/galaxy/jobs/runners/util/condor/htcondor_helper.py
@@ -1,10 +1,25 @@
+"""Out-of-process schedd access for a specific CONDOR_CONFIG.
+
+htcondor2 reads its configuration once per process, so a destination that
+overrides CONDOR_CONFIG needs its own interpreter.  ``HTCondorSubprocessClient``
+spawns this module as ``python -m <package>.htcondor_helper`` and speaks
+newline-delimited JSON to it over stdin/stdout.
+
+This module should contain functionality shared between Galaxy and the Pulsar.
+It must stay importable on Python 3.7 (see the sibling htcondor module).
+"""
+
+from __future__ import annotations
+
 import json
 import sys
 import threading
 from typing import Any
 
+DEFAULT_REMOVE_REASON = "Job stop request"
 
-def _locate_schedd(
+
+def locate_schedd(
     htcondor,
     schedd_cache: dict,
     schedd_lock: threading.Lock,
@@ -57,7 +72,7 @@ def main() -> int:
 
             collector = request.get("collector")
             schedd_name = request.get("schedd_name")
-            schedd = _locate_schedd(htcondor2, schedd_cache, schedd_lock, collector, schedd_name)
+            schedd = locate_schedd(htcondor2, schedd_cache, schedd_lock, collector, schedd_name)
             if command == "submit":
                 submit_result = schedd.submit(htcondor2.Submit(request["submit_description"]))
                 response = dict(ok=True, cluster=str(submit_result.cluster()))
@@ -65,7 +80,7 @@ def main() -> int:
                 schedd.act(
                     htcondor2.JobAction.Remove,
                     request["job_spec"],
-                    reason="Galaxy job stop request",
+                    reason=request.get("reason") or DEFAULT_REMOVE_REASON,
                 )
                 response = dict(ok=True)
             else:

--- a/test/integration/htcondor_fake/htcondor_helper.py
+++ b/test/integration/htcondor_fake/htcondor_helper.py
@@ -1,11 +1,11 @@
 """Thin wrapper so the subprocess helper uses the real main() with the fake htcondor2.
 
-The subprocess spawned by _HTCondorSubprocessClient runs ``python -m htcondor_helper``.
+The subprocess spawned by HTCondorSubprocessClient runs ``python -m htcondor_helper``.
 Because LIVE_FAKE_MODULE_PATH is prepended to PYTHONPATH the real main() resolves
 ``import htcondor2`` to the fake stub — no code duplication needed.
 """
 
-from galaxy.jobs.runners.htcondor_helper import main
+from galaxy.jobs.runners.util.condor.htcondor_helper import main
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/test/integration/test_htcondor_runner.py
+++ b/test/integration/test_htcondor_runner.py
@@ -838,6 +838,17 @@ def _write_user_log(cjs):
         handle.write("1")
 
 
+class _FakeClock:
+    """Drives a job state's escalation grace periods without sleeping."""
+
+    def __init__(self, cjs):
+        self.now = 0.0
+        cjs.clock = lambda: self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
 def _set_job_events(fake_htcondor, cjs, event_names):
     fake_htcondor.JobEventLog.set_events(
         cjs.user_log,
@@ -1216,7 +1227,7 @@ def test_stopped_or_deleted_jobs_are_not_submitted(fake_instance, fake_htcondor,
 
     assert _records(fake_instance) == []
     assert runner.monitor_queue.empty()
-    assert runner._client_cache == {}
+    assert runner._clients.clients() == []
 
 
 @pytest.mark.parametrize(
@@ -1281,7 +1292,7 @@ def test_runner_shutdown_terminates_all_helpers(fake_instance, fake_htcondor, ru
         )
     )
 
-    clients = list(runner._client_cache.values())
+    clients = runner._clients.clients()
     processes = [client._process for client in clients if getattr(client, "_process", None) is not None]
     assert len(processes) == 2
     assert all(process.poll() is None for process in processes)
@@ -1489,39 +1500,34 @@ def test_recover_with_completed_event_log(fake_instance, fake_htcondor, runner_f
 
 
 def test_transient_status_error_retries_before_failing(fake_instance, fake_htcondor, runner_factory, monkeypatch):
-    """Transient errors from _summarize_event_log keep the job watched for
-    MAX_STATUS_ERROR_COUNT-1 cycles, then fail it on the final error."""
-    from galaxy.jobs.runners import htcondor as htcondor_module
+    """Transient errors from _summarize_event_log keep the job watched until they
+    have persisted for STATUS_ERROR_GRACE_SECONDS, then fail it."""
+    from galaxy.jobs.runners.util.condor.htcondor import STATUS_ERROR_GRACE_SECONDS
 
     runner = runner_factory()
     job_wrapper = _job_wrapper(fake_instance, 1, dict(htcondor_config="/tmp/condor-transient-err"))
     cjs = _watch_job(runner, job_wrapper)
     _write_user_log(cjs)
-
-    call_count = 0
+    clock = _FakeClock(cjs)
 
     def always_raise(c):
-        nonlocal call_count
-        call_count += 1
         raise OSError("simulated NFS timeout")
 
     monkeypatch.setattr(runner, "_summarize_event_log", always_raise)
 
-    max_count = htcondor_module.MAX_STATUS_ERROR_COUNT
-
-    # First MAX_STATUS_ERROR_COUNT-1 errors: job stays in watched, nothing queued.
-    for i in range(max_count - 1):
+    # Polling faster than the grace period must not escalate, however many times.
+    for i in range(20):
+        clock.advance(STATUS_ERROR_GRACE_SECONDS / 40)
         runner.check_watched_items()
         assert len(runner.watched) == 1, f"job should still be watched after error {i + 1}"
         assert runner.work_queue.empty(), f"no failure should be queued after error {i + 1}"
-        assert cjs.status_error_count == i + 1
 
-    # Final error: job is failed.
+    # Once the errors have persisted past the grace period, the job is failed.
+    clock.advance(STATUS_ERROR_GRACE_SECONDS)
     runner.check_watched_items()
     assert len(runner.watched) == 0
     method, job_state_record = runner.work_queue.get_nowait()
     assert method == runner.fail_job
-    assert job_state_record.status_error_count == max_count
 
 
 def test_held_job_escalates_to_failure_after_max_count(fake_instance, fake_htcondor, runner_factory):
@@ -1721,7 +1727,7 @@ def _set_job_events_with_classads(fake_htcondor, cjs, events):
 
 
 def test_transient_status_error_resets_on_success(fake_instance, fake_htcondor, runner_factory, monkeypatch):
-    """A transient error followed by a successful check resets status_error_count to 0."""
+    """A transient error followed by a successful check restarts the grace period."""
     runner = runner_factory()
     job_wrapper = _job_wrapper(fake_instance, 1, dict(htcondor_config="/tmp/condor-err-reset"))
     cjs = _watch_job(runner, job_wrapper)
@@ -1739,14 +1745,14 @@ def test_transient_status_error_resets_on_success(fake_instance, fake_htcondor, 
 
     monkeypatch.setattr(runner, "_summarize_event_log", fail_once)
 
-    # Cycle 1: error — counter goes to 1
+    # Cycle 1: error — the grace period starts.
     runner.check_watched_items()
-    assert cjs.status_error_count == 1
+    assert cjs.status_error_since is not None
     assert len(runner.watched) == 1
 
-    # Cycle 2: success — counter must reset to 0
+    # Cycle 2: success — the grace period must be cleared.
     runner.check_watched_items()
-    assert cjs.status_error_count == 0
+    assert cjs.status_error_since is None
     assert len(runner.watched) == 1  # no terminal event yet, stays watched
 
 
@@ -1809,10 +1815,10 @@ def test_held_job_max_count_zero_disables_escalation(fake_instance, fake_htcondo
     ],
 )
 def test_inprocess_client_evicts_stale_schedd_on_error(fake_instance, fake_htcondor, operation, failing_method):
-    """_HTCondorInProcessClient evicts the cached Schedd when submit or remove raises."""
-    from galaxy.jobs.runners.htcondor import _HTCondorInProcessClient
+    """HTCondorInProcessClient evicts the cached Schedd when submit or remove raises."""
+    from galaxy.jobs.runners.util.condor.htcondor import HTCondorInProcessClient
 
-    client = _HTCondorInProcessClient(fake_htcondor)
+    client = HTCondorInProcessClient(fake_htcondor)
 
     class FailingSchedd:
         def submit(self, *a, **k):
@@ -2017,9 +2023,9 @@ def test_sigkill_on_user_stopped_job_finishes_not_oom(fake_instance, fake_htcond
 
 def test_subprocess_client_restarts_after_helper_crash(fake_instance, fake_htcondor):
     """The subprocess client spawns a fresh helper process when the old one dies unexpectedly."""
-    from galaxy.jobs.runners.htcondor import _HTCondorSubprocessClient
+    from galaxy.jobs.runners.util.condor.htcondor import HTCondorSubprocessClient
 
-    client = _HTCondorSubprocessClient("/tmp/condor-subprocess-restart")
+    client = HTCondorSubprocessClient("/tmp/condor-subprocess-restart")
     try:
         # First submit triggers process spawn.
         client.submit("universe = vanilla\ngetenv = true\nnotification = NEVER\nqueue", None, None)
@@ -2047,11 +2053,11 @@ def test_subprocess_client_restarts_after_helper_crash(fake_instance, fake_htcon
 
 
 def test_normalize_condor_config_expands_and_resolves(tmp_path):
-    from galaxy.jobs.runners.htcondor import _normalize_condor_config
+    from galaxy.jobs.runners.util.condor.htcondor import normalize_condor_config
 
     config_path = tmp_path / "condor.cfg"
     config_path.touch()
-    result = _normalize_condor_config(str(config_path))
+    result = normalize_condor_config(str(config_path))
     assert result == os.path.realpath(str(config_path))
     assert "~" not in result
 
@@ -2101,41 +2107,41 @@ def test_held_while_running_clears_running_flag(fake_instance, fake_htcondor, ru
 
 
 def test_locate_schedd_no_collector_no_name_returns_local_schedd(fake_htcondor):
-    """_locate_schedd with no collector and no schedd_name uses Schedd() directly."""
+    """locate_schedd with no collector and no schedd_name uses Schedd() directly."""
     import threading
 
-    from galaxy.jobs.runners.htcondor_helper import _locate_schedd
+    from galaxy.jobs.runners.util.condor.htcondor_helper import locate_schedd
 
     cache: dict = {}
     lock = threading.Lock()
-    schedd = _locate_schedd(fake_htcondor, cache, lock, None, None)
+    schedd = locate_schedd(fake_htcondor, cache, lock, None, None)
     assert schedd is not None
     assert (None, None) in cache
     assert cache[(None, None)] is schedd
 
 
 def test_locate_schedd_caches_and_returns_same_object(fake_htcondor):
-    """_locate_schedd returns the same object on a second call (cache hit)."""
+    """locate_schedd returns the same object on a second call (cache hit)."""
     import threading
 
-    from galaxy.jobs.runners.htcondor_helper import _locate_schedd
+    from galaxy.jobs.runners.util.condor.htcondor_helper import locate_schedd
 
     cache: dict = {}
     lock = threading.Lock()
-    first = _locate_schedd(fake_htcondor, cache, lock, None, None)
-    second = _locate_schedd(fake_htcondor, cache, lock, None, None)
+    first = locate_schedd(fake_htcondor, cache, lock, None, None)
+    second = locate_schedd(fake_htcondor, cache, lock, None, None)
     assert first is second
 
 
 def test_locate_schedd_with_collector_and_name(fake_htcondor):
-    """_locate_schedd with a collector and explicit schedd_name locates via the collector."""
+    """locate_schedd with a collector and explicit schedd_name locates via the collector."""
     import threading
 
-    from galaxy.jobs.runners.htcondor_helper import _locate_schedd
+    from galaxy.jobs.runners.util.condor.htcondor_helper import locate_schedd
 
     cache: dict = {}
     lock = threading.Lock()
-    schedd = _locate_schedd(fake_htcondor, cache, lock, "collector:9618", "schedd@host")
+    schedd = locate_schedd(fake_htcondor, cache, lock, "collector:9618", "schedd@host")
     assert schedd is not None
     assert ("collector:9618", "schedd@host") in cache
 
@@ -2194,9 +2200,9 @@ def test_htcondor_params_runner_default_used_when_destination_omits_params(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_event_log_escalates_to_failure_after_max_count(fake_instance, fake_htcondor, runner_factory):
-    """A job whose event log is absent for MAX_MISSING_LOG_COUNT consecutive cycles is failed."""
-    from galaxy.jobs.runners import htcondor as htcondor_module
+def test_missing_event_log_escalates_to_failure_after_grace_period(fake_instance, fake_htcondor, runner_factory):
+    """A job whose event log stays absent past MISSING_LOG_GRACE_SECONDS is failed."""
+    from galaxy.jobs.runners.util.condor.htcondor import MISSING_LOG_GRACE_SECONDS
 
     runner = runner_factory()
     job_wrapper = _job_wrapper(
@@ -2208,41 +2214,44 @@ def test_missing_event_log_escalates_to_failure_after_max_count(fake_instance, f
     cjs = _watch_job(runner, job_wrapper)
     # Deliberately do NOT write the user log — simulates a log that was never created or was lost.
     assert not os.path.exists(cjs.user_log)
+    clock = _FakeClock(cjs)
 
-    max_count = htcondor_module.MAX_MISSING_LOG_COUNT
-
-    for i in range(max_count - 1):
+    # Polling faster than the grace period must not escalate, however many times.
+    for i in range(20):
+        clock.advance(MISSING_LOG_GRACE_SECONDS / 40)
         runner.check_watched_items()
-        assert len(runner.watched) == 1, f"job should still be watched after absent-log cycle {i + 1}"
-        assert runner.work_queue.empty(), f"no failure should be queued after cycle {i + 1}"
-        assert cjs.missing_log_count == i + 1
+        assert len(runner.watched) == 1, f"job should still be watched after absent-log poll {i + 1}"
+        assert runner.work_queue.empty(), f"no failure should be queued after poll {i + 1}"
 
-    # Final cycle: escalates to failure.
+    # Once the log has been absent past the grace period, the job is failed.
+    clock.advance(MISSING_LOG_GRACE_SECONDS)
     runner.check_watched_items()
     assert len(runner.watched) == 0
     method, job_state_record = runner.work_queue.get_nowait()
     assert method == runner.fail_job
     assert "event log" in job_state_record.fail_message.lower()
-    assert job_state_record.missing_log_count == max_count
 
 
-def test_missing_log_count_resets_when_log_appears(fake_instance, fake_htcondor, runner_factory):
-    """missing_log_count resets to 0 as soon as the event log becomes available."""
+def test_missing_log_grace_period_resets_when_log_appears(fake_instance, fake_htcondor, runner_factory):
+    """The missing-log grace period is cleared as soon as the event log becomes available."""
+    from galaxy.jobs.runners.util.condor.htcondor import MISSING_LOG_GRACE_SECONDS
+
     runner = runner_factory()
     job_wrapper = _job_wrapper(fake_instance, 1, dict(htcondor_config="/tmp/condor-log-reappears"))
     cjs = _watch_job(runner, job_wrapper)
     assert not os.path.exists(cjs.user_log)
+    clock = _FakeClock(cjs)
 
     # Two cycles with no log.
     runner.check_watched_items()
-    assert cjs.missing_log_count == 1
+    assert cjs.missing_log_since is not None
+    clock.advance(MISSING_LOG_GRACE_SECONDS / 2)
     runner.check_watched_items()
-    assert cjs.missing_log_count == 2
 
-    # Log appears — counter resets and job stays watched (no terminal event yet).
+    # Log appears — the grace period resets and job stays watched (no terminal event yet).
     _write_user_log(cjs)
     runner.check_watched_items()
-    assert cjs.missing_log_count == 0
+    assert cjs.missing_log_since is None
     assert len(runner.watched) == 1
 
 
@@ -2262,9 +2271,9 @@ def test_missing_log_count_resets_when_log_appears(fake_instance, fake_htcondor,
     ],
 )
 def test_parse_memory_mb_valid(value, expected_mb):
-    from galaxy.jobs.runners.htcondor import _parse_memory_mb
+    from galaxy.jobs.runners.util.condor.htcondor import parse_memory_mb
 
-    assert _parse_memory_mb(value) == expected_mb
+    assert parse_memory_mb(value) == expected_mb
 
 
 @pytest.mark.parametrize(
@@ -2276,9 +2285,9 @@ def test_parse_memory_mb_valid(value, expected_mb):
     ],
 )
 def test_parse_memory_mb_unparseable_returns_none(value):
-    from galaxy.jobs.runners.htcondor import _parse_memory_mb
+    from galaxy.jobs.runners.util.condor.htcondor import parse_memory_mb
 
-    assert _parse_memory_mb(value) is None
+    assert parse_memory_mb(value) is None
 
 
 # ---------------------------------------------------------------------------
@@ -2298,9 +2307,9 @@ def test_parse_memory_mb_unparseable_returns_none(value):
     ],
 )
 def test_parse_walltime_seconds_valid(value, expected_seconds):
-    from galaxy.jobs.runners.htcondor import _parse_walltime_seconds
+    from galaxy.jobs.runners.util.condor.htcondor import parse_walltime_seconds
 
-    assert _parse_walltime_seconds(value) == expected_seconds
+    assert parse_walltime_seconds(value) == expected_seconds
 
 
 @pytest.mark.parametrize(
@@ -2312,9 +2321,9 @@ def test_parse_walltime_seconds_valid(value, expected_seconds):
     ],
 )
 def test_parse_walltime_seconds_invalid_returns_none(value):
-    from galaxy.jobs.runners.htcondor import _parse_walltime_seconds
+    from galaxy.jobs.runners.util.condor.htcondor import parse_walltime_seconds
 
-    assert _parse_walltime_seconds(value) is None
+    assert parse_walltime_seconds(value) is None
 
 
 def test_request_walltime_adds_periodic_hold(fake_instance, fake_htcondor, runner_factory):
@@ -2430,12 +2439,12 @@ def test_subprocess_client_times_out_on_hung_helper(fake_instance, fake_htcondor
     and marks the process as dead so the next call spawns a fresh helper."""
     import select as _select
 
-    from galaxy.jobs.runners.htcondor import (
-        _HTCondorSubprocessClient,
+    from galaxy.jobs.runners.util.condor.htcondor import (
         HTCONDOR_HELPER_TIMEOUT,
+        HTCondorSubprocessClient,
     )
 
-    client = _HTCondorSubprocessClient("/tmp/condor-timeout-test")
+    client = HTCondorSubprocessClient("/tmp/condor-timeout-test")
 
     # Patch select.select to simulate a timeout (no file descriptors ready).
     def fake_select(rlist, wlist, xlist, timeout):

--- a/test/integration/test_htcondor_runner.py
+++ b/test/integration/test_htcondor_runner.py
@@ -1906,13 +1906,23 @@ def test_hold_reason_code_sets_runner_state(
     expected_runner_state,
     message_fragment,
 ):
-    """JOB_HELD with a classified HoldReasonCode immediately fails with the correct runner_state."""
+    """A classified hold fails with the right runner_state once the grace window expires."""
+    from galaxy.jobs.runners.util.condor.htcondor import HELD_GRACE_SECONDS
+
     runner = runner_factory()
     job_wrapper = _job_wrapper(fake_instance, 1, dict(htcondor_config=f"/tmp/condor-hold-code-{hold_reason_code}"))
     cjs = _watch_job(runner, job_wrapper)
     _write_user_log(cjs)
+    clock = _FakeClock(cjs)
 
     _set_job_events_with_classads(fake_htcondor, cjs, [("JOB_HELD", {"HoldReasonCode": hold_reason_code})])
+    runner.check_watched_items()
+
+    # A hold is not terminal on sight - the pool may yet release the job.
+    assert runner.work_queue.empty()
+    assert len(runner.watched) == 1
+
+    clock.advance(HELD_GRACE_SECONDS)
     runner.check_watched_items()
 
     assert len(runner.watched) == 0
@@ -1920,6 +1930,61 @@ def test_hold_reason_code_sets_runner_state(
     assert method == runner.fail_job
     assert job_state_record.runner_state == expected_runner_state
     assert message_fragment.lower() in job_state_record.fail_message.lower()
+
+
+def test_memory_hold_released_by_pool_is_not_failed(fake_instance, fake_htcondor, runner_factory):
+    """A pool that releases held jobs must not be pre-empted by the hold reason.
+
+    Sites commonly configure periodic_release to retry a held job, at times
+    against a raised request_memory, so the retry can succeed where the first
+    attempt was held.
+    """
+    from galaxy.jobs.runners.util.condor.htcondor import HELD_GRACE_SECONDS
+
+    runner = runner_factory()
+    job_wrapper = _job_wrapper(fake_instance, 1, dict(htcondor_config="/tmp/condor-hold-released"))
+    cjs = _watch_job(runner, job_wrapper)
+    _write_user_log(cjs)
+    clock = _FakeClock(cjs)
+
+    _set_job_events_with_classads(fake_htcondor, cjs, [("JOB_HELD", {"HoldReasonCode": 34})])
+    runner.check_watched_items()
+    assert runner.work_queue.empty()
+    assert cjs.held_count == 1
+
+    clock.advance(HELD_GRACE_SECONDS / 2)
+    _set_job_events(fake_htcondor, cjs, ["JOB_RELEASED"])
+    runner.check_watched_items()
+    assert runner.work_queue.empty()
+    assert cjs.held_count == 0
+
+    # Well past the window the first hold opened, but the release cleared it.
+    clock.advance(HELD_GRACE_SECONDS)
+    runner.check_watched_items()
+    assert runner.work_queue.empty()
+    assert len(runner.watched) == 1
+
+
+def test_held_grace_seconds_is_configurable(fake_instance, fake_htcondor, runner_factory):
+    """held_grace_seconds destination param overrides how long a hold is tolerated."""
+    runner = runner_factory()
+    job_wrapper = _job_wrapper(
+        fake_instance, 1, dict(htcondor_config="/tmp/condor-hold-grace", held_grace_seconds="10")
+    )
+    cjs = _watch_job(runner, job_wrapper)
+    _write_user_log(cjs)
+    clock = _FakeClock(cjs)
+
+    _set_job_events_with_classads(fake_htcondor, cjs, [("JOB_HELD", {"HoldReasonCode": 34})])
+    runner.check_watched_items()
+    assert runner.work_queue.empty()
+
+    clock.advance(10)
+    runner.check_watched_items()
+
+    method, job_state_record = runner.work_queue.get_nowait()
+    assert method == runner.fail_job
+    assert job_state_record.runner_state == "memory_limit_reached"
 
 
 def test_hold_without_reason_code_uses_held_count_logic(fake_instance, fake_htcondor, runner_factory):


### PR DESCRIPTION
> **Note:** this pull request description was prepared and posted by Claude (AI assistant) on jmchilton's behalf, not authored by them personally.

Pulsar and Galaxy both need to talk to HTCondor, and until now each carried its own version of the mechanics. This moves the htcondor2 import, the schedd clients, event-log parsing, and hold/failure classification out of `lib/galaxy/jobs/runners/htcondor.py` into `galaxy.jobs.runners.util.condor.htcondor`, alongside `htcondor_helper` (moved from `galaxy.jobs.runners`).

That module is mirrored **byte-for-byte** into `pulsar/managers/util/condor/`, so the two applications share one implementation rather than two that drift. The companion Pulsar change is galaxyproject/pulsar#486.

The runner keeps only the mapping onto Galaxy's job model — it goes from ~530 lines of HTCondor plumbing plus model mapping down to the mapping alone, with `HTCondorJobState` now mixing in `HTCondorEventLogTracker`.

The shared module deliberately knows nothing about either application's job model. Callers map the vocabulary it defines (`EventLogSummary`, the `HOLD_REASON_*` and `FAILURE_*` keys) onto their own job states.

### Behavior change

Escalation for persistent status-check errors and for a missing event log is now measured in wall-clock seconds (`STATUS_ERROR_GRACE_SECONDS`, `MISSING_LOG_GRACE_SECONDS`) rather than in monitor cycles.

`job_runner_monitor_sleep` is admin-configurable and documented purely as a throughput knob, so counting cycles gave the grace window no fixed duration — lowering the sleep to improve responsiveness silently shortened how long a job was given before being escalated. The tracker takes an injectable clock, so tests drive escalation without sleeping.

### Constraint worth knowing about

Because the module is shared with Pulsar, which still supports Python 3.7, it must stay 3.7-parseable: `from __future__ import annotations` is required so the `X | None` annotations are never evaluated at runtime, and the walrus operator and any other post-3.7 syntax are off limits. This is documented in the module docstring so the constraint survives future edits.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

`test/integration/test_htcondor_runner.py` is updated for the new structure, and the injectable clock lets the escalation paths be tested directly rather than by waiting.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
