### PR TITLE
Enable tool request by default

### DIFF
--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -32,9 +32,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10']
-        use-legacy-api: ['if_needed', 'always']
+        use-legacy-api: ['never', 'always']
     services:
       postgres:
         image: postgres:18

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5652,7 +5652,7 @@
     `/api/tools` endpoint when this is disabled, when Celery is not
     enabled, or when the tool does not provide a typed parameter
     schema.
-:Default: ``false``
+:Default: ``true``
 :Type: bool
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -3067,7 +3067,7 @@ galaxy:
   # (`/api/jobs`) when available. The client falls back to the legacy
   # `/api/tools` endpoint when this is disabled, when Celery is not
   # enabled, or when the tool does not provide a typed parameter schema.
-  #enable_tool_requests: false
+  #enable_tool_requests: true
 
   # Configuration options passed to Celery.
   # To refer to a task by name, use the template `galaxy.foo` where

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4193,7 +4193,7 @@ mapping:
 
       enable_tool_requests:
         type: bool
-        default: false
+        default: true
         required: false
         desc: |
           Submit tool jobs through the asynchronous tool requests API (`/api/jobs`)

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import (
     Any,
+    cast,
     Literal,
     Union,
 )
@@ -23,6 +24,7 @@ from galaxy.tool_util.parser.interface import (
     TestCollectionDef,
     ToolSource,
     ToolSourceTest,
+    ToolSourceTestInput,
     ToolSourceTestInputs,
     ToolSourceTests,
 )
