### PR TITLE
[26.1] Wrap tooltips instead of overflowing out of width

### DIFF
--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -63,6 +63,7 @@ const TOOLTIP_STYLES = `
     top: 0;
     left: 0;
     opacity: 1;
+    overflow-wrap: anywhere;
 }
 .g-tooltip-d.g-tooltip-danger {
     background-color: var(--color-red-700, #dc3545);


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| <img width="368" height="233" alt="image" src="https://github.com/user-attachments/assets/966efc7c-7e34-4c14-b2bd-abbbe9b982b1" /> | <img width="368" height="233" alt="image" src="https://github.com/user-attachments/assets/7cbf5747-085d-448a-a9c4-31f9b8fcbd8f" /> |


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. For tooltips with long text, make sure text wraps to next lines

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
