### PR TITLE
Fix custom tool prompt guidance that doesn't match the schema

### DIFF
--- a/lib/galaxy/agents/prompts/custom_tool_critic.md
+++ b/lib/galaxy/agents/prompts/custom_tool_critic.md
@@ -17,17 +17,21 @@ You receive the original user request, the produced tool YAML, and you return a 
 **Idiomaticity issues** -- shape of the tool:
 
 - `shell_command` mixes shell quoting that won't escape correctly (e.g., bare `$(date)` instead of `\$(date)`)
-- Optional parameters have no `value`, forcing the user to supply values that should be sensible
-  (the field is `value`; `default` is not accepted and fails validation)
+- Optional **text**, **integer**, **float** or **boolean** parameters have no `value`,
+  forcing the user to supply values that should be sensible (the field is `value`;
+  `default` is not accepted and fails validation). **select** parameters take no
+  `value` at all -- their default is `selected: true` on one of their `options` -- and
+  **data** parameters take none either, so never ask for one on those.
 - Common analysis options aren't exposed (e.g., a BWA tool with no `-t` threads input)
 - File outputs declared without `from_work_dir` or matching command output (the validator should have caught these, but flag any borderline cases)
 
 ## Containers are not your concern
 
-Do NOT flag, judge, or second-guess the `container` image. A separate dedicated step infers the
-tool's dependencies and resolves a verified image against quay.io, so any container critique here
-is redundant and may conflict with it. Leave container choice out of `clarity_issues` and
-`idiomaticity_issues` entirely.
+Do NOT flag, judge, or second-guess the `container` image. Container choice is handled
+outside this critique -- where the deployment enables it, a dedicated step infers the
+tool's dependencies and resolves a verified image against quay.io -- so any container
+critique here is redundant and may conflict with it. Leave container choice out of
+`clarity_issues` and `idiomaticity_issues` entirely.
 
 ## What NOT to flag
 

--- a/lib/galaxy/agents/prompts/custom_tool_critic.md
+++ b/lib/galaxy/agents/prompts/custom_tool_critic.md
@@ -17,7 +17,8 @@ You receive the original user request, the produced tool YAML, and you return a 
 **Idiomaticity issues** -- shape of the tool:
 
 - `shell_command` mixes shell quoting that won't escape correctly (e.g., bare `$(date)` instead of `\$(date)`)
-- Optional parameters have no `default`, forcing the user to supply values that should be sensible
+- Optional parameters have no `value`, forcing the user to supply values that should be sensible
+  (the field is `value`; `default` is not accepted and fails validation)
 - Common analysis options aren't exposed (e.g., a BWA tool with no `-t` threads input)
 - File outputs declared without `from_work_dir` or matching command output (the validator should have caught these, but flag any borderline cases)
 

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -36,10 +36,13 @@ help:
 
 - Input file paths: `$(inputs.param_name.path)` for single files
 - Input values: `$(inputs.param_name)` for text, integer, float, boolean
-- For `multiple: true` data inputs the value is a list, so map over it and join:
-  `$(inputs.param_name.map((input) => input.path).join(" "))`. There is no `[]`
-  indexing syntax -- expressions are JavaScript, and `inputs.param_name[].path`
-  is a syntax error that only surfaces when the job is built.
+- For `multiple: true` data inputs the value is a list of file objects, so map over
+  it and join, quoting each path:
+  ``$(inputs.param_name.map((input) => `'${input.path}'`).join(" "))``. The result is
+  spliced into the command verbatim, so a bare `.join(" ")` leaves the paths unquoted.
+- `inputs.param_name[].path` is not valid -- the empty `[]` is a JavaScript syntax
+  error that only surfaces when the job is built. (Indexing itself is fine;
+  expressions are JavaScript, so `inputs.some_repeat[0].x` works.)
 - CRITICAL: every `inputs.param_name` you reference in `shell_command` MUST exactly match
   the `name` of an input you declared under `inputs`. Use the same name in both
   places; never reference an input you did not declare.
