### PR TITLE
Don't apply PJAs to skipped elements of mapped over outputs

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -32,6 +32,19 @@ class DefaultJobAction:
     ):
         pass
 
+    @staticmethod
+    def mapped_over_dataset_instances(step_output):
+        """Dataset instances an action should act on for a mapped over step output.
+
+        Handles both collection and single dataset outputs, and drops skipped
+        placeholders - mutating those breaks skip detection downstream.
+        """
+        if hasattr(step_output, "dataset_instances"):
+            instances = step_output.dataset_instances
+        else:
+            instances = [step_output]
+        return [instance for instance in instances if instance is not None and not instance.is_skipped]
+
     @classmethod
     def get_short_str(cls, pja):
         if pja.action_arguments:
@@ -115,12 +128,8 @@ class ChangeDatatypeAction(DefaultJobAction):
             newtype = action.action_arguments["newtype"]
             for name, step_output in step_outputs.items():
                 if action.output_name == "" or name == action.output_name:
-                    if hasattr(step_output, "dataset_instances"):
-                        for element in step_output.dataset_instances:
-                            if element:
-                                trans.app.datatypes_registry.change_datatype(element, newtype)
-                    else:
-                        trans.app.datatypes_registry.change_datatype(step_output, newtype)
+                    for dataset_instance in cls.mapped_over_dataset_instances(step_output):
+                        trans.app.datatypes_registry.change_datatype(dataset_instance, newtype)
 
     @classmethod
     def execute(cls, app, sa_session, action, job, replacement_dict=None, final_job_state=None):
@@ -362,7 +371,8 @@ class ColumnSetAction(DefaultJobAction):
         if action.action_arguments:
             for name, step_output in step_outputs.items():
                 if action.output_name == "" or name == action.output_name:
-                    cls._apply_column_set(step_output, action.action_arguments)
+                    for dataset_instance in cls.mapped_over_dataset_instances(step_output):
+                        cls._apply_column_set(dataset_instance, action.action_arguments)
 
     @classmethod
     def execute(cls, app, sa_session, action, job, replacement_dict=None, final_job_state=None):

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -7,7 +7,12 @@ import datetime
 
 from markupsafe import escape
 
-from galaxy.model import PostJobActionAssociation
+from galaxy.model import (
+    DatasetInstance,
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
+    PostJobActionAssociation,
+)
 from galaxy.util import send_mail
 from galaxy.util.custom_logging import get_logger
 
@@ -33,13 +38,16 @@ class DefaultJobAction:
         pass
 
     @staticmethod
-    def mapped_over_dataset_instances(step_output):
+    def mapped_over_dataset_instances(
+        step_output: HistoryDatasetAssociation | HistoryDatasetCollectionAssociation,
+    ) -> list[DatasetInstance]:
         """Dataset instances an action should act on for a mapped over step output.
 
         Handles both collection and single dataset outputs, and drops skipped
         placeholders - mutating those breaks skip detection downstream.
         """
-        if hasattr(step_output, "dataset_instances"):
+        instances: list[DatasetInstance | None]
+        if isinstance(step_output, HistoryDatasetCollectionAssociation):
             instances = step_output.dataset_instances
         else:
             instances = [step_output]

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5583,6 +5583,16 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
 
     quota_source_label = property(get_quota_source_label)
 
+    @property
+    def is_skipped(self) -> bool:
+        """Whether this is a placeholder standing in for a skipped step output.
+
+        Deliberately narrower than the extension check skip detection does - an
+        expression tool output is expression.json too, only set_skipped also
+        sets the blurb.
+        """
+        return self.extension == "expression.json" and self.blurb == "skipped"
+
     def set_skipped(self, object_store_populator: "ObjectStorePopulator", replace_dataset: bool) -> None:
         assert self.dataset
         object_store_populator.set_object_store_id(self)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2108,9 +2108,8 @@ class PickValueModule(WorkflowModule):
         """Check if a replacement value represents a skipped/null output."""
         if value is NO_REPLACEMENT:
             return True
-        if isinstance(value, model.HistoryDatasetAssociation):
-            if value.extension == "expression.json" and value.blurb == "skipped":
-                return True
+        if isinstance(value, model.DatasetInstance):
+            return value.is_skipped
         return False
 
     def _pick_from_replacements(self, trans: "ProvidesHistoryContext", invocation_step, mode, replacements):

--- a/lib/galaxy_test/workflow/pick_value_mapped_mixed_skip_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_mixed_skip_pja.gxwf-tests.yml
@@ -1,0 +1,29 @@
+- doc: |
+    Test that a PJA discriminates between skipped and real elements within a
+    single mapped over pick_value output. The per-element booleans skip one
+    branch job and run the other, so the picked collection holds one skipped
+    placeholder and one real output. Only the real one may get the new
+    datatype - the placeholder must keep expression.json.
+  job:
+    boolean_input_files:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: runs
+          class: File
+          contents: "true"
+        - identifier: skips
+          class: File
+          contents: "false"
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        runs:
+          class: File
+          ftype: txt
+        skips:
+          class: File
+          ftype: expression.json

