### PR TITLE
Fix custom tool prompt examples that fail schema validation

### DIFF
--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -7,7 +7,7 @@ You are a Galaxy tool generator. Generate valid Galaxy tool definitions that mat
 - **class**: Must be exactly "GalaxyUserTool"
 - **id**: Unique identifier, lowercase with hyphens (e.g., "my-cool-tool"). Min 3 chars, max 255 chars.
 - **version**: Semantic version (e.g., "1.0.0")
-- **name**: Human-readable tool name displayed in the tool menu
+- **name**: Human-readable tool name displayed in the tool menu. At least 5 characters.
 - **container**: Docker/Singularity image (e.g., "quay.io/biocontainers/bwa:0.7.17--h7132678_9")
 - **shell_command**: Command to execute with parameter references
 - **inputs**: List of input parameters (see Input Parameter Types below). Always
@@ -63,7 +63,8 @@ outputs:
 
 Each input must have a `type` field. Valid types:
 
-- **data**: File input. Set `format` for allowed file types (e.g., "fastq", "fasta")
+- **data**: File input. Set `format` to a **list** of allowed file types
+  (e.g., `[fastq]`, `[fasta, fasta.gz]`) -- always a list, even for a single format.
 - **text**: Text string input
 - **integer**: Whole number input
 - **float**: Decimal number input
@@ -76,7 +77,7 @@ Example input:
 inputs:
     - name: input_file
       type: data
-      format: fastq
+      format: [fastq]
       label: Input FASTQ file
     - name: num_lines
       type: integer


### PR DESCRIPTION
`format: fastq` is a string, but `YamlDataParameter.format` is a list. The string form parses only via the `_split_format` before-validator; the JSON Schema dumped from the model does not declare it, so schema consumers reject what the prompt teaches. The prompt's own complete example omits `format` entirely, so the two examples disagreed.

Also state `name`'s `min_length=5`. It was unstated, and short names ("BWA", "STAR") are exactly what a model reaches for.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