@@ -82,6 +85,11 @@ Each input must have a `type` field. Valid types:
 - **float**: Decimal number input
 - **boolean**: True/false checkbox
 - **select**: Dropdown with options
+
+`value` sets the default for **text**, **integer**, **float** and **boolean** inputs
+only. A **select** has no `value`; mark its default with `selected: true` on one of
+its `options`. A **data** input has no `value` either. Any other key -- including
+`default` -- is rejected as an unknown field.
 
 Example input:
 
@@ -197,7 +205,9 @@ it, so don't assume the two are equal.
 - Use biocontainers images when available for bioinformatics tools
 - Escape shell variables that aren't Galaxy expressions: `\$(date)`
 - Keep shell_command focused and simple
-- Provide a sensible `value` for optional parameters (the field is `value`, not `default`)
+- Give optional text, integer, float and boolean parameters a sensible `value` (and a
+  select a `selected` option) -- the field is `value`, never `default`, and an unknown
+  key is rejected outright
 - Use descriptive labels for inputs and outputs
 
 ## CRITICAL: Accuracy Requirements

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -27,7 +27,10 @@ You are a Galaxy tool generator. Generate valid Galaxy tool definitions that mat
 
 - Input file paths: `$(inputs.param_name.path)` for single files
 - Input values: `$(inputs.param_name)` for text, integer, float, boolean
-- For array inputs: `$(inputs.param_name[].path)`
+- For `multiple: true` data inputs the value is a list, so map over it and join:
+  `$(inputs.param_name.map((input) => input.path).join(" "))`. There is no `[]`
+  indexing syntax -- expressions are JavaScript, and `inputs.param_name[].path`
+  is a syntax error that only surfaces when the job is built.
 - CRITICAL: every `inputs.param_name` you reference in `shell_command` MUST exactly match
   the `name` of an input you declared under `inputs`. Use the same name in both
   places; never reference an input you did not declare.
@@ -114,9 +117,9 @@ declare:
 ```yaml
 container: quay.io/biocontainers/pandas:2.1.1
 shell_command: >-
-  python -c "import pandas as pd; d = pd.read_csv('$(inputs.table.path)', sep='\t');
-  d['group'] = d['sample_id'].str.startswith('Tx').map({True: 'Treatment', False: 'Vehicle'});
-  d.to_csv('output.tsv', sep='\t', index=False)"
+    python -c "import pandas as pd; d = pd.read_csv('$(inputs.table.path)', sep='\t');
+    d['group'] = d['sample_id'].str.startswith('Tx').map({True: 'Treatment', False: 'Vehicle'});
+    d.to_csv('output.tsv', sep='\t', index=False)"
 ```
 
 **2. Longer script: put it in a `configfiles` entry and run that file.** The file is
@@ -126,9 +129,9 @@ materialized in the working directory at `filename`, so `shell_command` runs it 
 configfiles:
     - filename: script.py
       content: |
-        import pandas as pd
-        df = pd.read_csv("$(inputs.table.path)", sep="\t")
-        df.describe().to_csv("summary.tsv", sep="\t")
+          import pandas as pd
+          df = pd.read_csv("$(inputs.table.path)", sep="\t")
+          df.describe().to_csv("summary.tsv", sep="\t")
 shell_command: python script.py
 ```
 
@@ -156,10 +159,10 @@ To request at least 2 cores, 1 Gibibyte memory and one CUDA core use
 
 ```yaml
 requirements:
