### PR TITLE
Remove the blinking ellipsis from LoadingSpan, keeping the spinner

### DIFF
--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -7,7 +7,7 @@
     <span>
         <span :class="spinnerClasses" title="loading"></span>
         <span v-if="!spinnerOnly" class="loading-message" data-description="loading message">
-            {{ message }}.<span class="blinking">..</span>
+            {{ message }}
         </span>
     </span>
 </template>

--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -7,7 +7,7 @@
     <span>
         <span :class="spinnerClasses" title="loading"></span>
         <span v-if="!spinnerOnly" class="loading-message" data-description="loading message">
-            {{ message }}
+            {{ message }}...
         </span>
     </span>
 </template>


### PR DESCRIPTION
Fixes #14275

Two loading gifs is potentially unnecessary — the component renders two concurrent animations: the
`fa-spin` spinner and the `blinking` ellipsis after the message. The issue asks
for one. This keeps the spinner and drops the animated ellipsis, so the message
is static text next to a single moving indicator.

```diff
--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -7,7 +7,7 @@
     <span>
         <span :class="spinnerClasses" title="loading"></span>
         <span v-if="!spinnerOnly" class="loading-message" data-description="loading message">
-            {{ message }}.<span class="blinking">..</span>
+            {{ message }}
         </span>
     </span>
 </template>
```

Kept deliberately:
- `data-description="loading message"` — used as a Selenium selector.
- The `blinking` class itself — still used by `ProgressBar.vue` and
  `lib/tool_shed/webapp/frontend/src/components/LoadingDiv.vue`, and defined in
  `client/src/style/scss/dataset.scss`, so it is not orphaned by this change.

Verified that no test or snapshot asserts the literal trailing dots. The other
`"Loading..."` occurrences in the client are prop values passed by callers or
unrelated static text, which this change does not affect.

Note: this supersedes #22989, which was auto-closed when its source fork was
deleted. That patch also added a second message span instead of replacing the
first one, which would have shown the message twice; this one replaces it.