@@ -79,7 +81,10 @@ def parse_tool_test_descriptions(
             if parameters is None:
                 tool_parameter_bundle = input_models_for_tool_source(tool_source)
                 parameters = tool_parameter_bundle.parameters
-            validated_test_case = case_state(raw_test_dict, parameters, profile, validate=validate_on_load)
+            qualified_test_dict = cast(
+                ToolSourceTest, {**raw_test_dict, "inputs": _qualify_test_inputs(tool_source, raw_test_dict)}
+            )
+            validated_test_case = case_state(qualified_test_dict, parameters, profile, validate=validate_on_load)
             if validated_test_case.unhandled_inputs:
                 # Inputs that map to no parameter (e.g. legacy unqualified repeats) can't be
                 # represented in a modern request; fall back to the legacy API.
@@ -125,6 +130,38 @@ def parse_tool_test_descriptions(
 class TestRequestAndSchema:
     request: TestCaseToolState
     request_schema: ToolParameterBundleModel
+
+
+def _qualify_test_inputs(tool_source: ToolSource, raw_test_dict: ToolSourceTest) -> ToolSourceTestInputs:
+    """Rewrite a legacy test's unqualified parameter names to the tool's own paths.
+
+    Reuses the loader's tree walk, so `input2` given twice becomes `queries_0|input2`
+    and `queries_1|input2` exactly as the legacy submission resolves it. Tools whose
+    profile disallows unqualified access resolve to the names they already carry.
+    """
+    inputs: ToolSourceTestInputs = raw_test_dict.get("inputs") or []
+    scratch: ToolSourceTestInputs = [cast(ToolSourceTestInput, dict(raw_input)) for raw_input in inputs]
+    qualified_names: dict[int, str] = {}
+    try:
+        _process_raw_inputs(
+            tool_source,
+            input_sources(tool_source),
+            list(scratch),
+            raw_test_dict.get("value_state_representation", "test_case_xml"),
+            [],
+            [],
+            [],
+            qualified_names=qualified_names,
+        )
+    except Exception:
+        # Only names are wanted here. Any loader complaint about a value is raised again
+        # by the caller's own walk, against the original inputs.
+        return inputs
+    qualified: ToolSourceTestInputs = []
+    for raw_input, probe in zip(inputs, scratch):
+        name = qualified_names.get(id(probe))
+        qualified.append(cast(ToolSourceTestInput, {**raw_input, "name": name}) if name else raw_input)
+    return qualified
 
 
 def _description_from_tool_source(
@@ -227,6 +264,7 @@ def _process_raw_inputs(
     required_data_tables: RequiredDataTablesT,
     required_loc_files: RequiredLocFileT,
     parent_context: AnyParamContext | None = None,
+    qualified_names: dict[int, str] | None = None,
 ) -> ExpandedToolInputs:
     """
     Recursively expand flat list of inputs into "tree" form of flat list
@@ -246,6 +284,8 @@ def _process_raw_inputs(
             case_name = test_param_input_source.parse_name()
             case_context = ParamContext(name=case_name, parent_context=cond_context)
             raw_input_dict = case_context.extract_value(raw_inputs)
+            if raw_input_dict is not None and qualified_names is not None:
+                qualified_names[id(raw_input_dict)] = case_context.for_state()
             case_value = raw_input_dict["value"] if raw_input_dict else None
             case_when, case_input_sources = _matching_case_for_value(
                 tool_source, input_source, test_param_input_source, case_value, allow_legacy_test_case_parameters
@@ -261,6 +301,7 @@ def _process_raw_inputs(
                         required_data_tables,
                         required_loc_files,
                         parent_context=cond_context,
+                        qualified_names=qualified_names,
                     )
                     expanded_inputs.update(case_inputs)
                 expanded_case_value = split_if_str(case_when)
@@ -293,6 +334,7 @@ def _process_raw_inputs(
                     required_data_tables,
                     required_loc_files,
                     parent_context=context,
+                    qualified_names=qualified_names,
                 )
                 if expanded_input:
                     expanded_inputs.update(expanded_input)
@@ -312,6 +354,7 @@ def _process_raw_inputs(
                         required_data_tables,
                         required_loc_files,
                         parent_context=context,
+                        qualified_names=qualified_names,
                     )
                     if expanded_input:
                         expanded_inputs.update(expanded_input)
@@ -322,6 +365,8 @@ def _process_raw_inputs(
         else:
             context = ParamContext(name=name, parent_context=parent_context)
             raw_input_dict = context.extract_value(raw_inputs)
+            if raw_input_dict is not None and qualified_names is not None:
+                qualified_names[id(raw_input_dict)] = context.for_state()
             param_type = input_source.get("type")
             if raw_input_dict:
                 name = raw_input_dict["name"]

--- a/lib/galaxy/tools/merge_collection.xml
+++ b/lib/galaxy/tools/merge_collection.xml
@@ -249,7 +249,11 @@
       </output_collection>
     </test>
     <test>
-      <expand macro="advanced_section" duplicate_handling="keep_last" suffix_pattern="__#" />
+      <section name="advanced">
+        <conditional name="conflict">
+          <param name="duplicate_options" value="keep_last" />
+        </conditional>
+      </section>
       <repeat name="inputs">
         <param name="input">
           <expand macro="test_collecton_simple_then_alternative" />

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -17,17 +17,6 @@ from galaxy_test.driver.integration_util import ConfiguresDatabaseVault
 
 SKIPTEST = os.path.join(os.path.dirname(__file__), "known_broken_tools.txt")
 
-# Test cases that name a repeat's parameters without an instance index. These cannot be
-# expressed as a typed request, so the interactor falls back to the legacy tool API. See
-# test_legacy_unqualified_repeat_inputs_are_not_expanded.
-LEGACY_ONLY_TOOLS = {
-    "multi_repeats",
-    "simple_constructs",
-    "implicit_default_conds",
-    "async_min_repeat_unqualified",
-    "async_repeat_unqualified_no_min",
-}
-
 
 class ToolTest(NamedTuple):
     tool_id: str
@@ -58,16 +47,9 @@ def get_cases() -> list[ToolTest]:
 
 def cases():
     skiplist = get_skiplist()
-    use_legacy_api = os.environ.get("GALAXY_TEST_USE_LEGACY_TOOL_API", DEFAULT_USE_LEGACY_API)
     for tool_test in get_cases():
         marks = []
         marks.append(pytest.mark.skipif(tool_test.tool_id in skiplist, reason="tool in skiplist"))
-        marks.append(
-            pytest.mark.skipif(
-                use_legacy_api == "never" and tool_test.tool_id in LEGACY_ONLY_TOOLS,
-                reason="test case is only expressible against the legacy tool API",
-            )
-        )
         if "data_manager_" in tool_test.tool_id:
             marks.append(pytest.mark.data_manager(tool_test))
         else:

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -22,6 +22,8 @@ SKIPTEST = os.path.join(os.path.dirname(__file__), "known_broken_tools.txt")
 # test_legacy_unqualified_repeat_inputs_are_not_expanded.
 LEGACY_ONLY_TOOLS = {
     "multi_repeats",
+    "simple_constructs",
+    "implicit_default_conds",
     "async_min_repeat_unqualified",
     "async_repeat_unqualified_no_min",
 }

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -17,6 +17,15 @@ from galaxy_test.driver.integration_util import ConfiguresDatabaseVault
 
 SKIPTEST = os.path.join(os.path.dirname(__file__), "known_broken_tools.txt")
 
+# Test cases that name a repeat's parameters without an instance index. These cannot be
+# expressed as a typed request, so the interactor falls back to the legacy tool API. See
+# test_legacy_unqualified_repeat_inputs_are_not_expanded.
+LEGACY_ONLY_TOOLS = {
+    "multi_repeats",
+    "async_min_repeat_unqualified",
+    "async_repeat_unqualified_no_min",
+}
+
 
 class ToolTest(NamedTuple):
     tool_id: str
@@ -47,9 +56,16 @@ def get_cases() -> list[ToolTest]:
 
 def cases():
     skiplist = get_skiplist()
+    use_legacy_api = os.environ.get("GALAXY_TEST_USE_LEGACY_TOOL_API", DEFAULT_USE_LEGACY_API)
     for tool_test in get_cases():
         marks = []
         marks.append(pytest.mark.skipif(tool_test.tool_id in skiplist, reason="tool in skiplist"))
+        marks.append(
+            pytest.mark.skipif(
+                use_legacy_api == "never" and tool_test.tool_id in LEGACY_ONLY_TOOLS,
+                reason="test case is only expressible against the legacy tool API",
+            )
+        )
         if "data_manager_" in tool_test.tool_id:
             marks.append(pytest.mark.data_manager(tool_test))
         else:

--- a/test/functional/tools/validation_value_in_datatable.xml
+++ b/test/functional/tools/validation_value_in_datatable.xml
@@ -41,7 +41,7 @@ echo 'Hello World' > out1
         <test expect_failure="true">
             <param name="value" value="wrongvalue"/>
             <param name="value_neg" value="hg19"/>
-            <param name="value_deprecated" value="hg19"/>
+            <param name="value_neg_deprecated" value="hg19"/>
             <param name="select_value" value="absent_value"/>
             <param name="select_value_multiple" value="absent_value,hg19_value"/>
         </test>

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -427,13 +427,19 @@ def test_legacy_unqualified_repeat_inputs_are_not_expanded():
         case_state_for(tool_source, test_cases[2])
 
 
-def test_unrepresentable_test_case_falls_back_to_legacy_request():
-    # A test whose inputs can't be represented in a modern request (unqualified repeats) yields no
-    # request, so the interactor falls back to the legacy tool API rather than erroring.
+def test_legacy_unqualified_repeat_inputs_are_qualified_on_load():
+    # Loading a legacy test resolves its unqualified repeat params against the tool's input
+    # tree, the way the sync path does, so the nth bare occurrence lands in the nth instance
+    # and sibling repeats stay separate. The request is then representable.
     tests = list(parse_tool_test_descriptions(tool_source_for("multi_repeats")))
     description = tests[2].to_dict()
     assert description["error"] is False
-    assert description["request"] is None
+    request = description["request"]
+    assert request is not None
+    assert len(request["queries"]) == 2
+    assert len(request["more_queries"]) == 2
+    assert request["queries"][0]["input2"]["path"] == "simple_line.txt"
+    assert request["more_queries"][1]["more_queries_input"]["path"] == "simple_line.txt"
 
 
 def test_legacy_unqualified_repeat_inside_conditional_is_resolved():


### PR DESCRIPTION
Re-enables tool requests by default for dev, reverting #23113.

Requires on #23442, which moves the framework tool tests from `if_needed` to `never`. Under `if_needed` the suite silently falls back to `/api/tools` whenever the typed path cannot build a request.

The latest full-suite async-vs-sync comparison ([run 33791633481](https://github.com/guerler/tools-iuc/actions/runs/33791633481/job/100904345880)) covers **907 repositories, 6,648 tests**:

| | count |
|---|---|
| pass under both | 6,466 |
| fail under both | 143 |
| fail only under async | 12 |
| pass only under async | 27 |

**None of the twelve is a tool request framework defect.** Grepping the delta for every framework signature (`could not build request`, `RequestParameterInvalidException`, `unhandled inputs`, `Field required`, `Ambiguous unqualified`) returns zero. The twelve break down as eight output-content differences (mostly fourth-decimal numeric drift, e.g. `megahit;0` at `multi=1.0505` against `multi=1.0486`), two tool crashes, one 900s timeout, and one image-size nondeterminism. They are tracked in galaxyproject/tools-iuc#8283.

The 27 pass-only column is worth reading too: ten are `stacks2_*`, where sync silently substitutes defaults for declared booleans and the async resolver applies them. That is a legacy defect this change fixes rather than a risk it introduces.

**On "zero regressions" as a merge bar.** 946 tests ran in both this run and the previous one; only one regression reproduced across the two days, and one test appeared on both sides of the ledger. The regression set partly regenerates per run, so a single green run would be luck rather than evidence. The meaningful bar is zero *reproducible* regressions established over repeated runs, and per-test stability tables are what answer the concern that a real bug is hiding among the tool-side noise.

**The comparison above covers the server side only**, where planemo submits the tool test directly. What this change actually flips is the browser form: the client picks the path from this config value (`config?.enable_tool_requests !== false` in `Tool/submit/index.js`). #23412 measures exactly that, driving the real tool form in Selenium with `enable_tool_requests` on and comparing the state the form submits against what the tool test declares.

Its [latest run](https://github.com/galaxyproject/galaxy/actions/runs/33957156011) is green across four shards: **609 of 651 form-driven tool tests submit state matching the declared parameters**, with 41 `xfail` entries that each carry a written reason and one `xpass` marking an entry to delete. The 41 are dominated by test-data and environment limits rather than typed-path defects: datatypes the instance does not know, options behind an unreachable `from_url`, tools needing credentials this instance has none of, and options filtered on another parameter that the default form does not render.

That is the client-side evidence for this change, and it holds whether or not #23412 itself merges: at roughly six hours of compute per run it may have to be trimmed to a subset before it can live in CI, but the measurement has already been made against the full set.