-  - type: resource
-    cores_min: 2
-    cuda_device_count_min: 1
-    ram_min: 1024
+    - type: resource
+      cores_min: 2
+      cuda_device_count_min: 1
+      ram_min: 1024
 ```
 
 The GALAXY_SLOTS environment variable will be available in the process

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -5,7 +5,8 @@ You are a Galaxy tool generator. Generate valid Galaxy tool definitions that mat
 ## Required Fields
 
 - **class**: Must be exactly "GalaxyUserTool"
-- **id**: Unique identifier, lowercase with hyphens (e.g., "my-cool-tool"). Min 3 chars, max 255 chars.
+- **id**: Unique identifier (e.g., "my-cool-tool"). Must start with a lowercase letter;
+  after that, lowercase letters, digits, `_` and `-` are allowed. Min 3 chars, max 255 chars.
 - **version**: Semantic version (e.g., "1.0.0")
 - **name**: Human-readable tool name displayed in the tool menu. At least 5 characters.
 - **container**: Docker/Singularity image (e.g., "quay.io/biocontainers/bwa:0.7.17--h7132678_9")
@@ -21,7 +22,15 @@ You are a Galaxy tool generator. Generate valid Galaxy tool definitions that mat
 
 - **description**: Brief description displayed in the tool menu
 - **license**: SPDX license identifier (e.g., "MIT")
-- **help**: Help text shown below the tool interface
+- **help**: Help shown below the tool interface. An object, not a string -- set both
+  `format` (`markdown`, `restructuredtext` or `plain_text`) and `content`:
+
+```yaml
+help:
+    format: markdown
+    content: |
+        Takes the first N lines of a file.
+```
 
 ## Input/Output Syntax in shell_command
 
@@ -92,8 +101,13 @@ inputs:
 
 Each output must have a `type` field. Common types:
 
-- **data**: Single output file
-- **collection**: Collection of output files
+- **data**: Single output file. Capture it with `from_work_dir`.
+- **collection**: Collection of output files. Requires `discover_datasets` -- a
+  collection with only `from_work_dir` is rejected, since nothing would claim its
+  elements from the working directory.
+
+Note `format` on an output is a single string, unlike a data input's `format`, which
+is a list.
 
 Example output:
 
@@ -104,6 +118,13 @@ outputs:
       format: sam
       from_work_dir: aligned.sam
       label: Aligned reads
+    - name: split_reads
+      type: collection
+      collection_type: list
+      discover_datasets:
+          - discover_via: pattern
+            pattern: __name__
+            directory: splits
 ```
 
 ## Running a script
@@ -148,9 +169,10 @@ instead.
 
 Set `container` to a reasonable image for your command (a `quay.io/biocontainers`
 image when the command is a bioinformatics tool, otherwise any sensible base
-image). Don't agonize over the exact tag: Galaxy resolves the container to a
-verified biocontainer for you after generation, so a close, plausible choice is
-fine.
+image). Pick an image you are confident exists rather than inventing a tag. Some
+deployments re-resolve the container against verified biocontainers after
+generation, but that is off by default -- assume the image you name is the image
+that runs. If you don't know a suitable image, say so instead of guessing.
 
 ## Resource requirements
 