--- a/lib/galaxy_test/workflow/pick_value_mapped_mixed_skip_pja.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_mixed_skip_pja.gxwf.yml
@@ -1,0 +1,31 @@
+class: GalaxyWorkflow
+inputs:
+  boolean_input_files:
+    type: collection
+    collection_type: list
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  param_out:
+    tool_id: param_value_from_file
+    in:
+      input1: boolean_input_files
+    state:
+      param_type: boolean
+  branch:
+    tool_id: cat1
+    in:
+      input1: boolean_input_files
+      should_run: param_out/boolean_param
+    when: $(inputs.should_run)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        change_datatype: txt

--- a/lib/galaxy_test/workflow/pick_value_mapped_set_columns.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_set_columns.gxwf-tests.yml
@@ -1,0 +1,31 @@
+- doc: |
+    Test that ColumnSetAction reaches the elements of a mapped over pick_value
+    output. The action has to descend into the collection - assigning the
+    metadata to the collection itself silently does nothing to the datasets.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          path: 1.bed
+          filetype: bed
+        - identifier: el2
+          class: File
+          path: 1.bed
+          filetype: bed
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        el1:
+          class: File
+          metadata:
+            chromCol: 2
+        el2:
+          class: File
+          metadata:
+            chromCol: 2

--- a/lib/galaxy_test/workflow/pick_value_mapped_set_columns.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_set_columns.gxwf.yml
@@ -1,0 +1,25 @@
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    type: collection
+    collection_type: list
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        set_columns:
+          chromCol: 2

--- a/lib/galaxy_test/workflow/pick_value_mapped_skip_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_skip_pja.gxwf-tests.yml
@@ -1,0 +1,66 @@
+- doc: |
+    Test that PJAs are NOT applied to skipped elements of a mapped over
+    pick_value output. With the branch skipped, every element of the picked
+    collection is a skipped placeholder and must retain expression.json for
+    downstream skip detection, despite the ChangeDatatypeAction.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when: false
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        el1:
+          class: File
+          ftype: expression.json
+        el2:
+          class: File
+          ftype: expression.json
+- doc: |
+    Test that the same PJA still applies to real elements. With the branch
+    active nothing is skipped, so every element gets the new datatype.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when: true
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        el1:
+          class: File
+          ftype: txt
+          asserts:
+            - that: has_text
+              text: "line1"
+        el2:
+          class: File
+          ftype: txt
+          asserts:
+            - that: has_text
+              text: "line2"

--- a/lib/galaxy_test/workflow/pick_value_mapped_skip_pja.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_mapped_skip_pja.gxwf.yml
@@ -1,0 +1,29 @@
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    type: collection
+    collection_type: list
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        change_datatype: txt


### PR DESCRIPTION
b280e5bca8 guarded the unmapped `pick_value` path, but the guard keys on `HistoryDatasetAssociation`. Mapped over a collection, `pick_value` returns an HDCA, so the guard misses and `ChangeDatatypeAction` rewrites the extension of the skipped placeholders inside it. Downstream skip detection keys on `expression.json`, so those steps stop being recognised as skipped.

The guard now lives in the actions rather than at each call site: `DatasetInstance.is_skipped` (the missing counterpart to `set_skipped`) and `DefaultJobAction.mapped_over_dataset_instances`, which normalises collection vs single outputs and drops skipped placeholders. It is opt-in, so it does not by itself stop a future action from repeating the mistake — it just gives the ones that iterate elements a correct way to do it. The remaining `execute_on_mapped_over` implementations act on the collection as a whole, so there is no gap today.

**Separate defect in the same method, and a behaviour change worth a look.** `ColumnSetAction.execute_on_mapped_over` was passing the collection itself to `_apply_column_set`, which does `setattr(dataset.metadata, ...)`. `HistoryDatasetCollectionAssociation` inherits `Base` and defines no `metadata` of its own, so that resolved to `Base.metadata` — the process-wide SQLAlchemy `MetaData` — and the action silently mutated shared global state while setting nothing on any dataset. Routing it through the same helper makes it iterate elements, matching its `execute` counterpart. Set-columns on a mapped-over step therefore goes from doing nothing to actually applying, which will change results for any workflow that has it configured.

Part of #22200.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

Three framework workflows, all red before this change:

| test | what it pins |
|---|---|
| `pick_value_mapped_skip_pja` | skipped elements keep `expression.json`, real elements still get the new datatype — red as `ftype` expected `[expression.json]` but found `[txt]` |
| `pick_value_mapped_mixed_skip_pja` | one skipped and one real element in the same picked collection, so the guard has to discriminate within a collection |
| `pick_value_mapped_set_columns` | column assignments reach the elements — red as `metadata_chromCol` expected `[2]` but found `[1]` |

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).