### PR TITLE
Analyze workflow when input references structurally

### DIFF
--- a/client/src/components/Workflow/Editor/modules/layout.test.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.test.ts
@@ -61,7 +61,7 @@ describe("layout.ts", () => {
                             input_type: "dataset",
                         },
                     ],
-                    when: "${check_value}",
+                    when: "$(inputs.check_value)",
                     inputConnections: {
                         check_value: { output_name: "output", id: 0 },
                     },
@@ -98,7 +98,7 @@ describe("layout.ts", () => {
             // First conditional step
             const cond1 = stepStore.addStep(
                 createTestStep(1, {
-                    when: "${flag1}",
+                    when: "$(inputs.flag1)",
                     inputConnections: { flag1: { output_name: "output", id: 0 } },
                 }),
             );
@@ -106,7 +106,7 @@ describe("layout.ts", () => {
             // Second conditional step
             const cond2 = stepStore.addStep(
                 createTestStep(2, {
-                    when: "${flag2}",
+                    when: "$(inputs.flag2)",
                     inputConnections: { flag2: { output_name: "output", id: 0 } },
                 }),
             );

--- a/client/src/components/Workflow/Editor/modules/whenExpression.test.ts
+++ b/client/src/components/Workflow/Editor/modules/whenExpression.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import EXPRESSION_SPECIFICATIONS from "./when_expression_spec.yml";
+import { analyzeInputReferences, expressionReferencesInput } from "./whenExpression";
+import type { InputPath } from "./workflowInputPath";
+
+type InputTarget = string | InputPath;
+
+interface ExpressionExpectations {
+    static_paths?: InputPath[];
+    dynamic?: boolean;
+    references_input?: boolean;
+}
+
+interface ExpressionSpecification {
+    doc: string;
+    expression: string;
+    input?: InputTarget;
+    expect: ExpressionExpectations;
+}
+
+const EXPRESSIONS = EXPRESSION_SPECIFICATIONS as ExpressionSpecification[];
+
+function requireInput(specification: ExpressionSpecification): InputTarget {
+    if (specification.input === undefined) {
+        throw new Error(`Specification '${specification.doc}' must declare an input`);
+    }
+    return specification.input;
+}
+
+describe("when expression specification", () => {
+    for (const specification of EXPRESSIONS) {
+        it(specification.doc, () => {
+            const { expression, expect: expected } = specification;
+
+            if (expected.static_paths !== undefined || expected.dynamic !== undefined) {
+                const analysis = analyzeInputReferences(expression);
+                if (expected.static_paths !== undefined) {
+                    expect(analysis.staticPaths).toEqual(expected.static_paths);
+                }
+                if (expected.dynamic !== undefined) {
+                    expect(analysis.hasDynamicInputsAccess).toBe(expected.dynamic);
+                }
+            }
+
+            if (expected.references_input !== undefined) {
+                expect(expressionReferencesInput(expression, requireInput(specification))).toBe(
+                    expected.references_input,
+                );
+            }
+        });
+    }
+});
+
+describe("analyzer failure boundaries", () => {
+    it("reports no references when no expression is present", () => {
+        expect(expressionReferencesInput(undefined, "input1")).toBe(false);
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/whenExpression.ts
+++ b/client/src/components/Workflow/Editor/modules/whenExpression.ts
@@ -1,0 +1,282 @@
+/**
+ * Static analysis of workflow step `when` expressions.
+ *
+ * Galaxy addresses connected tool inputs by flat, pipe-prefixed connection names
+ * (`cond|input1`), while a `when` expression walks nested tool state
+ * (`inputs.cond.input1`). These helpers bridge the two representations so the editor can
+ * reason about which inputs an expression reads.
+ *
+ * Nothing here executes user JavaScript. Expressions that are not structurally
+ * recognized are reported as unknown, and callers are expected to resolve unknown
+ * permissively: the runtime, not the editor, decides whether a step runs.
+ */
+
+import {
+    connectionNameToInputPath,
+    type InputPath,
+    inputPathIsPrefix,
+    type InputPathSegment,
+} from "./workflowInputPath";
+
+type TokenType = "identifier" | "number" | "string" | "punct";
+
+interface Token {
+    type: TokenType;
+    value: string;
+}
+
+export interface ReferenceAnalysis {
+    /** Fully static `inputs` accesses, as path segments. */
+    staticPaths: InputPath[];
+    /** True when some `inputs` access could not be resolved statically. */
+    hasDynamicInputsAccess: boolean;
+}
+
+const PUNCTUATORS = ["===", "!==", "==", "!=", "&&", "||", "!", "(", ")", "[", "]", ".", ",", "?", ":"];
+
+/** Tokenize a JavaScript-ish expression, or return null when it cannot be scanned. */
+function tokenize(expression: string): Token[] | null {
+    const tokens: Token[] = [];
+    let index = 0;
+
+    while (index < expression.length) {
+        const char = expression[index]!;
+
+        if (/\s/.test(char)) {
+            index++;
+            continue;
+        }
+
+        if (char === "/" && expression[index + 1] === "/") {
+            const newline = expression.indexOf("\n", index);
+            index = newline === -1 ? expression.length : newline;
+            continue;
+        }
+
+        if (char === "/" && expression[index + 1] === "*") {
+            const end = expression.indexOf("*/", index + 2);
+            if (end === -1) {
+                return null;
+            }
+            index = end + 2;
+            continue;
+        }
+
+        if (char === "/") {
+            // Ignore regex contents so text such as `inputs.foo` inside the pattern is
+            // not mistaken for an access. If this slash follows a value, it may instead
+            // be division; leave that unsupported rather than guessing.
+            if (!canStartRegex(tokens)) {
+                return null;
+            }
+            const next = readRegexLiteral(expression, index);
+            if (next === null) {
+                return null;
+            }
+            index = next;
+            continue;
+        }
+
+        if (char === '"' || char === "'" || char === "`") {
+            const literal = readStringLiteral(expression, index);
+            if (!literal) {
+                return null;
+            }
+            tokens.push({ type: "string", value: literal.value });
+            index = literal.next;
+            continue;
+        }
+
+        if (/[0-9]/.test(char)) {
+            const match = /^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/.exec(expression.slice(index))!;
+            tokens.push({ type: "number", value: match[0] });
+            index += match[0].length;
+            continue;
+        }
+
+        if (/[A-Za-z_$]/.test(char)) {
+            const match = /^[A-Za-z_$][A-Za-z0-9_$]*/.exec(expression.slice(index))!;
+            tokens.push({ type: "identifier", value: match[0] });
+            index += match[0].length;
+            continue;
+        }
+
+        const punctuator = PUNCTUATORS.find((candidate) => expression.startsWith(candidate, index));
+        tokens.push({ type: "punct", value: punctuator ?? char });
+        index += punctuator?.length ?? 1;
+    }
+
+    return tokens;
+}
+
+/** Conservatively recognize regex literals where the analyzer's subset expects a value. */
+function canStartRegex(tokens: Token[]): boolean {
+    const previous = tokens[tokens.length - 1];
+    if (!previous) {
+        return true;
+    }
+    return previous.type === "punct" && previous.value !== ")" && previous.value !== "]" && previous.value !== ".";
+}
+
+/** Skip a regex literal, including escaped characters, character classes, and flags. */
+function readRegexLiteral(expression: string, start: number): number | null {
+    let index = start + 1;
+    let inCharacterClass = false;
+
+    while (index < expression.length) {
+        const char = expression[index]!;
+        if (char === "\\") {
+            index += 2;
+            continue;
+        }
+        if (char === "[") {
+            inCharacterClass = true;
+        } else if (char === "]") {
+            inCharacterClass = false;
+        } else if (char === "/" && !inCharacterClass) {
+            index++;
+            while (/[A-Za-z]/.test(expression[index] ?? "")) {
+                index++;
+            }
+            return index;
+        } else if (char === "\n" || char === "\r") {
+            return null;
+        }
+        index++;
+    }
+
+    return null;
+}
+
+/** Read a quoted literal starting at `start`. Template literals keep their raw body. */
+function readStringLiteral(expression: string, start: number): { value: string; next: number } | null {
+    const quote = expression[start]!;
+    let value = "";
+    let index = start + 1;
+
+    while (index < expression.length) {
+        const char = expression[index]!;
+        if (char === "\\") {
+            value += expression[index + 1] ?? "";
+            index += 2;
+            continue;
+        }
+        if (char === quote) {
+            return { value, next: index + 1 };
+        }
+        value += char;
+        index++;
+    }
+
+    return null;
+}
+
+function isTemplateLiteral(expression: string): boolean {
+    return expression.includes("`");
+}
+
+/**
+ * Collect every `inputs` access in an expression.
+ *
+ * Recognizes dot access, chained bracket access with string or numeric literals, and
+ * mixtures of the two. Anything else — a computed index, a bare `inputs` reference, a template
+ * literal that might interpolate one — is reported through `hasDynamicInputsAccess`.
+ */
+export function analyzeInputReferences(expression: string): ReferenceAnalysis {
+    const tokens = tokenize(expression);
+    if (!tokens) {
+        return { staticPaths: [], hasDynamicInputsAccess: true };
+    }
+
+    const analysis: ReferenceAnalysis = {
+        staticPaths: [],
+        hasDynamicInputsAccess: isTemplateLiteral(expression),
+    };
+
+    tokens.forEach((token, position) => {
+        if (token.type !== "identifier" || token.value !== "inputs") {
+            return;
+        }
+        if (tokens[position - 1]?.value === ".") {
+            return;
+        }
+        const path = readAccessPath(tokens, position + 1);
+        if (path.dynamic || path.segments.length === 0) {
+            analysis.hasDynamicInputsAccess = true;
+        }
+        if (path.segments.length > 0) {
+            analysis.staticPaths.push(path.segments);
+        }
+    });
+
+    return analysis;
+}
+
+interface AccessPath {
+    segments: InputPath;
+    /** Segment counts after which `?.` starts an optional chain. */
+    optionalAfterSegments: number[];
+    dynamic: boolean;
+    next: number;
+}
+
+/** Walk the property access chain that follows an `inputs` token. */
+function readAccessPath(tokens: Token[], start: number): AccessPath {
+    const segments: InputPath = [];
+    const optionalAfterSegments: number[] = [];
+    let index = start;
+
+    for (;;) {
+        if (tokens[index]?.value === "?" && (tokens[index + 1]?.value === "." || tokens[index + 1]?.value === "[")) {
+            optionalAfterSegments.push(segments.length);
+            // `value?.name` leaves the dot for the ordinary dot-access branch;
+            // `value?.[name]` must skip both `?` and `.` to reach the bracket.
+            index += tokens[index + 1]?.value === "." && tokens[index + 2]?.value === "[" ? 2 : 1;
+        }
+        const token = tokens[index];
+        if (token?.value === "." && tokens[index + 1]?.type === "identifier") {
+            segments.push(tokens[index + 1]!.value);
+            index += 2;
+            continue;
+        }
+        if (token?.value === "[") {
+            const inner = tokens[index + 1];
+            if ((inner?.type === "string" || inner?.type === "number") && tokens[index + 2]?.value === "]") {
+                segments.push(inner.type === "number" ? Number(inner.value) : inner.value);
+                index += 3;
+                continue;
+            }
+            return { segments, optionalAfterSegments, dynamic: true, next: index };
+        }
+        return { segments, optionalAfterSegments, dynamic: false, next: index };
+    }
+}
+
+/**
+ * True when the expression could read the named connection.
+ *
+ * Deliberately permissive: an expression the analyzer cannot resolve is treated as
+ * referencing every candidate. Callers only ever ask about inputs that are already
+ * connected, so an over-match shows a real edge while an under-match hides one.
+ */
+export function expressionReferencesInput(
+    expression: string | null | undefined,
+    input: string | readonly InputPathSegment[],
+): boolean {
+    if (!expression) {
+        return false;
+    }
+
+    const targetPath = normalizeInputPath(input);
+    const references = analyzeInputReferences(expression);
+
+    if (references.hasDynamicInputsAccess) {
+        return true;
+    }
+
+    return references.staticPaths.some((referencedPath) => inputPathIsPrefix(targetPath, referencedPath));
+}
+
+function normalizeInputPath(input: string | readonly InputPathSegment[]): InputPath {
+    return typeof input === "string" ? connectionNameToInputPath(input) : [...input];
+}

--- a/client/src/components/Workflow/Editor/modules/when_expression_spec.yml
+++ b/client/src/components/Workflow/Editor/modules/when_expression_spec.yml
@@ -1,0 +1,171 @@
+- doc: Dot access identifies a nested input
+  expression: $(inputs.cond.input1)
+  input: cond|input1
+  expect:
+    static_paths: [[cond, input1]] # Statically resolved paths read from `inputs`.
+    dynamic: false # Whether some `inputs` access cannot be resolved statically.
+    references_input: true # Whether the expression reads the declared `input`.
+
+- doc: Chained bracket access identifies a nested input
+  expression: '$(inputs["cond"]["input1"])'
+  expect:
+    static_paths: [[cond, input1]]
+    dynamic: false
+
+- doc: Mixed dot and bracket access identifies a nested input
+  expression: '$(inputs.cond["input1"])'
+  expect:
+    static_paths: [[cond, input1]]
+    dynamic: false
+
+- doc: Single-quoted bracket access identifies a nested input
+  expression: "$(inputs['cond'].input1)"
+  expect:
+    static_paths: [[cond, input1]]
+    dynamic: false
+
+- doc: A literal pipe belongs to one property and does not name a nested connection
+  expression: '$(inputs["cond|input1"] !== null)'
+  input: cond|input1
+  expect:
+    static_paths: [["cond|input1"]]
+    dynamic: false
+    references_input: false
+
+- doc: A numeric bracket identifies an item inside a repeat
+  expression: $(inputs.queries[0].input2)
+  input: [queries, 0, input2]
+  expect:
+    static_paths: [[queries, 0, input2]]
+    dynamic: false
+    references_input: true
+
+- doc: Every root input access is collected
+  expression: $(inputs.a && inputs.b)
+  expect:
+    static_paths: [[a], [b]]
+    dynamic: false
+
+- doc: Input-like text inside a string literal is ignored
+  expression: '$(inputs.a === "inputs.b")'
+  expect:
+    static_paths: [[a]]
+    dynamic: false
+
+- doc: Input-like text inside comments is ignored
+  expression: $(inputs.a /* inputs.b */ !== null) // inputs.c
+  expect:
+    static_paths: [[a]]
+    dynamic: false
+
+- doc: A property named inputs is not mistaken for another root access
+  expression: $(inputs.inputs.a)
+  expect:
+    static_paths: [[inputs, a]]
+    dynamic: false
+
+- doc: A computed property cannot be resolved statically
+  expression: $(inputs[name] !== null)
+  input: cond|input1
+  expect:
+    static_paths: []
+    dynamic: true
+    references_input: true
+
+- doc: A bare inputs reference cannot be resolved statically
+  expression: $(Object.keys(inputs).length)
+  expect:
+    static_paths: []
+    dynamic: true
+
+- doc: A template literal is treated as dynamic
+  expression: '$(`${inputs.a}` !== null)'
+  expect:
+    dynamic: true
+
+- doc: The static prefix of a computed property is retained
+  expression: $(inputs.cond[name])
+  expect:
+    static_paths: [[cond]]
+    dynamic: true
+
+- doc: A nested presence condition is false when its input is absent
+  expression: $(inputs.cond.input1 !== null)
+  input: cond|input1
+  expect:
+    references_input: true
+
+- doc: A condition on a nested property also references its ancestor connection
+  expression: $(inputs.cond.input1 !== null)
+  input: cond
+  expect:
+    references_input: true
+
+- doc: An unsupported helper call is handled permissively
+  expression: $(helper(inputs.cond.input1))
+  input: cond|input1
+  expect:
+    references_input: true
+
+- doc: A condition on another input does not reference the target
+  expression: $(inputs.other !== null)
+  input: cond|input1
+  expect:
+    references_input: false
+
+- doc: Similar property names are compared as complete path segments
+  expression: $(inputs.cond.input10 !== null)
+  input: cond|input1
+  expect:
+    references_input: false
+
+- doc: Similar top-level names are compared as complete path segments
+  expression: $(inputs.input10 !== null)
+  input: input1
+  expect:
+    references_input: false
+
+- doc: Reading a property of an absent input has indeterminate behavior
+  expression: '$(inputs.reference.format != "bwa_mem2_index")'
+  input: reference
+  expect:
+    references_input: true
+
+- doc: Optional chaining to a property produces undefined when the input is absent
+  expression: $(inputs.reference?.format !== null)
+  input: reference
+  expect:
+    references_input: true
+
+- doc: An unrelated cross-type comparison prevents a presence condition from being proven
+  expression: '$(inputs.a !== null || 0 == "")'
+  input: a
+  expect:
+    references_input: true
+
+- doc: Optional chaining through a nested group still identifies the input
+  expression: $(inputs.cond?.input1 === null)
+  input: cond|input1
+  expect:
+    static_paths: [[cond, input1]]
+    references_input: true
+
+- doc: Input-like text inside a regular expression is ignored while real code is retained
+  expression: $(/inputs.zzz/.test(inputs.a))
+  expect:
+    static_paths: [[a]]
+    dynamic: false
+
+- doc: Input-like text inside both a regular expression and a string is ignored
+  expression: $(/inputs.zzz/.test('inputs.a'))
+  input: a
+  expect:
+    static_paths: []
+    dynamic: false
+    references_input: false
+
+- doc: An empty expression references and protects no input
+  expression: ''
+  input: input1
+  expect:
+    references_input: false

--- a/client/src/components/Workflow/Editor/modules/workflowInputPath.test.ts
+++ b/client/src/components/Workflow/Editor/modules/workflowInputPath.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { connectionNameToInputPath, inputPathIsPrefix, resolveConnectionNameToInputPath } from "./workflowInputPath";
+
+describe("workflow input paths", () => {
+    it("maps flat connection names to nested expression paths", () => {
+        expect(connectionNameToInputPath("cond|input1")).toEqual(["cond", "input1"]);
+    });
+
+    it("compares complete path segments", () => {
+        expect(inputPathIsPrefix(["cond"], ["cond", "input1"])).toBe(true);
+        expect(inputPathIsPrefix(["cond", "input1"], ["cond", "input10"])).toBe(false);
+    });
+
+    it("resolves repeat indices from tool state", () => {
+        const state = { queries: '[{"__index__": 0, "input2": {}}]' };
+        expect(resolveConnectionNameToInputPath("queries_0|input2", state)).toEqual(["queries", 0, "input2"]);
+    });
+
+    it("resolves nested repeats", () => {
+        const state = { outer: [{ inner: [{}, { param: {} }] }] };
+        expect(resolveConnectionNameToInputPath("outer_0|inner_1|param", state)).toEqual([
+            "outer",
+            0,
+            "inner",
+            1,
+            "param",
+        ]);
+    });
+
+    it("preserves a literal name that looks like a repeat", () => {
+        const state = { outer_0: { param: {} } };
+        expect(resolveConnectionNameToInputPath("outer_0|param", state)).toEqual(["outer_0", "param"]);
+    });
+
+    it("declines a genuinely ambiguous flattened name", () => {
+        const state = { outer_0: { param: {} }, outer: [{ param: {} }] };
+        expect(resolveConnectionNameToInputPath("outer_0|param", state)).toBeNull();
+    });
+
+    it("declines when no state path matches", () => {
+        expect(resolveConnectionNameToInputPath("queries_0|input2", {})).toBeNull();
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/workflowInputPath.ts
+++ b/client/src/components/Workflow/Editor/modules/workflowInputPath.ts
@@ -1,0 +1,97 @@
+/**
+ * Translate between persisted workflow connection names and `when` input paths.
+ *
+ * Galaxy flattens nested tool inputs with `|` in `input_connections`, while expression
+ * code addresses the same input one property at a time. Keep comparisons segmented:
+ * joining an expression path is lossy when a literal property name itself contains `|`.
+ */
+
+export type InputPathSegment = string | number;
+export type InputPath = InputPathSegment[];
+
+/** Map a flat, pipe-delimited connection name onto its ordinary nested `inputs` path. */
+export function connectionNameToInputPath(inputName: string): InputPath {
+    return inputName.split("|");
+}
+
+/**
+ * Resolve a flattened connection name against tool state, including repeat indices.
+ *
+ * A repeat named `queries` produces connection names such as `queries_0|input2`, but
+ * expression state exposes that value as `inputs.queries[0].input2`. Exact property
+ * names win only when they are the sole successful interpretation; if both a literal
+ * `queries_0` group and the repeat path resolve, declining is safer than gating on the
+ * wrong value.
+ */
+export function resolveConnectionNameToInputPath(
+    inputName: string,
+    rawToolState: Record<string, unknown> | null | undefined,
+): InputPath | null {
+    if (!inputName.includes("|")) {
+        // Top-level workflow-only probes are not represented in tool state.
+        return [inputName];
+    }
+
+    const state = parseTopLevelToolState(rawToolState ?? {});
+    const resolutions = resolveSegments(inputName.split("|"), 0, state);
+    return resolutions.length === 1 ? resolutions[0]! : null;
+}
+
+function resolveSegments(segments: string[], position: number, level: unknown): InputPath[] {
+    if (position === segments.length) {
+        return [[]];
+    }
+    if (!isRecord(level)) {
+        return [];
+    }
+
+    const segment = segments[position]!;
+    const candidates: Array<{ path: InputPath; value: unknown }> = [];
+    if (Object.prototype.hasOwnProperty.call(level, segment)) {
+        candidates.push({ path: [segment], value: level[segment] });
+    }
+
+    const repeat = /^(.*)_([0-9]+)$/.exec(segment);
+    if (repeat) {
+        const [, repeatName, indexText] = repeat;
+        const repeatValue = level[repeatName!];
+        const index = Number(indexText);
+        if (Array.isArray(repeatValue) && index in repeatValue) {
+            candidates.push({ path: [repeatName!, index], value: repeatValue[index] });
+        }
+    }
+
+    return candidates.flatMap(({ path, value }) =>
+        resolveSegments(segments, position + 1, value).map((suffix) => [...path, ...suffix]),
+    );
+}
+
+/** Tool state arrives with its top-level values JSON encoded, inconsistently. */
+function parseTopLevelToolState(raw: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries(raw).map(([key, value]) => [key, typeof value === "string" ? tryParseJson(value) : value]),
+    );
+}
+
+function tryParseJson(value: string): unknown {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return value;
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True when `targetPath` names `referencedPath` or one of its ancestors. */
+export function inputPathIsPrefix(
+    targetPath: readonly InputPathSegment[],
+    referencedPath: readonly InputPathSegment[],
+): boolean {
+    if (targetPath.length > referencedPath.length) {
+        return false;
+    }
+    return targetPath.every((segment, position) => segment === referencedPath[position]);
+}

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -100,7 +100,7 @@ describe("getCombinedStepInputs", () => {
     const stepWithWhen = createTestStep(1, {
         inputs: [regularInput],
         outputs: [],
-        when: "${check_value}",
+        when: "$(inputs.check_value)",
         inputConnections: {
             check_value: { output_name: "output", id: 0 },
         },
@@ -139,6 +139,19 @@ describe("getCombinedStepInputs", () => {
         // Extra inputs should come first
         expect(combinedInputs[0]?.name).toBe("check_value");
         expect(combinedInputs[1]?.name).toBe("input_dataset");
+    });
+
+    it("does not confuse a connection name with a longer referenced input", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        stepStore.addStep(workflowStepZero);
+        const step = stepStore.addStep(
+            createTestStep(1, {
+                when: "$(inputs.check_value)",
+                inputConnections: { check: { output_name: "output", id: 0 } },
+            }),
+        );
+
+        expect(getCombinedStepInputs(step, stepStore)).toHaveLength(0);
     });
 
     it("handles step with no inputs gracefully", () => {

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -3,6 +3,8 @@ import { computed, del, ref, set } from "vue";
 import type { FieldDict, SampleSheetColumnDefinitions } from "@/api";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import type { CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
+import { expressionReferencesInput } from "@/components/Workflow/Editor/modules/whenExpression";
+import { resolveConnectionNameToInputPath } from "@/components/Workflow/Editor/modules/workflowInputPath";
 import { getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 
@@ -475,21 +477,26 @@ function stepToConnections(step: Step): Connection[] {
 
 function findStepExtraInputs(step: Step) {
     const extraInputs: InputTerminalSource[] = [];
-    if (step.when !== undefined) {
-        Object.keys(step.input_connections).forEach((inputName) => {
-            if (!step.inputs.find((input) => input.name === inputName) && step.when?.includes(inputName)) {
-                const terminalSource = {
-                    name: inputName,
-                    optional: false,
-                    input_type: "parameter" as const,
-                    type: "boolean" as const,
-                    multiple: false,
-                    label: inputName,
-                    extensions: [],
-                };
-                extraInputs.push(terminalSource);
-            }
-        });
+    if (step.when === undefined) {
+        return extraInputs;
     }
+    Object.keys(step.input_connections).forEach((inputName) => {
+        if (step.inputs.find((input) => input.name === inputName)) {
+            return;
+        }
+        const inputPath = resolveConnectionNameToInputPath(inputName, step.tool_state);
+        if (!inputPath || !expressionReferencesInput(step.when, inputPath)) {
+            return;
+        }
+        extraInputs.push({
+            name: inputName,
+            optional: false,
+            input_type: "parameter",
+            type: "boolean",
+            multiple: false,
+            label: inputName,
+            extensions: [],
+        });
+    });
     return extraInputs;
 }


### PR DESCRIPTION
<!-- Suggested title: Analyze workflow when input references structurally -->

This is PR 2 of 3. It is a frontend cleanup built on the expression-context normalization in PR 1 and provides the path-aware analysis used by the optional-input authoring feature in PR 3. It does not add a new workflow-editor control by itself.

The workflow editor previously decided whether a `when` expression referenced an extra connection with a substring check:

```typescript
step.when?.includes(inputName)
```

That is not sufficient once nested tool inputs have two intentionally different representations:

- workflow connections use flattened names such as `cond|input1`;
- expressions use property paths such as `inputs.cond.input1`; and
- repeat members add an indexed mapping such as `queries_0|input2` to `inputs.queries[0].input2`.

Substring matching can also confuse `input1` with `input10`, count input-like text inside strings or comments, and mistake a literal property containing `|` for a nested path.

This PR adds two small, focused modules:

- `workflowInputPath.ts` translates connection names into segmented expression paths, resolves repeat indices through tool state, and declines ambiguous names rather than guessing.
- `whenExpression.ts` tokenizes the supported JavaScript-like property-access shapes without executing user code. It recognizes dot, bracket, mixed, numeric, and optional-chain access; ignores strings, comments, and regular-expression contents; and treats computed or otherwise unsupported access conservatively as dynamic.

The workflow step store now uses this structural analysis when synthesizing extra input terminals for a `when` expression. This fixes false matches while preserving dynamically addressed expressions when static analysis cannot disprove the reference.

The expression cases live in declarative YAML so supported syntax and conservative failure boundaries can be reviewed as data. Separate path tests cover nested conditionals, repeats, nested repeats, literal names that resemble repeat members, and genuinely ambiguous flattened names.

## Stack

1. `issue_23333`: normalize the backend `when` expression context.
2. **This PR:** add structural input-path and expression-reference analysis in the editor.
3. `optional_input_gating`: consume this analysis for optional-input presence conditions.

This PR should be reviewed against `issue_23333`, not against `dev`.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

From `client/`:

```shell
pnpm exec vitest run \
    src/components/Workflow/Editor/modules/whenExpression.test.ts \
    src/components/Workflow/Editor/modules/workflowInputPath.test.ts \
    src/components/Workflow/Editor/modules/layout.test.ts \
    src/stores/workflowStepStore.test.ts
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