@@ -165,15 +187,17 @@ requirements:
       ram_min: 1024
 ```
 
-The GALAXY_SLOTS environment variable will be available in the process
-environment and be set to `cores_min`.
+The GALAXY_SLOTS environment variable will be available in the process environment
+and reports the cores the job runner actually allocated. Use it rather than
+hardcoding a thread count; it reflects `cores_min` only where the deployment maps
+it, so don't assume the two are equal.
 
 ## Important Guidelines
 
 - Use biocontainers images when available for bioinformatics tools
 - Escape shell variables that aren't Galaxy expressions: `\$(date)`
 - Keep shell_command focused and simple
-- Provide sensible defaults for optional parameters
+- Provide a sensible `value` for optional parameters (the field is `value`, not `default`)
 - Use descriptive labels for inputs and outputs
 
 ## CRITICAL: Accuracy Requirements

--- a/test/unit/app/test_agent_prompts.py
+++ b/test/unit/app/test_agent_prompts.py
@@ -1,0 +1,105 @@
+"""Hold the agent prompt files to the schemas they claim to teach.
+
+``custom_tool_structured.md`` is a system prompt whose entire job is telling a
+model what shape validates. Nothing else reads it, so when the models narrow --
+as when ``YamlDataParameter.format`` became a ``list[str]`` -- its examples go
+stale silently and the prompt starts teaching YAML that consumers reject.
+
+Validating against pydantic alone is not enough. ``_split_format`` normalizes the
+legacy comma-separated string form, so ``format: fastq`` satisfies pydantic while
+the dumped JSON Schema (what a structured-output consumer actually enforces)
+rejects it. These tests check both.
+"""
+
+import re
+from pathlib import Path
+from typing import (
+    Any,
+)
+
+import jsonschema
+import pytest
+import yaml
+
+from galaxy.tool_util_models import UserToolSourceAuthoringView
+from galaxy.util import galaxy_directory
+
+PROMPT_DIR = Path(galaxy_directory()) / "lib" / "galaxy" / "agents" / "prompts"
+CUSTOM_TOOL_PROMPT = PROMPT_DIR / "custom_tool_structured.md"
+
+YAML_FENCE = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+INPUT_REF = re.compile(r"\$\(inputs\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _yaml_blocks(path: Path) -> list[tuple[int, Any]]:
+    """Parse every ```yaml fence in a prompt, keyed by position for readable failures."""
+    blocks = []
+    for index, raw in enumerate(YAML_FENCE.findall(path.read_text())):
+        blocks.append((index, yaml.safe_load(raw)))
+    return blocks
+
+
+def _as_tool(fragment: dict[str, Any]) -> dict[str, Any]:
+    """Splice a prompt fragment into an otherwise-valid tool.
+
+    Most examples in the prompt are fragments -- a bare ``inputs:`` list, a
+    ``configfiles:`` entry -- that only mean anything in the context of a whole
+    tool. Any input the fragment's command references is declared automatically so
+    the cross-reference validator doesn't fire on an excerpt taken out of context.
+    """
+    tool: dict[str, Any] = {
+        "class": "GalaxyUserTool",
+        "id": "example-tool",
+        "name": "Example tool",
+        "version": "0.1.0",
+        "container": "busybox",
+        "shell_command": "true",
+        "inputs": [],
+        "outputs": [],
+        **fragment,
+    }
+    referenced = set(INPUT_REF.findall(tool["shell_command"]))
+    for configfile in tool.get("configfiles") or []:
+        referenced |= set(INPUT_REF.findall(configfile.get("content", "")))
+    declared = {declared_input["name"] for declared_input in tool["inputs"]}
+    for name in sorted(referenced - declared):
+        tool["inputs"].append({"name": name, "type": "data"})
+    return tool
+
+
+def _prompt_examples() -> list[tuple[int, dict[str, Any]]]:
+    return [(index, _as_tool(block)) for index, block in _yaml_blocks(CUSTOM_TOOL_PROMPT) if isinstance(block, dict)]
+
+
+@pytest.mark.parametrize("index,tool", _prompt_examples())
+def test_custom_tool_prompt_examples_satisfy_pydantic(index: int, tool: dict[str, Any]) -> None:
+    """Every YAML example in the prompt must validate as a tool."""
+    UserToolSourceAuthoringView.model_validate(tool)
+
+
+@pytest.mark.parametrize("index,tool", _prompt_examples())
+def test_custom_tool_prompt_examples_satisfy_json_schema(index: int, tool: dict[str, Any]) -> None:
+    """And must satisfy the dumped schema, which has no before-validators to lean on.
+
+    This is the half that catches a scalar where the model declares a list.
+    """
+    schema = UserToolSourceAuthoringView.model_json_schema()
+    errors = sorted(jsonschema.Draft202012Validator(schema).iter_errors(tool), key=str)
+    assert not errors, "\n".join(f"{list(error.absolute_path)}: {error.message}" for error in errors)
+
+
+def test_custom_tool_prompt_documents_a_data_input_format() -> None:
+    """Guard the specific drift that started this: ``format`` is a list, not a scalar.
+
+    Without this the prompt could quietly regress to ``format: fastq`` in an example
+    that declares no ``format`` at all and still pass the checks above.
+    """
+    formats = [
+        declared_input["format"]
+        for _, tool in _prompt_examples()
+        for declared_input in tool["inputs"]
+        if "format" in declared_input
+    ]
+    assert formats, "prompt no longer shows a data input format at all"
+    for declared_format in formats:
+        assert isinstance(declared_format, list), f"data input format must be a list, got {declared_format!r}"


### PR DESCRIPTION
Follow-up to #23335. That PR fixed two cases where `custom_tool_structured.md` taught YAML the schema rejects; reviewing it I went through the rest of the file against the actual models and found more of the same -- [written up here](https://github.com/galaxyproject/galaxy/pull/23335#issuecomment-5375230232) -- including one that's worse than either of the originals.

The prompt told the model to use `$(inputs.param_name[].path)` for multiple data inputs. That isn't valid JavaScript. Expressions go through `do_eval`, so it dies with `SyntaxError: Unexpected token ']'`, and nothing catches it up front -- `_check_input_refs` only extracts the leading input name, so a tool using it validates, saves, and then fails when Galaxy builds the command line.

It's replaced with the per-element-quoted map that `test/functional/tools/cat_multiple_user_defined.yml` already uses. The quoting matters: `shell_command` is the one branch of `_build_command_line` that doesn't `shlex.quote` its result, unlike `base_command`/`arguments` directly above it, so the expression's output is spliced in verbatim and a bare `.join(" ")` turns a path with a space into two arguments. The `[]` guidance is narrowed to what's actually true -- the *empty* `[]` is the syntax error; `inputs.some_repeat[0].x` is fine, since expressions are JavaScript with `InlineJavascriptRequirement` always on.

The rest are one-liners where the prompt asserts something untrue. The container section promised Galaxy re-resolves a "close, plausible" image to a verified biocontainer, but `container_recommendation_enabled` is off by default, so the guess is usually what runs -- and the accuracy section immediately below told the model never to guess. `help` was described as help text but wants a `HelpContent` object. Collection outputs need `discover_datasets`, not `from_work_dir`. The id pattern must start with a letter. `GALAXY_SLOTS` was promised to equal `cores_min`, which only holds where the deployment maps it.

`value` gets scoped to the types that have one. It sets the default on text, integer, float and boolean inputs; `select` and `data` forbid it and fail with `extra_forbidden`, and a select's default is `selected: true` on one of its options. The critic prompt had the same two problems -- it asked for `default` (rejected outright), and asking for a field that cannot exist on a `select` would have set `needs_full_refine` and burned an extra generation pass chasing it. Its unconditional claim that a dedicated step resolves the container has the same off-by-default problem as the producer prompt.

Underneath is the reason these drift: nothing read the prompt. The new test parses the fenced YAML out of it and holds each example to `UserToolSourceAuthoringView` -- through pydantic and through the dumped JSON Schema. Checking both is the point. `_split_format` normalizes the legacy comma-separated string, so `format: fastq` passes pydantic happily while the schema a structured-output consumer enforces rejects it; a pydantic-only test catches neither bug from #23335. I mutation-tested it against both.

Two notes for reviewing. The last commit is a self-review pass correcting the two before it -- the quoting and `value` scoping above came out of that, so reading commit-by-commit will show the intermediate state. And prettier reindented the YAML examples when I touched the file, so a few blocks I didn't otherwise change show up in the diff; the file wasn't prettier-clean on dev and the local pre-commit hook rewrites it. All six pre-existing blocks parse identically before and after -- I checked. Happy to strip that out if you'd rather keep the diff to the substance.

## How to test the changes?
(Select all options that apply)
- [x] I added new tests to cover this change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
