### PR TITLE
Support optional-input workflow conditions in the editor

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormConditional.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.test.ts
@@ -1,0 +1,343 @@
+import "@/composables/__mocks__/filter";
+
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount, shallowMount, type Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { createPinia, PiniaVuePlugin, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type Vue from "vue";
+
+import { type Step, type Steps, useWorkflowStepStore } from "@/stores/workflowStepStore";
+
+import FormConditional from "./FormConditional.vue";
+import FormElement from "@/components/Form/FormElement.vue";
+
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
+
+vi.mock("@/composables/confirmDialog", () => ({
+    useConfirmDialog: () => ({ confirm: confirmMock }),
+}));
+
+const localVue = getLocalVue();
+localVue.use(PiniaVuePlugin);
+
+const bootstrappedVue = getLocalVue(true);
+bootstrappedVue.use(PiniaVuePlugin);
+
+const GATED_STEP_ID = 3;
+
+function makeSteps(gatedStepOverrides: Partial<Step> = {}): Steps {
+    const dataInput = (id: number, optional: boolean) =>
+        ({
+            id,
+            type: "data_input",
+            name: "Input dataset",
+            inputs: [],
+            outputs: [{ name: "output", extensions: ["input"], optional }],
+            input_connections: {},
+            position: { left: 0, top: 0 },
+            tool_state: {},
+            workflow_outputs: [],
+        }) as unknown as Step;
+
+    return {
+        1: dataInput(1, true),
+        2: dataInput(2, false),
+        3: {
+            id: GATED_STEP_ID,
+            type: "tool",
+            name: "Concatenate datasets",
+            inputs: [
+                {
+                    name: "input1",
+                    label: "First input",
+                    multiple: false,
+                    extensions: ["txt"],
+                    optional: false,
+                    input_type: "dataset",
+                },
+                {
+                    name: "cond|input2",
+                    label: "Second input",
+                    multiple: false,
+                    extensions: ["txt"],
+                    optional: false,
+                    input_type: "dataset",
+                },
+                {
+                    name: "queries_0|input3",
+                    label: "Repeat input",
+                    multiple: false,
+                    extensions: ["txt"],
+                    optional: false,
+                    input_type: "dataset",
+                },
+                {
+                    name: "input4",
+                    label: "Always present input",
+                    multiple: false,
+                    extensions: ["txt"],
+                    optional: false,
+                    input_type: "dataset",
+                },
+            ],
+            outputs: [{ name: "out_file1", extensions: ["txt"], optional: false }],
+            input_connections: {
+                input1: { id: 1, output_name: "output" },
+                "cond|input2": { id: 1, output_name: "output" },
+                "queries_0|input3": { id: 1, output_name: "output" },
+                input4: { id: 2, output_name: "output" },
+            },
+            position: { left: 0, top: 0 },
+            tool_state: {
+                input1: '{"__class__": "ConnectedValue"}',
+                cond: { input2: { __class__: "ConnectedValue" } },
+                queries: '[{"__index__": 0, "input3": {"__class__": "ConnectedValue"}}]',
+            },
+            workflow_outputs: [],
+            ...gatedStepOverrides,
+        } as unknown as Step,
+    } as unknown as Steps;
+}
+
+function mountWith(
+    mountFn: typeof mount | typeof shallowMount,
+    vue: typeof localVue,
+    gatedStepOverrides: Partial<Step>,
+): Wrapper<Vue> {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const stepStore = useWorkflowStepStore("mock-workflow");
+    const steps = makeSteps(gatedStepOverrides);
+    Object.values(steps).forEach((step) => stepStore.addStep(step, false, false));
+
+    return mountFn(FormConditional as any, {
+        propsData: { step: steps[GATED_STEP_ID] },
+        localVue: vue,
+        pinia,
+        provide: { workflowId: "mock-workflow" },
+    });
+}
+
+function mountConditional(gatedStepOverrides: Partial<Step> = {}): Wrapper<Vue> {
+    return mountWith(shallowMount, localVue, gatedStepOverrides);
+}
+
+/** Renders the real form elements, so a control this form cannot mount is a failure. */
+function mountConditionalDeep(gatedStepOverrides: Partial<Step> = {}): Wrapper<Vue> {
+    return mountWith(mount, bootstrappedVue, gatedStepOverrides);
+}
+
+function modeElement(wrapper: Wrapper<Vue>) {
+    return wrapper.findAllComponents(FormElement).at(0);
+}
+
+/** `options` reaches FormElement through attrs rather than a declared prop. */
+function optionValues(wrapper: Wrapper<Vue>, index: number): string[] {
+    return optionPairs(wrapper, index).map((option) => option[1]!);
+}
+
+function optionPairs(wrapper: Wrapper<Vue>, index: number): string[][] {
+    return wrapper.findAllComponents(FormElement).at(index).vm.$attrs["options"] as unknown as string[][];
+}
+
+function updates(wrapper: Wrapper<Vue>): Array<[number, Partial<Step>]> {
+    return (wrapper.emitted().onUpdateStep ?? []) as Array<[number, Partial<Step>]>;
+}
+
+function lastUpdate(wrapper: Wrapper<Vue>): Partial<Step> {
+    const emitted = updates(wrapper);
+    return emitted[emitted.length - 1]![1];
+}
+
+describe("FormConditional", () => {
+    beforeEach(() => {
+        confirmMock.mockReset();
+    });
+
+    describe("rendering", () => {
+        it("mounts the mode control as a select showing the current mode", () => {
+            const wrapper = mountConditionalDeep();
+            const select = wrapper.find("#__conditional");
+            expect(select.find(".multiselect").exists()).toBe(true);
+            expect(select.text()).toContain("Always run this step");
+        });
+
+        it("mounts the gated-input control as a select showing the gated input", () => {
+            const wrapper = mountConditionalDeep({ when: "$(inputs.input1 !== null)" });
+            const select = wrapper.find("#__when_input");
+            expect(select.find(".multiselect").exists()).toBe(true);
+            expect(select.text()).toContain("First input");
+        });
+    });
+
+    describe("mode round-trips", () => {
+        it("reads an ungated step as unconditional", () => {
+            const wrapper = mountConditional();
+            expect(modeElement(wrapper).props("value")).toBe("none");
+        });
+
+        it("reads the boolean gate", () => {
+            const wrapper = mountConditional({ when: "$(inputs.when)" });
+            expect(modeElement(wrapper).props("value")).toBe("boolean");
+        });
+
+        it("reads a generated presence gate and the input it addresses", () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 !== null)" });
+            expect(modeElement(wrapper).props("value")).toBe("presence");
+            expect(wrapper.findAllComponents(FormElement).at(1).props("value")).toBe("input1");
+        });
+
+        it("reads a nested presence gate", () => {
+            const wrapper = mountConditional({
+                when: "$(inputs.cond.input2 !== null)",
+            });
+            expect(modeElement(wrapper).props("value")).toBe("presence");
+            expect(wrapper.findAllComponents(FormElement).at(1).props("value")).toBe("cond|input2");
+        });
+
+        it("reads a repeat presence gate", () => {
+            const wrapper = mountConditional({ when: "$(inputs.queries[0].input3 !== null)" });
+            expect(modeElement(wrapper).props("value")).toBe("presence");
+            expect(wrapper.findAllComponents(FormElement).at(1).props("value")).toBe("queries_0|input3");
+        });
+
+        it("reads anything else as a custom expression", () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 != null)" });
+            expect(modeElement(wrapper).props("value")).toBe("custom");
+        });
+    });
+
+    describe("gateable inputs", () => {
+        it("offers only connections whose source can be absent", () => {
+            const wrapper = mountConditional();
+            expect(optionValues(wrapper, 0)).toContain("presence");
+
+            const gated = mountConditional({ when: "$(inputs.input1 !== null)" });
+            expect(optionPairs(gated, 1).map((option) => option[1])).not.toContain("input4");
+        });
+
+        it("does not offer the presence mode when nothing gateable is connected", () => {
+            const wrapper = mountConditional({
+                input_connections: { input4: { id: 2, output_name: "output" } },
+            });
+            expect(optionValues(wrapper, 0)).not.toContain("presence");
+        });
+    });
+
+    describe("nested gate inputs", () => {
+        it("offers an input nested in a repeat", () => {
+            const gated = mountConditional({ when: "$(inputs.input1 !== null)" });
+            expect(optionPairs(gated, 1).map((option) => option[1])).toContain("queries_0|input3");
+        });
+
+        it("offers an input nested in a conditional", () => {
+            const gated = mountConditional({ when: "$(inputs.input1 !== null)" });
+            expect(optionPairs(gated, 1).map((option) => option[1])).toContain("cond|input2");
+        });
+    });
+
+    describe("writing a gate", () => {
+        it("writes the boolean gate and clears its connection", () => {
+            const wrapper = mountConditional();
+            modeElement(wrapper).vm.$emit("input", "boolean");
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.when)");
+            expect(lastUpdate(wrapper).input_connections).toHaveProperty("when", undefined);
+        });
+
+        it("writes a presence gate for the first gateable input", () => {
+            const wrapper = mountConditional();
+            modeElement(wrapper).vm.$emit("input", "presence");
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.input1 !== null)");
+        });
+
+        it("rewrites the expression when the gated input changes", () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 !== null)" });
+            wrapper.findAllComponents(FormElement).at(1).vm.$emit("input", "cond|input2");
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.cond.input2 !== null)");
+        });
+
+        it("writes an indexed presence gate for a repeat input", () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 !== null)" });
+            wrapper.findAllComponents(FormElement).at(1).vm.$emit("input", "queries_0|input3");
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.queries[0].input3 !== null)");
+        });
+
+        it("ignores a selection of the mode already in effect", () => {
+            const wrapper = mountConditional({ when: "$(inputs.when)" });
+            modeElement(wrapper).vm.$emit("input", "boolean");
+            expect(updates(wrapper)).toHaveLength(0);
+        });
+    });
+
+    describe("clearing a gate", () => {
+        it("clears a generated gate without asking", async () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 !== null)" });
+            modeElement(wrapper).vm.$emit("input", "none");
+            await flushPromises();
+            expect(confirmMock).not.toHaveBeenCalled();
+            expect(lastUpdate(wrapper).when).toBeUndefined();
+        });
+
+        it("asks before clearing a hand-written expression", async () => {
+            confirmMock.mockResolvedValue(true);
+            const wrapper = mountConditional({ when: "$(inputs.input1 != null)" });
+            modeElement(wrapper).vm.$emit("input", "none");
+            await flushPromises();
+            expect(confirmMock).toHaveBeenCalled();
+            expect(lastUpdate(wrapper).when).toBeUndefined();
+        });
+
+        it("keeps a hand-written expression when the user declines", async () => {
+            confirmMock.mockResolvedValue(false);
+            const wrapper = mountConditional({ when: "$(inputs.input1 != null)" });
+            modeElement(wrapper).vm.$emit("input", "none");
+            await flushPromises();
+            expect(confirmMock).toHaveBeenCalled();
+            expect(updates(wrapper)).toHaveLength(0);
+        });
+
+        it("asks before replacing a hand-written expression with the boolean gate", async () => {
+            confirmMock.mockResolvedValue(false);
+            const wrapper = mountConditional({ when: "$(inputs.flag && inputs.other !== null)" });
+            modeElement(wrapper).vm.$emit("input", "boolean");
+            await flushPromises();
+            expect(confirmMock).toHaveBeenCalled();
+            expect(updates(wrapper)).toHaveLength(0);
+        });
+
+        it("asks before replacing a hand-written expression with a presence gate", async () => {
+            confirmMock.mockResolvedValue(false);
+            const wrapper = mountConditional({ when: "$(inputs.flag && inputs.other !== null)" });
+            modeElement(wrapper).vm.$emit("input", "presence");
+            await flushPromises();
+            expect(confirmMock).toHaveBeenCalled();
+            expect(updates(wrapper)).toHaveLength(0);
+        });
+
+        it("replaces a hand-written expression once the user agrees", async () => {
+            confirmMock.mockResolvedValue(true);
+            const wrapper = mountConditional({ when: "$(inputs.flag && inputs.other !== null)" });
+            modeElement(wrapper).vm.$emit("input", "boolean");
+            await flushPromises();
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.when)");
+        });
+
+        it("does not ask when the expression is one this form generated", async () => {
+            const wrapper = mountConditional({ when: "$(inputs.input1 !== null)" });
+            modeElement(wrapper).vm.$emit("input", "boolean");
+            await flushPromises();
+            expect(confirmMock).not.toHaveBeenCalled();
+            expect(lastUpdate(wrapper).when).toBe("$(inputs.when)");
+        });
+
+        it("shows a hand-written expression without rewriting it", () => {
+            const expression = "$(inputs.input1 != null && inputs.other)";
+            const wrapper = mountConditional({ when: expression });
+            const custom = wrapper.findAllComponents(FormElement).at(1);
+            expect(custom.props("value")).toBe(expression);
+            expect(custom.props("disabled")).toBe(true);
+            expect(updates(wrapper)).toHaveLength(0);
+        });
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormConditional.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.vue
@@ -1,9 +1,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import type { Step } from "@/stores/workflowStepStore";
+import { useConfirmDialog } from "@/composables/confirmDialog";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import {
+    connectedInputCanBeAbsent,
+    presenceGateInputPath,
+    presenceGateIsSpellable,
+    type Step,
+} from "@/stores/workflowStepStore";
+
+import { BOOLEAN_GATE_EXPRESSION, BOOLEAN_GATE_INPUT_NAME, presenceGateExpression } from "../modules/whenExpression";
 
 import FormElement from "@/components/Form/FormElement.vue";
+
+type GateMode = "none" | "boolean" | "presence" | "custom";
 
 const emit = defineEmits<{
     (e: "onUpdateStep", id: number, value: Partial<Step>): void;
@@ -12,40 +23,120 @@ const props = defineProps<{
     step: Step;
 }>();
 
-const conditionalDefined = computed(() => {
-    return Boolean(props.step.when);
+const { stepStore } = useWorkflowStores();
+const { confirm } = useConfirmDialog();
+
+const connectedInputNames = computed(() => Object.keys(props.step.input_connections ?? {}));
+
+const gateableInputs = computed(() =>
+    connectedInputNames.value
+        .filter((name) => connectedInputCanBeAbsent(props.step, name, stepStore))
+        .filter((name) => presenceGateIsSpellable(props.step, name))
+        .map((name) => [inputLabel(name), name]),
+);
+
+/** The input a presence gate written by this form addresses, if the gate is one of ours. */
+const presenceGateInput = computed(() =>
+    connectedInputNames.value.find((name) => props.step.when === gateExpression(name)),
+);
+
+const mode = computed<GateMode>(() => {
+    if (!props.step.when) {
+        return "none";
+    }
+    if (props.step.when === BOOLEAN_GATE_EXPRESSION) {
+        return "boolean";
+    }
+    return presenceGateInput.value ? "presence" : "custom";
 });
 
-function onSkipBoolean(value: boolean) {
-    if (props.step.when && value === false) {
-        emit("onUpdateStep", props.step.id, { when: undefined });
-    } else if (value === true && !props.step.when) {
-        const when = "$(inputs.when)";
-        const newStep = {
-            when,
-            input_connections: { ...props.step.input_connections, when: undefined },
-        };
-        emit("onUpdateStep", props.step.id, newStep);
+const modeOptions = computed(() => {
+    const options = [
+        ["Always run this step", "none"],
+        ["Run when a boolean parameter is true", "boolean"],
+    ];
+    if (gateableInputs.value.length > 0 || mode.value === "presence") {
+        options.push(["Run when an input is provided", "presence"]);
     }
+    if (mode.value === "custom") {
+        options.push(["Custom expression", "custom"]);
+    }
+    return options;
+});
+
+function inputLabel(name: string): string {
+    return props.step.inputs?.find((input) => input.name === name)?.label || name;
+}
+
+async function onMode(newMode: GateMode) {
+    if (newMode === mode.value) {
+        return;
+    }
+    // Every transition out of a custom expression discards it, not just clearing.
+    if (mode.value === "custom" && !(await confirmDiscardingCustomExpression())) {
+        return;
+    }
+    if (newMode === "none") {
+        emit("onUpdateStep", props.step.id, { when: undefined });
+    } else if (newMode === "boolean") {
+        emit("onUpdateStep", props.step.id, {
+            when: BOOLEAN_GATE_EXPRESSION,
+            input_connections: { ...(props.step.input_connections ?? {}), [BOOLEAN_GATE_INPUT_NAME]: undefined },
+        });
+    } else if (newMode === "presence") {
+        const firstGateable = gateableInputs.value[0];
+        if (firstGateable) {
+            onPresenceInput(firstGateable[1]!);
+        }
+    }
+}
+
+function onPresenceInput(inputName: string) {
+    const expression = gateExpression(inputName);
+    if (expression) {
+        emit("onUpdateStep", props.step.id, { when: expression });
+    }
+}
+
+function gateExpression(inputName: string): string | null {
+    const inputPath = presenceGateInputPath(props.step, inputName);
+    return inputPath ? presenceGateExpression(inputPath) : null;
+}
+
+function confirmDiscardingCustomExpression() {
+    return confirm(
+        `This step runs only when ${props.step.when} is true. That condition was not written by this form and cannot be restored here.`,
+        { title: "Discard this step's condition?", okText: "Discard" },
+    );
 }
 </script>
 
 <template>
-    <FormElement
-        id="__conditional"
-        :value="conditionalDefined"
-        title="Conditionally skip step?"
-        help="Set to true and connect a boolean parameter that determines whether the step should run. The step runs if the parameter value is true and will be skipped if the parameter value is false"
-        type="boolean"
-        @input="onSkipBoolean"></FormElement>
-    <!-- We don't seem to have a disabled text field
+    <div>
         <FormElement
-            v-if="setConditional"
+            id="__conditional"
+            :value="mode"
+            title="Conditionally skip step?"
+            type="select"
+            :options="modeOptions"
+            help="Choose what decides whether this step runs. A skipped step produces no outputs; merge them with a fallback using a Pick Value step."
+            @input="onMode" />
+        <FormElement
+            v-if="mode === 'presence'"
+            id="__when_input"
+            :value="presenceGateInput"
+            title="Run only when this input is provided"
+            type="select"
+            :options="gateableInputs"
+            help="The step is skipped when the connected input carries no dataset or value."
+            @input="onPresenceInput" />
+        <FormElement
+            v-if="mode === 'custom'"
             id="__when"
             :value="step.when"
+            title="Condition"
             type="text"
-            help="Step will be executed if javascript expression below evaluates to true."
-            >
-        </FormElement>
-    -->
+            :disabled="true"
+            help="This step runs if the expression evaluates to true. Expressions written outside this form are shown but not edited here." />
+    </div>
 </template>

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -1,3 +1,5 @@
+import "@/composables/__mocks__/filter";
+
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
@@ -5,6 +7,9 @@ import { PiniaVuePlugin } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FormDefault from "./FormDefault.vue";
+
+// The conditional gate control renders FormSelect, which spawns a filter web worker.
+vi.mock("@/composables/filter");
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -1,3 +1,5 @@
+import "@/composables/__mocks__/filter";
+
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";

--- a/client/src/components/Workflow/Editor/Lint.test.ts
+++ b/client/src/components/Workflow/Editor/Lint.test.ts
@@ -117,3 +117,65 @@ describe("Lint", () => {
         expect(actions[2].action_type).toBe("remove_unlabeled_workflow_outputs");
     });
 });
+
+describe("Lint conditional gates", () => {
+    function mountLint(when: string | undefined, inputConnections: Record<string, unknown>): Wrapper<Vue> {
+        const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+        setActivePinia(pinia);
+
+        const gatedSteps = {
+            ...(JSON.parse(JSON.stringify(steps)) as Steps),
+            3: {
+                id: 3,
+                name: "Concatenate datasets",
+                label: "gated",
+                type: "tool",
+                content_id: "cat1",
+                inputs: [],
+                outputs: [],
+                input_connections: inputConnections,
+                position: { left: 0, top: 0 },
+                tool_state: {},
+                workflow_outputs: [],
+                when,
+            },
+        } as unknown as Steps;
+        const gatedStepsRef = ref(gatedSteps);
+
+        const wrapper = mount(Lint as object, {
+            propsData: {
+                lintData: useLintData(ref("1"), gatedStepsRef, ref(testDatatypesMapper)),
+                steps: gatedSteps,
+                datatypesMapper: testDatatypesMapper,
+                hasChanges: false,
+            },
+            localVue,
+            pinia,
+            provide: { workflowId: "mock-workflow" },
+        });
+
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        Object.values(gatedSteps).map((step) => stepStore.addStep(step));
+        return wrapper;
+    }
+
+    function sectionStatus(wrapper: Wrapper<Vue>): string | void {
+        return wrapper.find("[data-description='linting conditional gates']").attributes("data-lint-status");
+    }
+
+    it("says nothing when no step is gated", () => {
+        const wrapper = mountLint(undefined, {});
+        expect(wrapper.find("[data-description='linting conditional gates']").exists()).toBe(false);
+    });
+
+    it("passes when a gate reads a connected input", () => {
+        const wrapper = mountLint("$(inputs.when)", { when: { id: 0, output_name: "output" } });
+        expect(sectionStatus(wrapper)).toBe("ok");
+    });
+
+    it("warns when a gate reads an input nothing is connected to", () => {
+        const wrapper = mountLint("$(inputs.when)", {});
+        expect(sectionStatus(wrapper)).toBe("warning");
+        expect(wrapper.find("[data-description='linting conditional gates']").text()).toContain("when");
+    });
+});

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -16,6 +16,7 @@ import {
     fixDisconnectedInput,
     fixUnlabeledOutputs,
     fixUntypedParameter,
+    hasGatedSteps,
     isStateForInputOrOutput,
 } from "./modules/linting";
 import type { DisconnectedInputState, LintState, UntypedParameterState } from "./modules/lintingTypes";
@@ -52,9 +53,12 @@ const {
     unlabeledOutputs,
     untypedParameterWarnings,
     disconnectedInputs,
+    danglingGates,
     duplicateLabels,
     missingMetadata,
 } = toRefs(props.lintData);
+
+const showGateSection = computed(() => hasGatedSteps(props.steps));
 
 /** Renders the celebratory reaction when all critical and non-critical best practice issues are resolved. */
 const showSuccessReaction = computed(
@@ -231,6 +235,16 @@ async function onRefactor() {
             @onMouseOver="onHighlight"
             @onClick="onFixDisconnectedInput"
             @onSaveRequested="saveChanges(false)" />
+        <LintSection
+            v-if="showGateSection"
+            data-description="linting conditional gates"
+            high-priority
+            success-message="Every conditional step reads inputs that are connected."
+            warning-message="Some conditional steps read an input that nothing is connected to. Such a step is skipped
+                on every run, or fails while its condition is evaluated. Connect the input or change the condition:"
+            :warning-items="danglingGates"
+            @onMouseOver="onHighlight"
+            @onClick="openAndFocus" />
         <LintSection
             v-if="hasInputSteps"
             data-description="linting input metadata"

--- a/client/src/components/Workflow/Editor/NodeInput.test.ts
+++ b/client/src/components/Workflow/Editor/NodeInput.test.ts
@@ -1,0 +1,150 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { shallowMount, type Wrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type Vue from "vue";
+import type { VueConstructor } from "vue";
+import { nextTick, ref } from "vue";
+
+import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import type { useWorkflowStores } from "@/composables/workflowStores";
+import { useUndoRedoStore } from "@/stores/undoRedoStore";
+import { useConnectionStore } from "@/stores/workflowConnectionStore";
+import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { type Step, type Steps, useWorkflowStepStore } from "@/stores/workflowStepStore";
+
+import { type OutputTerminals, terminalFactory } from "./modules/terminals";
+import { advancedSteps, mockOffset } from "./test_fixtures";
+
+import NodeInput from "./NodeInput.vue";
+
+const localVue = getLocalVue();
+const workflowId = "node-input-drop-preview";
+const transform = ref({ x: 0, y: 0, k: 1 });
+
+class ResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+}
+
+// eslint-disable-next-line compat/compat
+window.ResizeObserver = ResizeObserver;
+
+function stepForLabel(label: string, steps: Steps): Step {
+    const step = Object.values(steps).find((step) => step.label === label);
+    if (!step) {
+        throw new Error(`No step labeled '${label}'`);
+    }
+    return step;
+}
+
+describe("NodeInput drop preview", () => {
+    let pinia: ReturnType<typeof createPinia>;
+    let steps: Steps;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+        const stepStore = useWorkflowStepStore(workflowId);
+        steps = JSON.parse(JSON.stringify(advancedSteps)) as Steps;
+        Object.values(steps).forEach((step) => stepStore.addStep(step));
+    });
+
+    function outputTerminal(stepLabel: string): OutputTerminals {
+        const step = stepForLabel(stepLabel, steps);
+        return terminalFactory(step.id, step.outputs[0]!, testDatatypesMapper, {
+            connectionStore: useConnectionStore(workflowId),
+            stepStore: useWorkflowStepStore(workflowId),
+            undoRedoStore: useUndoRedoStore(workflowId),
+        } as unknown as ReturnType<typeof useWorkflowStores>) as OutputTerminals;
+    }
+
+    function addReceiverStep(label: string, type: Step["type"]): void {
+        const template = stepForLabel("simple data", steps);
+        const id = Math.max(...Object.values(steps).map((step) => step.id)) + 1;
+        const step = {
+            ...JSON.parse(JSON.stringify(template)),
+            id,
+            type,
+            label,
+            name: label,
+            input_connections: {},
+        } as Step;
+        steps[id] = step;
+        useWorkflowStepStore(workflowId).addStep(step);
+    }
+
+    function mountInput(stepLabel: string): Wrapper<Vue> {
+        const step = stepForLabel(stepLabel, steps);
+        return shallowMount(NodeInput as unknown as VueConstructor<Vue>, {
+            propsData: {
+                input: step.inputs[0],
+                stepId: step.id,
+                datatypesMapper: testDatatypesMapper,
+                stepPosition: step.position,
+                rootOffset: mockOffset,
+                scale: 1,
+                scroll: { x: ref(0), y: ref(0) },
+                parentNode: null,
+                readonly: false,
+                blank: false,
+            },
+            localVue,
+            pinia,
+            provide: { transform, workflowId, isDragging: ref(true) },
+        });
+    }
+
+    async function preview(outputStepLabel: string, inputStepLabel: string) {
+        useWorkflowStateStore(workflowId).draggingTerminal = outputTerminal(outputStepLabel);
+        const wrapper = mountInput(inputStepLabel);
+        await nextTick();
+        return wrapper;
+    }
+
+    it("shows a directly accepted drop in green", async () => {
+        const wrapper = await preview("data input", "simple data");
+
+        expect(wrapper.find(".input-terminal").classes()).toContain("can-accept");
+        expect(wrapper.find(".input-terminal").classes()).not.toContain("can-not-accept");
+    });
+
+    it("shows a presence-gated drop in green with an actionable explanation", async () => {
+        const wrapper = await preview("optional data input", "simple data");
+
+        expect(wrapper.find(".input-terminal").classes()).toContain("can-accept");
+        expect(wrapper.find(".input-terminal").classes()).not.toContain("can-not-accept");
+        expect(wrapper.text()).toContain("Drop to connect and run this step only when From is provided.");
+        expect(wrapper.text()).not.toContain("Cannot connect an optional output");
+    });
+
+    it("offers presence gating for a required subworkflow input", async () => {
+        addReceiverStep("required subworkflow", "subworkflow");
+
+        const wrapper = await preview("optional data input", "required subworkflow");
+
+        expect(wrapper.find(".input-terminal").classes()).toContain("can-accept");
+        expect(wrapper.find(".input-terminal").classes()).not.toContain("can-not-accept");
+        expect(wrapper.text()).toContain("Drop to connect and run this step only when From is provided.");
+    });
+
+    it("does not offer presence gating for a pause step", async () => {
+        addReceiverStep("pause for review", "pause");
+
+        const wrapper = await preview("optional data input", "pause for review");
+
+        expect(wrapper.find(".input-terminal").classes()).toContain("can-not-accept");
+        expect(wrapper.find(".input-terminal").classes()).not.toContain("can-accept");
+        expect(wrapper.text()).toContain("Cannot connect an optional output to a non-optional input");
+        expect(wrapper.text()).not.toContain("run this step only when");
+    });
+
+    it("keeps a genuinely incompatible drop orange with its rejection", async () => {
+        const wrapper = await preview("optional data input", "list collection input");
+
+        expect(wrapper.find(".input-terminal").classes()).toContain("can-not-accept");
+        expect(wrapper.find(".input-terminal").classes()).not.toContain("can-accept");
+        expect(wrapper.text()).toContain("Cannot attach a data output to a collection input.");
+    });
+});

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -20,12 +20,14 @@ import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import {
     ConnectionAcceptable,
     type InputTerminals,
-    type OutputCollectionTerminal,
+    type OutputTerminals,
     terminalFactory,
 } from "@/components/Workflow/Editor/modules/terminals";
+import { presenceGateExpression } from "@/components/Workflow/Editor/modules/whenExpression";
+import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useWorkflowStores } from "@/composables/workflowStores";
 import { getConnectionId } from "@/stores/workflowConnectionStore";
-import type { InputTerminalSource } from "@/stores/workflowStepStore";
+import { type InputTerminalSource, presenceGateInputPath } from "@/stores/workflowStepStore";
 
 import { useRelativePosition } from "./composables/relativePosition";
 import { useTerminal } from "./composables/useTerminal";
@@ -92,7 +94,8 @@ const position = useRelativePosition(
 );
 
 const stores = useWorkflowStores();
-const { connectionStore, stateStore } = stores;
+const { connectionStore, stateStore, stepStore } = stores;
+const { confirm } = useConfirmDialog();
 const hasTerminals = ref(false);
 watchEffect(() => {
     hasTerminals.value = connectionStore.getOutputTerminalsForInputTerminal(id.value).length > 0;
@@ -110,9 +113,28 @@ const invalidConnectionReasons = computed(() =>
 
 const { draggingTerminal } = storeToRefs(stateStore);
 
+interface DropAssessment {
+    acceptance: ConnectionAcceptable;
+    requiresPresenceGate: boolean;
+}
+
+function assessDrop(droppedTerminal: OutputTerminals): DropAssessment {
+    const directAcceptance = terminal.value.canAccept(droppedTerminal);
+    if (directAcceptance.canAccept) {
+        return { acceptance: directAcceptance, requiresPresenceGate: false };
+    }
+    const gatedAcceptance = terminal.value.canAcceptWithPresenceGate(droppedTerminal);
+    if (gatedAcceptance.canAccept) {
+        return { acceptance: gatedAcceptance, requiresPresenceGate: true };
+    }
+    return { acceptance: directAcceptance, requiresPresenceGate: false };
+}
+
+const dragAssessment = computed(() => (draggingTerminal.value ? assessDrop(draggingTerminal.value) : null));
+
 const canAccept = computed(() => {
-    if (draggingTerminal.value) {
-        return terminal.value.canAccept(draggingTerminal.value);
+    if (dragAssessment.value) {
+        return dragAssessment.value.acceptance;
     } else {
         const firstReason = invalidConnectionReasons.value[0];
         if (firstReason) {
@@ -141,8 +163,13 @@ watch([endX, endY], ([x, y]) => {
 });
 
 const isDragging = inject("isDragging");
-const reason = computed(() => canAccept.value?.reason ?? undefined);
 const label = computed(() => props.input.label || props.input.name);
+const reason = computed(() => {
+    if (dragAssessment.value?.requiresPresenceGate) {
+        return `Drop to connect and run this step only when ${label.value} is provided.`;
+    }
+    return canAccept.value?.reason ?? undefined;
+});
 const hasConnections = computed(() => connections.value.length > 0);
 const rowClass = computed(() => {
     const classes = ["form-row", "dataRow", "input-data-row"];
@@ -170,7 +197,7 @@ function onRemove() {
     connections.forEach((connection) => terminal.value.disconnect(connection));
 }
 
-function onDrop(event: DragEvent) {
+async function onDrop(event: DragEvent) {
     if (!event.dataTransfer) {
         return;
     }
@@ -181,13 +208,50 @@ function onDrop(event: DragEvent) {
         stepOut.output,
         props.datatypesMapper,
         stores,
-    ) as OutputCollectionTerminal;
+    ) as OutputTerminals;
 
     showTooltip.value = false;
 
-    if (terminal.value.canAccept(droppedTerminal).canAccept) {
-        terminal.value.connect(droppedTerminal);
+    const assessment = assessDrop(droppedTerminal);
+    if (!assessment.acceptance.canAccept) {
+        return;
     }
+    if (!assessment.requiresPresenceGate) {
+        terminal.value.connect(droppedTerminal);
+        return;
+    }
+    await offerPresenceGate(droppedTerminal);
+}
+
+/** The dropped value may be absent, and only a gate makes that safe. Offer to write one. */
+async function offerPresenceGate(droppedTerminal: OutputTerminals) {
+    const confirmed = await confirm(
+        `${label.value} may arrive empty, and this step requires it. Run this step only when ${label.value} is provided?`,
+        { title: "Run this step conditionally?", okText: "Run only when provided" },
+    );
+    if (!confirmed) {
+        return;
+    }
+    const step = stepStore.getStep(props.stepId);
+    const inputPath = step && presenceGateInputPath(step, props.input.name);
+    if (!inputPath) {
+        return;
+    }
+
+    stores.undoRedoStore
+        .action()
+        .onRun(() => {
+            // Raw, because the surrounding action is what makes this one undo step.
+            terminal.value.makeConnection(droppedTerminal);
+            terminal.value.setDefaultMapOver(droppedTerminal);
+            stepStore.updateStepValue(props.stepId, "when", presenceGateExpression(inputPath));
+        })
+        .onUndo(() => {
+            stepStore.updateStepValue(props.stepId, "when", undefined);
+            terminal.value.dropConnection(droppedTerminal);
+        })
+        .setName("gate step on input")
+        .apply();
 }
 
 const draggedOver = ref(false);

--- a/client/src/components/Workflow/Editor/modules/generated_presence_conditions.yml
+++ b/client/src/components/Workflow/Editor/modules/generated_presence_conditions.yml
@@ -1,0 +1,24 @@
+# Inputs and the presence-checking expressions that should be generated for them.
+- doc: A top-level identifier uses dot access
+  input: input1
+  expression: $(inputs.input1 !== null)
+
+- doc: A nested connection follows each pipe-delimited segment
+  input: cond|input1
+  expression: $(inputs.cond.input1 !== null)
+
+- doc: A non-identifier top-level name uses bracket access
+  input: segment-with-dashes
+  expression: '$(inputs["segment-with-dashes"] !== null)'
+
+- doc: A non-identifier nested name uses bracket access
+  input: cond|has-dash
+  expression: '$(inputs.cond["has-dash"] !== null)'
+
+- doc: A numeric-looking property name remains a quoted property
+  input: 0|input1
+  expression: '$(inputs["0"].input1 !== null)'
+
+- doc: A resolved repeat path uses a numeric index
+  input: [queries, 0, input2]
+  expression: $(inputs.queries[0].input2 !== null)

--- a/client/src/components/Workflow/Editor/modules/linting.test.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import type { Step, Steps } from "@/stores/workflowStepStore";
+
+import { getDanglingGates, hasGatedSteps } from "./linting";
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+    return {
+        id: 1,
+        name: "Concatenate datasets",
+        label: "gated",
+        type: "tool",
+        content_id: "cat1",
+        inputs: [
+            {
+                name: "input1",
+                label: "First input",
+                multiple: false,
+                extensions: ["txt"],
+                optional: false,
+                input_type: "dataset",
+            },
+        ],
+        outputs: [{ name: "out_file1", extensions: ["txt"], optional: false }],
+        input_connections: {},
+        position: { left: 0, top: 0 },
+        tool_state: { cond: { cond_test: "first" } },
+        workflow_outputs: [],
+        ...overrides,
+    } as unknown as Step;
+}
+
+function steps(step: Step): Steps {
+    return { 1: step } as unknown as Steps;
+}
+
+const CONNECTED_INPUT1 = { input1: { id: 0, output_name: "output" } };
+
+describe("getDanglingGates", () => {
+    it("ignores an ungated step", () => {
+        expect(getDanglingGates(steps(makeStep()))).toEqual([]);
+    });
+
+    it("accepts a boolean gate whose port is connected", () => {
+        const step = makeStep({
+            when: "$(inputs.when)",
+            input_connections: { when: { id: 0, output_name: "output" } },
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("flags a boolean gate with nothing connected to its port", () => {
+        const step = makeStep({ when: "$(inputs.when)" });
+        const dangling = getDanglingGates(steps(step));
+        expect(dangling).toHaveLength(1);
+        expect(dangling[0]).toMatchObject({
+            stepId: 1,
+            stepLabel: "gated",
+            inputName: "when",
+            autofix: false,
+            highlightType: "input",
+        });
+    });
+
+    it("accepts a presence gate on a connected parameter", () => {
+        const step = makeStep({
+            when: "$(inputs.input1 !== null)",
+            input_connections: CONNECTED_INPUT1,
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("flags a presence gate whose parameter lost its connection", () => {
+        const step = makeStep({ when: "$(inputs.input1 !== null)" });
+        expect(getDanglingGates(steps(step))).toHaveLength(1);
+    });
+
+    it("accepts a gate reading a parameter that carries its value in step state", () => {
+        const step = makeStep({
+            when: '$(inputs.cond.cond_test === "first")',
+            input_connections: CONNECTED_INPUT1,
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("accepts a gate reading a connection nested under a conditional", () => {
+        const step = makeStep({
+            when: "$(inputs.cond.input1 !== null)",
+            input_connections: { "cond|input1": { id: 0, output_name: "output" } },
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("accepts a gate reading a connection nested under a repeat", () => {
+        const step = makeStep({
+            when: "$(inputs.queries[0].input2 !== null)",
+            input_connections: { "queries_0|input2": { id: 0, output_name: "output" } },
+            tool_state: { queries: '[{"__index__": 0, "input2": {}}]' },
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("does not confuse a literal pipe in an access with a nested connection path", () => {
+        const step = makeStep({
+            when: '$(inputs["cond|input1"] !== null)',
+            input_connections: { "cond|input1": { id: 0, output_name: "output" } },
+        });
+        expect(getDanglingGates(steps(step))).toHaveLength(1);
+    });
+
+    it("accepts an inverse probe gate whose probe is connected", () => {
+        const step = makeStep({
+            when: "$(inputs.probe === null)",
+            input_connections: { probe: { id: 0, output_name: "output" } },
+        });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("says nothing about a step whose tool could not be loaded", () => {
+        // An uninstalled tool has no inputs and no usable state, so every reference
+        // would look unsatisfied. The missing tool is the problem to report, not the gate.
+        const step = makeStep({ when: "$(inputs.input1 !== null)", inputs: [], tool_state: {}, errors: ["boom"] });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("says nothing about an expression it cannot resolve statically", () => {
+        const step = makeStep({ when: "$(inputs[name] !== null)" });
+        expect(getDanglingGates(steps(step))).toEqual([]);
+    });
+
+    it("reports each missing name once", () => {
+        const step = makeStep({ when: "$(inputs.probe !== null && inputs.probe !== undefined)" });
+        expect(getDanglingGates(steps(step))).toHaveLength(1);
+    });
+
+    it("reports only the missing half of a mixed expression", () => {
+        const step = makeStep({
+            when: "$(inputs.input1 !== null && inputs.probe !== null)",
+            input_connections: CONNECTED_INPUT1,
+        });
+        const dangling = getDanglingGates(steps(step));
+        expect(dangling.map((item) => item.inputName)).toEqual(["probe"]);
+    });
+});
+
+describe("hasGatedSteps", () => {
+    it("is false without gates", () => {
+        expect(hasGatedSteps(steps(makeStep()))).toBe(false);
+    });
+
+    it("is true with a gate", () => {
+        expect(hasGatedSteps(steps(makeStep({ when: "$(inputs.when)" })))).toBe(true);
+    });
+
+    it("is false for an empty workflow", () => {
+        expect(hasGatedSteps({})).toBe(false);
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -1,11 +1,12 @@
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import type { UntypedParameters } from "@/components/Workflow/Editor/modules/parameters";
 import type { useWorkflowStores } from "@/composables/workflowStores";
-import type { Steps } from "@/stores/workflowStepStore";
+import type { Step, Steps } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { isWorkflowInput } from "../../constants";
 import type {
+    DanglingGateState,
     DisconnectedInputState,
     DuplicateLabelState,
     ExtractInputAction,
@@ -17,6 +18,8 @@ import type {
     UntypedParameterState,
 } from "./lintingTypes";
 import { terminalFactory } from "./terminals";
+import { analyzeInputReferences } from "./whenExpression";
+import { type InputPath, inputPathIsPrefix, resolveConnectionNameToInputPath } from "./workflowInputPath";
 
 export const bestPracticeWarningAnnotation =
     "This workflow does not provide a short description. Providing a short description helps workflow executors understand the purpose and usage of the workflow.";
@@ -53,6 +56,82 @@ export function getDisconnectedInputs(
         });
     });
     return inputs;
+}
+
+/**
+ * Steps whose `when` expression reads a name nothing supplies.
+ *
+ * A gate on a disconnected tool parameter evaluates false forever, because the tool
+ * state key survives as null; a gate on a disconnected probe raises during evaluation.
+ * Neither is visible without this check -- `getDisconnectedInputs` walks `step.inputs`,
+ * which never contains a synthesized gate port.
+ */
+export function getDanglingGates(steps: Steps = {}) {
+    const dangling: DanglingGateState[] = [];
+    Object.values(steps).forEach((step) => {
+        if (!step.when) {
+            return;
+        }
+        if (step.errors?.length) {
+            // Nothing loaded, so nothing resolves. The missing tool is the report to make.
+            return;
+        }
+        const references = analyzeInputReferences(step.when);
+        if (references.hasDynamicInputsAccess) {
+            return;
+        }
+        const reported = new Set<string>();
+        references.staticPaths.forEach((path) => {
+            const name = path.join("|");
+            const referenceKey = JSON.stringify(path);
+            if (reported.has(referenceKey) || gateReferenceIsSatisfied(step, path)) {
+                return;
+            }
+            reported.add(referenceKey);
+            dangling.push({
+                stepId: step.id,
+                stepLabel: step.label || step.content_id || step.name,
+                warningLabel: name,
+                inputName: name,
+                autofix: false,
+                highlightType: "input",
+                name,
+            });
+        });
+    });
+    return dangling;
+}
+
+function gateReferenceIsSatisfied(step: Step, path: InputPath): boolean {
+    if (connectionNamesIncludePath(step, Object.keys(step.input_connections ?? {}), path)) {
+        return true;
+    }
+    if (
+        connectionNamesIncludePath(
+            step,
+            (step.inputs ?? []).map((input) => input.name),
+            path,
+        )
+    ) {
+        // A connectable tool parameter with nothing connected is the dangling case.
+        return false;
+    }
+    // Everything else the expression can legitimately read comes from the step's state.
+    const root = path[0]!;
+    return typeof root === "string" && Object.prototype.hasOwnProperty.call(step.tool_state ?? {}, root);
+}
+
+/** True when `path` names a candidate connection or one of its ancestors. */
+function connectionNamesIncludePath(step: Step, candidates: string[], path: InputPath): boolean {
+    return candidates.some((candidate) => {
+        const candidatePath = resolveConnectionNameToInputPath(candidate, step.tool_state);
+        return candidatePath ? inputPathIsPrefix(path, candidatePath) : false;
+    });
+}
+
+/** Gate checks only make sense once something in the workflow is gated. */
+export function hasGatedSteps(steps: Steps = {}): boolean {
+    return Object.values(steps).some((step) => Boolean(step.when));
 }
 
 export function getMissingMetadata(steps: Steps) {
@@ -235,6 +314,6 @@ function isMetadataLintState(state: LintState): state is MetadataLintState {
 /** Type guard for linting states that are for a workflow step input or output. */
 export function isStateForInputOrOutput(
     state: LintState,
-): state is DisconnectedInputState | DuplicateLabelState | UnlabeledOuputState {
+): state is DanglingGateState | DisconnectedInputState | DuplicateLabelState | UnlabeledOuputState {
     return "highlightType" in state;
 }

--- a/client/src/components/Workflow/Editor/modules/lintingTypes.d.ts
+++ b/client/src/components/Workflow/Editor/modules/lintingTypes.d.ts
@@ -19,6 +19,14 @@ export interface DisconnectedInputState extends LintStateBase {
     name: string;
 }
 
+/** Lint state for a `when` expression that reads an input nothing is connected to */
+export interface DanglingGateState extends LintStateBase {
+    autofix: false;
+    highlightType: "input";
+    inputName: string;
+    name: string;
+}
+
 /** Lint state for duplicate label issues */
 export interface DuplicateLabelState extends LintStateBase {
     highlightType: "output";
@@ -48,6 +56,7 @@ export interface UntypedParameterState extends LintStateBase {
 
 /** Union type for all linting states */
 export type LintState =
+    | DanglingGateState
     | DisconnectedInputState
     | DuplicateLabelState
     | MetadataLintState

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -533,6 +533,31 @@ describe("canAccept", () => {
             "Cannot connect an optional output to a non-optional input",
         );
     });
+    it("accepts optional data -> required data when the step is gated on that input", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        stepStore.updateStepValue(dataIn.stepId, "when", "$(inputs.input !== null)");
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(true);
+        expect(dataIn.canAccept(optionalDataOut).reason).toBe(null);
+    });
+    it("rejects optional data -> required data when the gate reads a different input", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        stepStore.updateStepValue(dataIn.stepId, "when", "$(inputs.unrelated !== null)");
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(false);
+        expect(dataIn.canAccept(optionalDataOut).reason).toBe(
+            "Cannot connect an optional output to a non-optional input",
+        );
+    });
+    it("rejects optional data -> required data when the gate runs the step while the input is absent", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        stepStore.updateStepValue(dataIn.stepId, "when", "$(inputs.input === null)");
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(false);
+        expect(dataIn.canAccept(optionalDataOut).reason).toBe(
+            "Cannot connect an optional output to a non-optional input",
+        );
+    });
     it("rejects parameter to data connection", () => {
         const dataIn = terminals["simple data"]!["input"] as InputTerminal;
         // # type system would reject this, but test runtime too
@@ -560,6 +585,37 @@ describe("canAccept", () => {
         const optionalIntegerOutputParam = terminals["optional integer parameter input"]![
             "output"
         ] as OutputParameterTerminal;
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).canAccept).toBe(false);
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).reason).toBe(
+            "Cannot attach an optional output to a required parameter",
+        );
+    });
+    it("accepts optional parameter -> required parameter when the step is gated on that input", () => {
+        const integerInputParam = terminals["multi data"]!["advanced|advanced_threshold"] as InputParameterTerminal;
+        const optionalIntegerOutputParam = terminals["optional integer parameter input"]![
+            "output"
+        ] as OutputParameterTerminal;
+        stepStore.updateStepValue(integerInputParam.stepId, "when", "$(inputs.advanced.advanced_threshold !== null)");
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).canAccept).toBe(true);
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).reason).toBe(null);
+    });
+    it("rejects optional parameter -> required parameter when the gate reads a different input", () => {
+        const integerInputParam = terminals["multi data"]!["advanced|advanced_threshold"] as InputParameterTerminal;
+        const optionalIntegerOutputParam = terminals["optional integer parameter input"]![
+            "output"
+        ] as OutputParameterTerminal;
+        stepStore.updateStepValue(integerInputParam.stepId, "when", "$(inputs.advanced.other !== null)");
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).canAccept).toBe(false);
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).reason).toBe(
+            "Cannot attach an optional output to a required parameter",
+        );
+    });
+    it("rejects optional parameter -> required parameter when the gate runs the step while the input is absent", () => {
+        const integerInputParam = terminals["multi data"]!["advanced|advanced_threshold"] as InputParameterTerminal;
+        const optionalIntegerOutputParam = terminals["optional integer parameter input"]![
+            "output"
+        ] as OutputParameterTerminal;
+        stepStore.updateStepValue(integerInputParam.stepId, "when", "$(inputs.advanced.advanced_threshold === null)");
         expect(integerInputParam.canAccept(optionalIntegerOutputParam).canAccept).toBe(false);
         expect(integerInputParam.canAccept(optionalIntegerOutputParam).reason).toBe(
             "Cannot attach an optional output to a required parameter",
@@ -997,5 +1053,192 @@ describe("producesAcceptableDatatype", () => {
         expect(producesAcceptableDatatype(testDatatypesMapper, ["txt"], ["ab1"]).reason).toBe(
             "Effective output data type(s) [ab1] do not appear to match input type(s) [txt].",
         );
+    });
+});
+
+describe("invalid connection marking", () => {
+    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
+    let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    let connectionStore: ReturnType<typeof useConnectionStore>;
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        terminals = setupAdvanced();
+        stepStore = useWorkflowStepStore("mock-workflow");
+        connectionStore = useConnectionStore("mock-workflow");
+        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
+            stepStore.addStep(step);
+        });
+    });
+
+    function connectOptionalDataToRequiredInput() {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        dataIn.connect(optionalDataOut);
+        return { optionalDataOut, dataIn };
+    }
+
+    it("marks an ungated optional data connection invalid", () => {
+        const { optionalDataOut, dataIn } = connectOptionalDataToRequiredInput();
+        expect(dataIn.getInvalidConnectedTerminals()).toHaveLength(1);
+        expect(optionalDataOut.getInvalidConnectedTerminals()).toHaveLength(1);
+        expect(Object.keys(connectionStore.invalidConnections)).toHaveLength(1);
+    });
+
+    it("leaves a gated optional data connection alone", () => {
+        const { optionalDataOut, dataIn } = connectOptionalDataToRequiredInput();
+        stepStore.updateStepValue(dataIn.stepId, "when", "$(inputs.input !== null)");
+        expect(dataIn.getInvalidConnectedTerminals()).toHaveLength(0);
+        expect(optionalDataOut.getInvalidConnectedTerminals()).toHaveLength(0);
+        expect(Object.keys(connectionStore.invalidConnections)).toHaveLength(0);
+    });
+});
+
+describe("canAcceptWithPresenceGate", () => {
+    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
+    let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        terminals = setupAdvanced();
+        stepStore = useWorkflowStepStore("mock-workflow");
+        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
+            stepStore.addStep(step);
+        });
+    });
+
+    it("accepts an optional output the step is not yet gated on", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(false);
+        expect(dataIn.canAcceptWithPresenceGate(optionalDataOut).canAccept).toBe(true);
+    });
+
+    it("leaves the terminal ungated afterwards", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        dataIn.canAcceptWithPresenceGate(optionalDataOut);
+        expect(dataIn.isPresenceGated()).toBe(false);
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(false);
+    });
+
+    it("still refuses a connection a gate would not rescue", () => {
+        const dataOut = terminals["data input"]!["output"] as OutputTerminal;
+        const collectionInput = terminals["any collection"]!["input"] as InputCollectionTerminal;
+        expect(collectionInput.canAcceptWithPresenceGate(dataOut).canAccept).toBe(false);
+        expect(collectionInput.canAcceptWithPresenceGate(dataOut).reason).toBe(
+            "Cannot attach a data output to a collection input.",
+        );
+    });
+
+    it("still refuses when the input is already filled", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataOut = terminals["data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        dataIn.connect(dataOut);
+        expect(dataIn.canAcceptWithPresenceGate(optionalDataOut).canAccept).toBe(false);
+    });
+
+    it("works for parameter terminals too", () => {
+        const integerInputParam = terminals["multi data"]!["advanced|advanced_threshold"] as InputParameterTerminal;
+        const optionalIntegerOutputParam = terminals["optional integer parameter input"]![
+            "output"
+        ] as OutputParameterTerminal;
+        expect(integerInputParam.canAccept(optionalIntegerOutputParam).canAccept).toBe(false);
+        expect(integerInputParam.canAcceptWithPresenceGate(optionalIntegerOutputParam).canAccept).toBe(true);
+    });
+});
+
+describe("canAcceptWithPresenceGate spellability", () => {
+    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        terminals = setupAdvanced();
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
+            stepStore.addStep(step);
+        });
+    });
+
+    it("offers a gate for an input nested in a repeat", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const repeatIn = terminals["multiple simple data"]!["queries_0|input2"] as InputTerminal;
+        expect(repeatIn.canAccept(optionalDataOut).canAccept).toBe(false);
+        expect(repeatIn.canAcceptWithPresenceGate(optionalDataOut).canAccept).toBe(true);
+    });
+
+    it("declines to offer a gate for a step that already has one", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        stepStore.updateStepValue(dataIn.stepId, "when", "$(inputs.unrelated)");
+        expect(dataIn.canAccept(optionalDataOut).canAccept).toBe(false);
+        expect(dataIn.canAcceptWithPresenceGate(optionalDataOut).canAccept).toBe(false);
+    });
+
+    it("offers a gate for an input nested in a conditional", () => {
+        const optionalIntegerOut = terminals["optional integer parameter input"]!["output"] as OutputParameterTerminal;
+        const nestedIn = terminals["multi data"]!["advanced|advanced_threshold"] as InputParameterTerminal;
+        expect(nestedIn.canAcceptWithPresenceGate(optionalIntegerOut).canAccept).toBe(true);
+    });
+});
+
+describe("twin dispatch acceptance", () => {
+    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
+    let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        terminals = setupAdvanced();
+        stepStore = useWorkflowStepStore("mock-workflow");
+        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
+            stepStore.addStep(step);
+        });
+    });
+
+    function gatedTwin(when: string, gatedSource: OutputTerminal) {
+        const gatedIn = terminals["multiple simple data"]!["input1"] as InputTerminal;
+        const consumingIn = terminals["multiple simple data"]!["queries_0|input2"] as InputTerminal;
+        gatedIn.connect(gatedSource);
+        stepStore.updateStepValue(gatedIn.stepId, "when", when);
+        return consumingIn;
+    }
+
+    it("accepts an output the step already gates on through another input", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const consumingIn = gatedTwin("$(inputs.input1 !== null)", optionalDataOut);
+        // The gate does not name this input, but the step cannot run while the shared
+        // source is absent, so the value is never consumed missing.
+        expect(consumingIn.attachable(optionalDataOut).canAccept).toBe(true);
+    });
+
+    it("refuses when the gate runs the step while the shared source is absent", () => {
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const consumingIn = gatedTwin("$(inputs.input1 === null)", optionalDataOut);
+        expect(consumingIn.attachable(optionalDataOut).canAccept).toBe(false);
+    });
+
+    it("refuses when the gated input is fed by a different source", () => {
+        const requiredDataOut = terminals["data input"]!["output"] as OutputTerminal;
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const consumingIn = gatedTwin("$(inputs.input1 !== null)", requiredDataOut);
+        expect(consumingIn.attachable(optionalDataOut).canAccept).toBe(false);
+    });
+
+    it("refuses a twin connection when the gate probe has a second source", () => {
+        const requiredDataOut = terminals["data input"]!["output"] as OutputTerminal;
+        const optionalDataOut = terminals["optional data input"]!["output"] as OutputTerminal;
+        const consumingIn = terminals["multiple simple data"]!["queries_0|input2"] as InputTerminal;
+        const step = stepStore.getStep(consumingIn.stepId)!;
+        stepStore.updateStep({
+            ...step,
+            when: "$(inputs.probe !== null)",
+            input_connections: {
+                ...step.input_connections,
+                probe: [
+                    { id: optionalDataOut.stepId, output_name: optionalDataOut.name },
+                    { id: requiredDataOut.stepId, output_name: requiredDataOut.name },
+                ],
+            },
+        });
+
+        expect(consumingIn.attachable(optionalDataOut).canAccept).toBe(false);
     });
 });

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -9,8 +9,12 @@ import {
     type DataOutput,
     type DataStepInput,
     getCombinedStepInputs,
+    normalizeConnectionOutputLinks,
     type ParameterOutput,
     type ParameterStepInput,
+    presenceGateInputPath,
+    presenceGateIsSpellable,
+    type Step,
     type TerminalSource,
 } from "@/stores/workflowStepStore";
 import type { Connection, ConnectionId } from "@/stores/workflowStoreTypes";
@@ -23,6 +27,7 @@ import {
     NULL_COLLECTION_TYPE_DESCRIPTION,
 } from "./collectionTypeDescription";
 import { applyCompaction, computePickValueCompaction, reverseCompaction } from "./pickValueCompact";
+import { expressionGuardsInputPresence, expressionReferencesInput } from "./whenExpression";
 
 export const NO_COLLECTION_TYPE_INFORMATION_MESSAGE =
     "No collection type or collection type source defined - this is fine but may lead to less intuitive connection logic.";
@@ -222,6 +227,7 @@ class BaseInputTerminal extends Terminal {
     datatypes: InputTerminalInputs["datatypes"];
     optional: InputTerminalInputs["optional"];
     localMapOver: CollectionTypeDescriptor;
+    private presenceGateAssumed = false;
 
     constructor(attr: InputTerminalArgs) {
         super(attr);
@@ -236,6 +242,79 @@ class BaseInputTerminal extends Terminal {
         } else {
             this.localMapOver = NULL_COLLECTION_TYPE_DESCRIPTION;
         }
+    }
+    /**
+     * Evaluate acceptance as though the step were already gated on this input.
+     *
+     * A drop cannot authorize itself: at drop time there is no `when` yet, so the rule
+     * that would allow the connection has nothing to read. This answers whether writing
+     * the gate is the remedy, or whether the connection is refused for other reasons.
+     */
+    canAcceptWithPresenceGate(other: BaseOutputTerminal): ConnectionAcceptable {
+        const step = this.stores.stepStore.getStep(this.stepId);
+        if (!step || (step.type !== "tool" && step.type !== "subworkflow")) {
+            return new ConnectionAcceptable(false, "This step type cannot run conditionally.");
+        }
+        if (!presenceGateIsSpellable(step, this.name)) {
+            return new ConnectionAcceptable(false, "No presence gate can be written for this input.");
+        }
+        if (step.when) {
+            // Writing one here would replace a condition the author already chose.
+            return new ConnectionAcceptable(false, "This step already has a condition.");
+        }
+        this.presenceGateAssumed = true;
+        try {
+            return this.canAccept(other);
+        } finally {
+            this.presenceGateAssumed = false;
+        }
+    }
+    /**
+     * True when the editor can treat this input as presence-gated.
+     *
+     * Generated gates are decisive. Hand-written gates follow the analyzer's permissive
+     * policy: accept a reference unless it is known to run while the input is absent.
+     */
+    isPresenceGated(other?: BaseOutputTerminal): boolean {
+        if (this.presenceGateAssumed) {
+            return true;
+        }
+        const step = this.stores.stepStore.getStep(this.stepId);
+        if (!step?.when) {
+            return false;
+        }
+        const isSynthesizedGatePort = !step.inputs?.some((input) => input.name === this.name);
+        const inputPath = presenceGateInputPath(step, this.name);
+        if (!inputPath) {
+            return false;
+        }
+        if (isSynthesizedGatePort) {
+            // Nothing consumes a gate probe, so an inverse gate is as valid as a positive one.
+            return expressionReferencesInput(step.when, inputPath);
+        }
+        if (expressionGuardsInputPresence(step.when, inputPath)) {
+            return true;
+        }
+        return other ? this.gatedThroughSharedSource(step, other) : false;
+    }
+    /**
+     * The twin dispatch shape: the gate names a different input of this step, but one fed
+     * solely by the output being attached. Apply the same presence-gate decision to that
+     * probe, because it and this input become absent together.
+     */
+    private gatedThroughSharedSource(step: Step, other: BaseOutputTerminal): boolean {
+        return Object.entries(step.input_connections ?? {}).some(([name, links]) => {
+            const inputPath = presenceGateInputPath(step, name);
+            if (name === this.name || !inputPath || !expressionGuardsInputPresence(step.when, inputPath)) {
+                return false;
+            }
+            const linkArray = normalizeConnectionOutputLinks(links);
+            // A second source could keep the probe present while `other` is absent, so
+            // only a single-source probe establishes the twin relationship.
+            return (
+                linkArray.length === 1 && linkArray[0]!.id === other.stepId && linkArray[0]!.output_name === other.name
+            );
+        });
     }
     connect(other: BaseOutputTerminal): void {
         super.connect(other);
@@ -375,7 +454,7 @@ class BaseInputTerminal extends Terminal {
         return producesAcceptableDatatype(this.datatypesMapper, this.datatypes, other.datatypes);
     }
     _producesAcceptableDatatypeAndOptionalness(other: BaseOutputTerminal) {
-        if (!this.optional && !this.multiple && other.optional) {
+        if (!this.optional && !this.multiple && other.optional && !this.isPresenceGated(other)) {
             return new ConnectionAcceptable(false, "Cannot connect an optional output to a non-optional input");
         }
         return this._producesAcceptableDatatype(other);
@@ -582,7 +661,7 @@ export class InputParameterTerminal extends BaseInputTerminal {
         const effectiveThisType = this.effectiveType(this.type);
         const otherType = ("type" in other && other.type) || "data";
         const effectiveOtherType = this.effectiveType(otherType);
-        if (!this.optional && other.optional) {
+        if (!this.optional && other.optional && !this.isPresenceGated(other)) {
             return new ConnectionAcceptable(false, `Cannot attach an optional output to a required parameter`);
         }
         const canAccept = effectiveThisType === effectiveOtherType;

--- a/client/src/components/Workflow/Editor/modules/useLinting.ts
+++ b/client/src/components/Workflow/Editor/modules/useLinting.ts
@@ -8,13 +8,16 @@ import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Steps } from "@/stores/workflowStepStore";
 
 import {
+    getDanglingGates,
     getDisconnectedInputs,
     getDuplicateLabels,
     getMissingMetadata,
     getUnlabeledOutputs,
     getUntypedParameters,
+    hasGatedSteps,
 } from "./linting";
 import type {
+    DanglingGateState,
     DisconnectedInputState,
     DuplicateLabelState,
     MetadataLintState,
@@ -36,6 +39,7 @@ export interface LintData {
     untypedParameters: Ref<UntypedParameters | undefined>;
     untypedParameterWarnings: Ref<UntypedParameterState[]>;
     disconnectedInputs: Ref<DisconnectedInputState[]>;
+    danglingGates: Ref<DanglingGateState[]>;
     duplicateLabels: Ref<DuplicateLabelState[]>;
     unlabeledOutputs: Ref<UnlabeledOuputState[]>;
     missingMetadata: Ref<MetadataLintState[]>;
@@ -55,6 +59,7 @@ export function useLintData(
     const untypedParameters = ref<UntypedParameters>();
     const untypedParameterWarnings = ref<UntypedParameterState[]>([]);
     const disconnectedInputs = ref<DisconnectedInputState[]>([]);
+    const danglingGates = ref<DanglingGateState[]>([]);
     const duplicateLabels = ref<DuplicateLabelState[]>([]);
     const unlabeledOutputs = ref<UnlabeledOuputState[]>([]);
     const missingMetadata = ref<MetadataLintState[]>([]);
@@ -65,6 +70,7 @@ export function useLintData(
                 untypedParameters.value = getUntypedWorkflowParameters(steps.value);
                 untypedParameterWarnings.value = getUntypedParameters(untypedParameters.value);
                 disconnectedInputs.value = getDisconnectedInputs(steps.value, datatypesMapper.value, workflowStores);
+                danglingGates.value = getDanglingGates(steps.value);
                 duplicateLabels.value = getDuplicateLabels(steps.value, workflowStores);
                 unlabeledOutputs.value = getUnlabeledOutputs(steps.value);
                 missingMetadata.value = getMissingMetadata(steps.value);
@@ -131,6 +137,12 @@ export function useLintData(
             priority: "high",
         },
         {
+            name: "danglingGates",
+            exists: hasGatedSteps(steps.value),
+            resolved: danglingGates.value.length === 0,
+            priority: "high",
+        },
+        {
             name: "missingMetadata",
             exists: hasInputSteps.value,
             resolved: missingMetadata.value.length === 0,
@@ -189,6 +201,7 @@ export function useLintData(
         untypedParameters,
         untypedParameterWarnings,
         disconnectedInputs,
+        danglingGates,
         duplicateLabels,
         unlabeledOutputs,
         missingMetadata,

--- a/client/src/components/Workflow/Editor/modules/whenExpression.test.ts
+++ b/client/src/components/Workflow/Editor/modules/whenExpression.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import GENERATED_PRESENCE_CONDITIONS from "./generated_presence_conditions.yml";
 import EXPRESSION_SPECIFICATIONS from "./when_expression_spec.yml";
-import { analyzeInputReferences, expressionReferencesInput } from "./whenExpression";
+import {
+    analyzeInputReferences,
+    classifyWhenInputIsNull,
+    expressionGuardsInputPresence,
+    expressionReferencesInput,
+    type NullBehavior,
+    presenceGateExpression,
+} from "./whenExpression";
 import type { InputPath } from "./workflowInputPath";
 
 type InputTarget = string | InputPath;
@@ -10,6 +18,8 @@ interface ExpressionExpectations {
     static_paths?: InputPath[];
     dynamic?: boolean;
     references_input?: boolean;
+    null_behavior?: NullBehavior;
+    guards_presence?: boolean;
 }
 
 interface ExpressionSpecification {
@@ -19,7 +29,14 @@ interface ExpressionSpecification {
     expect: ExpressionExpectations;
 }
 
+interface GeneratedConditionSpecification {
+    doc: string;
+    input: InputTarget;
+    expression: string;
+}
+
 const EXPRESSIONS = EXPRESSION_SPECIFICATIONS as ExpressionSpecification[];
+const GENERATED_CONDITIONS = GENERATED_PRESENCE_CONDITIONS as GeneratedConditionSpecification[];
 
 function requireInput(specification: ExpressionSpecification): InputTarget {
     if (specification.input === undefined) {
@@ -48,12 +65,41 @@ describe("when expression specification", () => {
                     expected.references_input,
                 );
             }
+            if (expected.null_behavior !== undefined) {
+                expect(classifyWhenInputIsNull(expression, requireInput(specification))).toBe(expected.null_behavior);
+            }
+            if (expected.guards_presence !== undefined) {
+                expect(expressionGuardsInputPresence(expression, requireInput(specification))).toBe(
+                    expected.guards_presence,
+                );
+            }
+        });
+    }
+});
+
+describe("generated presence conditions", () => {
+    for (const specification of GENERATED_CONDITIONS) {
+        it(specification.doc, () => {
+            const expression = presenceGateExpression(specification.input);
+            expect(expression).toBe(specification.expression);
+            expect(expressionReferencesInput(expression, specification.input)).toBe(true);
+            expect(classifyWhenInputIsNull(expression, specification.input)).toBe("false-when-null");
+            expect(expressionGuardsInputPresence(expression, specification.input)).toBe(true);
         });
     }
 });
 
 describe("analyzer failure boundaries", () => {
-    it("reports no references when no expression is present", () => {
+    it("returns conservative answers when no expression is present", () => {
         expect(expressionReferencesInput(undefined, "input1")).toBe(false);
+        expect(expressionGuardsInputPresence(undefined, "input1")).toBe(false);
+        expect(classifyWhenInputIsNull(undefined, "input1")).toBe("unknown");
+    });
+
+    it("survives an expression deep enough to exhaust the stack", () => {
+        const deep = `$(${"(".repeat(20000)}inputs.a${")".repeat(20000)} !== null)`;
+        expect(() => classifyWhenInputIsNull(deep, "a")).not.toThrow();
+        expect(classifyWhenInputIsNull(deep, "a")).toBe("unknown");
+        expect(() => expressionGuardsInputPresence(deep, "a")).not.toThrow();
     });
 });

--- a/client/src/components/Workflow/Editor/modules/whenExpression.ts
+++ b/client/src/components/Workflow/Editor/modules/whenExpression.ts
@@ -4,7 +4,8 @@
  * Galaxy addresses connected tool inputs by flat, pipe-prefixed connection names
  * (`cond|input1`), while a `when` expression walks nested tool state
  * (`inputs.cond.input1`). These helpers bridge the two representations so the editor can
- * reason about which inputs an expression reads.
+ * reason about which inputs a gate reads and how the gate behaves when one of them is
+ * absent.
  *
  * Nothing here executes user JavaScript. Expressions that are not structurally
  * recognized are reported as unknown, and callers are expected to resolve unknown
@@ -32,7 +33,26 @@ export interface ReferenceAnalysis {
     hasDynamicInputsAccess: boolean;
 }
 
+export type NullBehavior = "false-when-null" | "true-when-null" | "unknown";
+
 const PUNCTUATORS = ["===", "!==", "==", "!=", "&&", "||", "!", "(", ")", "[", "]", ".", ",", "?", ":"];
+
+// `UNKNOWN` has unknown value and truthiness. The other two retain only the
+// truthiness established by short-circuit evaluation; equality must still treat their
+// exact values as indeterminate.
+const UNKNOWN = Symbol("unknown");
+const TRUTHY_UNKNOWN = Symbol("truthy-unknown");
+const FALSY_UNKNOWN = Symbol("falsy-unknown");
+
+type EvaluatedValue =
+    | typeof UNKNOWN
+    | typeof TRUTHY_UNKNOWN
+    | typeof FALSY_UNKNOWN
+    | string
+    | number
+    | boolean
+    | null
+    | undefined;
 
 /** Tokenize a JavaScript-ish expression, or return null when it cannot be scanned. */
 function tokenize(expression: string): Token[] | null {
@@ -252,6 +272,10 @@ function readAccessPath(tokens: Token[], start: number): AccessPath {
     }
 }
 
+function isSamePath(targetPath: InputPath, referencedPath: InputPath): boolean {
+    return targetPath.length === referencedPath.length && inputPathIsPrefix(targetPath, referencedPath);
+}
+
 /**
  * True when the expression could read the named connection.
  *
@@ -277,6 +301,303 @@ export function expressionReferencesInput(
     return references.staticPaths.some((referencedPath) => inputPathIsPrefix(targetPath, referencedPath));
 }
 
+/**
+ * Decide how the expression behaves when the named connection carries no value.
+ *
+ * Evaluates a small, side-effect-free subset of JavaScript — literals, `inputs`
+ * accesses, `!`, equality, and `&&`/`||` — with the target bound to `null` and every
+ * other input left indeterminate. Anything outside that subset is `"unknown"`.
+ */
+export function classifyWhenInputIsNull(
+    expression: string | null | undefined,
+    input: string | readonly InputPathSegment[],
+): NullBehavior {
+    if (!expression) {
+        return "unknown";
+    }
+
+    const trimmed = expression.trim();
+    if (isTemplateLiteral(trimmed)) {
+        return "unknown";
+    }
+
+    const tokens = tokenize(trimmed);
+    // Galaxy `when` expressions are a `$(...)` body.
+    if (!tokens || tokens[0]?.value !== "$" || tokens[1]?.value !== "(") {
+        return "unknown";
+    }
+
+    const parser = new PresenceEvaluator(tokens, normalizeInputPath(input));
+    const value = parser.evaluate();
+    if (value === UNKNOWN) {
+        return "unknown";
+    }
+
+    return isTruthy(value) ? "true-when-null" : "false-when-null";
+}
+
+/**
+ * True when the editor should treat the expression as a presence guard for the input.
+ *
+ * This is deliberately permissive for existing, hand-written expressions: a gate that
+ * references the input is accepted unless the evaluator can prove it runs while the
+ * input is absent. The runtime remains authoritative for expressions classified as
+ * unknown.
+ */
+export function expressionGuardsInputPresence(
+    expression: string | null | undefined,
+    input: string | readonly InputPathSegment[],
+): boolean {
+    if (!expressionReferencesInput(expression, input)) {
+        return false;
+    }
+
+    return classifyWhenInputIsNull(expression, input) !== "true-when-null";
+}
+
+function isTruthy(value: Exclude<EvaluatedValue, typeof UNKNOWN>): boolean {
+    if (value === TRUTHY_UNKNOWN) {
+        return true;
+    }
+    if (value === FALSY_UNKNOWN) {
+        return false;
+    }
+    return Boolean(value);
+}
+
+/** Raised on anything the evaluator does not model; mapped to "unknown", never to a verdict. */
+class ParseFailure extends Error {}
+
+/** Recursive-descent evaluator over the recognized expression subset. */
+class PresenceEvaluator {
+    private tokens: Token[];
+    private targetPath: InputPath;
+    private position: number;
+
+    constructor(tokens: Token[], targetPath: InputPath) {
+        this.tokens = tokens;
+        this.targetPath = targetPath;
+        this.position = 2;
+    }
+
+    evaluate(): EvaluatedValue {
+        try {
+            const value = this.parseOr();
+            if (!this.consume(")") || !this.atEnd()) {
+                return UNKNOWN;
+            }
+            return value;
+        } catch {
+            // Including anything the recursive descent itself can raise, such as a
+            // RangeError on a deeply nested expression. Nothing escapes into the editor.
+            return UNKNOWN;
+        }
+    }
+
+    /** Only statement punctuation may follow the expression body. */
+    private atEnd(): boolean {
+        return this.tokens.slice(this.position).every((token) => token.value === ";");
+    }
+
+    private peek(): Token | undefined {
+        return this.tokens[this.position];
+    }
+
+    private consume(value: string): boolean {
+        if (this.peek()?.value === value) {
+            this.position++;
+            return true;
+        }
+        return false;
+    }
+
+    private parseOr(): EvaluatedValue {
+        let left = this.parseAnd();
+        while (this.consume("||")) {
+            const right = this.parseAnd();
+            left = combineOr(left, right);
+        }
+        return left;
+    }
+
+    private parseAnd(): EvaluatedValue {
+        let left = this.parseEquality();
+        while (this.consume("&&")) {
+            const right = this.parseEquality();
+            left = combineAnd(left, right);
+        }
+        return left;
+    }
+
+    private parseEquality(): EvaluatedValue {
+        let left = this.parseUnary();
+        for (;;) {
+            const operator = this.peek()?.value;
+            if (operator !== "===" && operator !== "!==" && operator !== "==" && operator !== "!=") {
+                return left;
+            }
+            this.position++;
+            const right = this.parseUnary();
+            left = compare(operator, left, right);
+        }
+    }
+
+    private parseUnary(): EvaluatedValue {
+        if (this.consume("!")) {
+            const value = this.parseUnary();
+            return value === UNKNOWN ? UNKNOWN : !isTruthy(value);
+        }
+        return this.parsePrimary();
+    }
+
+    private parsePrimary(): EvaluatedValue {
+        const token = this.peek();
+        if (!token) {
+            throw new ParseFailure("unexpected end of expression");
+        }
+
+        if (this.consume("(")) {
+            const value = this.parseOr();
+            if (!this.consume(")")) {
+                throw new ParseFailure("unbalanced parentheses");
+            }
+            return value;
+        }
+
+        if (token.type === "string") {
+            this.position++;
+            return token.value;
+        }
+
+        if (token.type === "number") {
+            this.position++;
+            return Number(token.value);
+        }
+
+        if (token.type === "identifier") {
+            return this.parseIdentifier(token);
+        }
+
+        throw new ParseFailure(`unrecognized token ${token.value}`);
+    }
+
+    private parseIdentifier(token: Token): EvaluatedValue {
+        this.position++;
+
+        switch (token.value) {
+            case "null":
+                return null;
+            case "undefined":
+                return undefined;
+            case "true":
+                return true;
+            case "false":
+                return false;
+        }
+
+        if (token.value !== "inputs") {
+            throw new ParseFailure(`unrecognized identifier ${token.value}`);
+        }
+
+        const path = readAccessPath(this.tokens, this.position);
+        this.position = path.next;
+        if (path.dynamic) {
+            throw new ParseFailure("dynamic inputs access");
+        }
+        // Only the target itself is known to be null. Reading a property *of* the target
+        // would throw at run time rather than yield a value, so it stays indeterminate.
+        if (isSamePath(this.targetPath, path.segments)) {
+            return null;
+        }
+        if (
+            inputPathIsPrefix(this.targetPath, path.segments) &&
+            path.optionalAfterSegments.includes(this.targetPath.length)
+        ) {
+            // `target?.property` short-circuits to undefined when target is null;
+            // the equivalent non-optional property read throws and remains unknown.
+            return undefined;
+        }
+        return UNKNOWN;
+    }
+}
+
+function combineAnd(left: EvaluatedValue, right: EvaluatedValue): EvaluatedValue {
+    if (left === UNKNOWN) {
+        // If the unknown left side is falsy, JavaScript returns that falsy value;
+        // otherwise it returns `right`. A falsy right therefore settles the result's
+        // truthiness even though its exact value is unknown.
+        return right !== UNKNOWN && !isTruthy(right) ? FALSY_UNKNOWN : UNKNOWN;
+    }
+    return isTruthy(left) ? right : left;
+}
+
+function combineOr(left: EvaluatedValue, right: EvaluatedValue): EvaluatedValue {
+    if (left === UNKNOWN) {
+        // Symmetrically, a truthy right side makes `unknown || right` truthy for
+        // either possible truthiness of the left side.
+        return right !== UNKNOWN && isTruthy(right) ? TRUTHY_UNKNOWN : UNKNOWN;
+    }
+    return isTruthy(left) ? left : right;
+}
+
+function compare(operator: string, left: EvaluatedValue, right: EvaluatedValue): EvaluatedValue {
+    if (isIndeterminate(left) || isIndeterminate(right)) {
+        return UNKNOWN;
+    }
+
+    const strict = left === right;
+    if (operator === "===") {
+        return strict;
+    }
+    if (operator === "!==") {
+        return !strict;
+    }
+
+    // Loose equality across types has its own coercion rules -- `1 == "1"` is true.
+    // Decide it only where coercion cannot apply.
+    let loose: boolean;
+    if (isNullish(left) || isNullish(right)) {
+        loose = isNullish(left) && isNullish(right);
+    } else if (typeof left === typeof right) {
+        loose = strict;
+    } else {
+        return UNKNOWN;
+    }
+
+    return operator === "==" ? loose : !loose;
+}
+
+function isNullish(value: Exclude<EvaluatedValue, typeof UNKNOWN>): boolean {
+    return value === null || value === undefined;
+}
+
+function isIndeterminate(
+    value: EvaluatedValue,
+): value is typeof UNKNOWN | typeof TRUTHY_UNKNOWN | typeof FALSY_UNKNOWN {
+    return value === UNKNOWN || value === TRUTHY_UNKNOWN || value === FALSY_UNKNOWN;
+}
+
+const JAVASCRIPT_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
 function normalizeInputPath(input: string | readonly InputPathSegment[]): InputPath {
     return typeof input === "string" ? connectionNameToInputPath(input) : [...input];
 }
+
+/** Spell an input path as a JavaScript access path into `inputs`. */
+export function inputsAccessPath(input: string | readonly InputPathSegment[]): string {
+    return normalizeInputPath(input).reduce<string>((path, segment) => {
+        if (typeof segment === "number") {
+            return `${path}[${segment}]`;
+        }
+        return JAVASCRIPT_IDENTIFIER.test(segment) ? `${path}.${segment}` : `${path}[${JSON.stringify(segment)}]`;
+    }, "inputs");
+}
+
+/** The `when` expression that runs a step only while the addressed input carries a value. */
+export function presenceGateExpression(input: string | readonly InputPathSegment[]): string {
+    return `$(${inputsAccessPath(input)} !== null)`;
+}
+
+/** The established workflow-editor convention for a direct boolean gate. */
+export const BOOLEAN_GATE_INPUT_NAME = "when";
+export const BOOLEAN_GATE_EXPRESSION = `$(inputs.${BOOLEAN_GATE_INPUT_NAME})`;

--- a/client/src/components/Workflow/Editor/modules/when_expression_spec.yml
+++ b/client/src/components/Workflow/Editor/modules/when_expression_spec.yml
@@ -5,6 +5,8 @@
     static_paths: [[cond, input1]] # Statically resolved paths read from `inputs`.
     dynamic: false # Whether some `inputs` access cannot be resolved statically.
     references_input: true # Whether the expression reads the declared `input`.
+    null_behavior: false-when-null # Expression truthiness when that input is null.
+    guards_presence: true # Whether it prevents running when the input is absent.
 
 - doc: Chained bracket access identifies a nested input
   expression: '$(inputs["cond"]["input1"])'
@@ -31,6 +33,7 @@
     static_paths: [["cond|input1"]]
     dynamic: false
     references_input: false
+    guards_presence: false
 
 - doc: A numeric bracket identifies an item inside a repeat
   expression: $(inputs.queries[0].input2)
@@ -39,6 +42,8 @@
     static_paths: [[queries, 0, input2]]
     dynamic: false
     references_input: true
+    null_behavior: false-when-null
+    guards_presence: true
 
 - doc: Every root input access is collected
   expression: $(inputs.a && inputs.b)
@@ -71,6 +76,8 @@
     static_paths: []
     dynamic: true
     references_input: true
+    null_behavior: unknown
+    guards_presence: true
 
 - doc: A bare inputs reference cannot be resolved statically
   expression: $(Object.keys(inputs).length)
@@ -94,6 +101,8 @@
   input: cond|input1
   expect:
     references_input: true
+    null_behavior: false-when-null
+    guards_presence: true
 
 - doc: A condition on a nested property also references its ancestor connection
   expression: $(inputs.cond.input1 !== null)
@@ -101,23 +110,87 @@
   expect:
     references_input: true
 
+- doc: A loose null check also handles an absent nested input
+  expression: '$(inputs["cond"]["input1"] != null)'
+  input: cond|input1
+  expect:
+    null_behavior: false-when-null
+    guards_presence: true
+
+- doc: Double negation is false when the input is absent
+  expression: $(!!inputs.cond.input1)
+  input: cond|input1
+  expect:
+    null_behavior: false-when-null
+    guards_presence: true
+
+- doc: A presence check remains safe when combined with another condition using and
+  expression: $(inputs.cond.input1 !== null && inputs.force)
+  input: cond|input1
+  expect:
+    null_behavior: false-when-null
+    guards_presence: true
+
+- doc: An inverse presence condition is true when the input is absent
+  expression: $(inputs.cond.input1 === null)
+  input: cond|input1
+  expect:
+    null_behavior: true-when-null
+    guards_presence: false
+
+- doc: A loose inverse presence condition is true when the input is absent
+  expression: $(inputs.cond.input1 == null)
+  input: cond|input1
+  expect:
+    null_behavior: true-when-null
+
+- doc: Negating the input is true when it is absent
+  expression: $(!inputs.cond.input1)
+  input: cond|input1
+  expect:
+    null_behavior: true-when-null
+
+- doc: An inverse condition remains true when combined with another condition using or
+  expression: $(inputs.cond.input1 === null || inputs.force)
+  input: cond|input1
+  expect:
+    null_behavior: true-when-null
+    guards_presence: false
+
 - doc: An unsupported helper call is handled permissively
   expression: $(helper(inputs.cond.input1))
   input: cond|input1
   expect:
     references_input: true
+    null_behavior: unknown
+    guards_presence: true
+
+- doc: A presence check combined with or cannot prove what happens when the input is absent
+  expression: $(inputs.cond.input1 !== null || inputs.force)
+  input: cond|input1
+  expect:
+    null_behavior: unknown
+
+- doc: A JavaScript block is not treated as a simple condition body
+  expression: '${ return inputs.cond.input1 !== null; }'
+  input: cond|input1
+  expect:
+    null_behavior: unknown
 
 - doc: A condition on another input does not reference the target
   expression: $(inputs.other !== null)
   input: cond|input1
   expect:
     references_input: false
+    null_behavior: unknown
+    guards_presence: false
 
 - doc: Similar property names are compared as complete path segments
   expression: $(inputs.cond.input10 !== null)
   input: cond|input1
   expect:
     references_input: false
+    guards_presence: false
 
 - doc: Similar top-level names are compared as complete path segments
   expression: $(inputs.input10 !== null)
@@ -130,18 +203,72 @@
   input: reference
   expect:
     references_input: true
+    null_behavior: unknown
+    guards_presence: true
+
+- doc: Strictly comparing a property of an absent input is also indeterminate
+  expression: '$(inputs.reference.format === "x")'
+  input: reference
+  expect:
+    null_behavior: unknown
 
 - doc: Optional chaining to a property produces undefined when the input is absent
   expression: $(inputs.reference?.format !== null)
   input: reference
   expect:
     references_input: true
+    null_behavior: true-when-null
+    guards_presence: false
+
+- doc: Optional chaining can explicitly detect undefined
+  expression: $(inputs.reference?.format === undefined)
+  input: reference
+  expect:
+    null_behavior: true-when-null
+
+- doc: Optional chaining does not produce null when the input is absent
+  expression: $(inputs.reference?.format === null)
+  input: reference
+  expect:
+    null_behavior: false-when-null
+
+- doc: Cross-type loose comparisons remain unknown
+  expression: "$(1 == '1' && inputs.cond.input1 === null)"
+  input: cond|input1
+  expect:
+    null_behavior: unknown
 
 - doc: An unrelated cross-type comparison prevents a presence condition from being proven
   expression: '$(inputs.a !== null || 0 == "")'
   input: a
   expect:
     references_input: true
+    null_behavior: unknown
+    guards_presence: true
+
+- doc: Same-type loose equality with null is understood
+  expression: $(inputs.a == null)
+  input: a
+  expect:
+    null_behavior: true-when-null
+
+- doc: Same-type loose inequality with null is understood
+  expression: $(inputs.a != null)
+  input: a
+  expect:
+    null_behavior: false-when-null
+
+- doc: Logical or yields its surviving operand
+  expression: $((inputs.a || inputs.a) !== null)
+  input: a
+  expect:
+    null_behavior: false-when-null
+
+- doc: Logical and yields its surviving operand
+  expression: $((inputs.a && inputs.a) === null)
+  input: a
+  expect:
+    null_behavior: true-when-null
 
 - doc: Optional chaining through a nested group still identifies the input
   expression: $(inputs.cond?.input1 === null)
@@ -149,6 +276,7 @@
   expect:
     static_paths: [[cond, input1]]
     references_input: true
+    null_behavior: true-when-null
 
 - doc: Input-like text inside a regular expression is ignored while real code is retained
   expression: $(/inputs.zzz/.test(inputs.a))
@@ -164,8 +292,60 @@
     dynamic: false
     references_input: false
 
+- doc: An inverse condition is recognized after an indeterminate or operand
+  expression: $(inputs.force || inputs.a === null)
+  input: a
+  expect:
+    null_behavior: true-when-null
+    guards_presence: false
+
+- doc: A known false left branch does not obscure an inverse condition
+  expression: $((inputs.force && false) || inputs.a === null)
+  input: a
+  expect:
+    null_behavior: true-when-null
+
+- doc: Known truthiness is not mistaken for the exact boolean true
+  expression: $((inputs.force || true) === true && inputs.a === null)
+  input: a
+  expect:
+    null_behavior: unknown
+
+- doc: Known falsiness is not mistaken for the exact boolean false
+  expression: $((inputs.force && false) === false && inputs.a === null)
+  input: a
+  expect:
+    null_behavior: unknown
+
+- doc: A semicolon after the condition body is harmless
+  expression: $(inputs.a === null);
+  input: a
+  expect:
+    null_behavior: true-when-null
+    guards_presence: false
+
+- doc: A trailing comment after the condition body is harmless
+  expression: $(inputs.a === null) // trailing
+  input: a
+  expect:
+    null_behavior: true-when-null
+
+- doc: A truncated condition remains unknown
+  expression: $(inputs.a === null
+  input: a
+  expect:
+    null_behavior: unknown
+
+- doc: Extra code after the condition body remains unknown
+  expression: $(inputs.a === null)) extra
+  input: a
+  expect:
+    null_behavior: unknown
+
 - doc: An empty expression references and protects no input
   expression: ''
   input: input1
   expect:
     references_input: false
+    null_behavior: unknown
+    guards_presence: false

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -6,6 +6,9 @@ import {
     getCombinedStepInputs,
     type InputTerminalSource,
     type NewStep,
+    normalizeConnectionOutputLinks,
+    presenceGateIsSpellable,
+    type Step,
     type StepInputConnection,
     useWorkflowStepStore,
 } from "@/stores/workflowStepStore";
@@ -32,6 +35,19 @@ const workflowStepZero: NewStep = {
 };
 
 const workflowStepOne: NewStep = { ...workflowStepZero, input_connections: stepInputConnection };
+
+describe("normalizeConnectionOutputLinks", () => {
+    const link = { output_name: "output", id: 0 };
+
+    it("normalizes absent, single, and multiple persisted connections", () => {
+        expect(normalizeConnectionOutputLinks(undefined)).toEqual([]);
+        expect(normalizeConnectionOutputLinks(link)).toEqual([link]);
+        expect(normalizeConnectionOutputLinks([link, { output_name: "other", id: 1 }])).toEqual([
+            link,
+            { output_name: "other", id: 1 },
+        ]);
+    });
+});
 
 describe("Connection Store", () => {
     beforeEach(() => {
@@ -141,19 +157,6 @@ describe("getCombinedStepInputs", () => {
         expect(combinedInputs[1]?.name).toBe("input_dataset");
     });
 
-    it("does not confuse a connection name with a longer referenced input", () => {
-        const stepStore = useWorkflowStepStore("mock-workflow");
-        stepStore.addStep(workflowStepZero);
-        const step = stepStore.addStep(
-            createTestStep(1, {
-                when: "$(inputs.check_value)",
-                inputConnections: { check: { output_name: "output", id: 0 } },
-            }),
-        );
-
-        expect(getCombinedStepInputs(step, stepStore)).toHaveLength(0);
-    });
-
     it("handles step with no inputs gracefully", () => {
         const stepStore = useWorkflowStepStore("mock-workflow");
         const step = stepStore.addStep(workflowStepZero); // Step with empty inputs
@@ -161,5 +164,225 @@ describe("getCombinedStepInputs", () => {
         const combinedInputs = getCombinedStepInputs(step, stepStore);
 
         expect(combinedInputs).toHaveLength(0);
+    });
+});
+
+describe("synthesized gate ports", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    const optionalDataInput: NewStep = {
+        ...workflowStepZero,
+        id: 0,
+        type: "data_input",
+        outputs: [{ name: "output", extensions: ["input"], optional: true }],
+    };
+
+    const booleanParameterInput: NewStep = {
+        ...workflowStepZero,
+        id: 0,
+        type: "parameter_input",
+        outputs: [{ name: "output", optional: false, type: "boolean", parameter: true, multiple: false }],
+    } as NewStep;
+
+    function gatePort(source: NewStep, when: string, connectionName = "probe") {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        stepStore.addStep(source);
+        const gated = addProbeGatedStep(stepStore, when, connectionName);
+        return stepStore.getStepExtraInputs(gated.id);
+    }
+
+    function addProbeGatedStep(
+        stepStore: ReturnType<typeof useWorkflowStepStore>,
+        when = "$(inputs.probe !== null)",
+        connectionName = "probe",
+    ) {
+        return stepStore.addStep(
+            createTestStep(1, {
+                when,
+                inputConnections: { [connectionName]: { output_name: "output", id: 0 } },
+            }),
+        );
+    }
+
+    it("types a data probe as a dataset terminal carrying its source's optionality", () => {
+        const ports = gatePort(optionalDataInput, "$(inputs.probe !== null)");
+        expect(ports).toHaveLength(1);
+        expect(ports[0]).toMatchObject({
+            name: "probe",
+            input_type: "dataset",
+            optional: true,
+            extensions: ["input"],
+        });
+    });
+
+    it("keeps a boolean parameter probe a boolean parameter", () => {
+        const ports = gatePort(booleanParameterInput, "$(inputs.probe)");
+        expect(ports).toHaveLength(1);
+        expect(ports[0]).toMatchObject({
+            name: "probe",
+            input_type: "parameter",
+            type: "boolean",
+            optional: false,
+        });
+    });
+
+    it("keeps a multiple parameter probe multiple", () => {
+        const multipleParameterInput: NewStep = {
+            ...booleanParameterInput,
+            outputs: [{ name: "output", optional: false, type: "text", parameter: true, multiple: true }],
+        } as NewStep;
+        const ports = gatePort(multipleParameterInput, "$(inputs.probe)");
+        expect(ports[0]).toMatchObject({
+            input_type: "parameter",
+            type: "text",
+            multiple: true,
+        });
+    });
+
+    it("marks a probe fed by a gated step optional", () => {
+        const gatedSource: NewStep = { ...workflowStepZero, id: 0, when: "$(inputs.when)" };
+        const ports = gatePort(gatedSource, "$(inputs.probe !== null)");
+        expect(ports[0]).toMatchObject({ optional: true });
+    });
+
+    it("keeps the conventional when port a required boolean whatever feeds it", () => {
+        const textParameterInput: NewStep = {
+            ...workflowStepZero,
+            id: 0,
+            type: "parameter_input",
+            outputs: [{ name: "output", optional: true, type: "text", parameter: true, multiple: false }],
+        } as NewStep;
+        const ports = gatePort(textParameterInput, "$(inputs.when)", "when");
+        expect(ports).toHaveLength(1);
+        expect(ports[0]).toMatchObject({
+            name: "when",
+            input_type: "parameter",
+            type: "boolean",
+            optional: false,
+        });
+    });
+
+    it("does not synthesize a port for a connection the expression only appears to name", () => {
+        const ports = gatePort(optionalDataInput, "$(inputs.probe !== null)", "pro");
+        expect(ports).toHaveLength(0);
+    });
+
+    it("retypes a probe when its source is added after the gated step", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const gated = addProbeGatedStep(stepStore);
+
+        stepStore.addStep(optionalDataInput);
+
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({
+            name: "probe",
+            input_type: "dataset",
+            optional: true,
+            extensions: ["input"],
+        });
+    });
+
+    it("retypes a probe when its source output changes", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const source = stepStore.addStep(booleanParameterInput);
+        const gated = addProbeGatedStep(stepStore);
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({
+            input_type: "parameter",
+            type: "boolean",
+            optional: false,
+        });
+
+        stepStore.updateStep({ ...source, outputs: optionalDataInput.outputs });
+
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({
+            input_type: "dataset",
+            optional: true,
+            extensions: ["input"],
+        });
+    });
+
+    it("updates probe optionality when its source becomes gated", () => {
+        const requiredDataInput: NewStep = {
+            ...optionalDataInput,
+            outputs: [{ name: "output", extensions: ["input"], optional: false }],
+        };
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const source = stepStore.addStep(requiredDataInput);
+        const gated = addProbeGatedStep(stepStore);
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({ optional: false });
+
+        stepStore.updateStep({ ...source, when: "$(inputs.when)" });
+
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({ optional: true });
+    });
+
+    it("updates a data probe when its source changes output datatype", () => {
+        const requiredDataInput: NewStep = {
+            ...optionalDataInput,
+            outputs: [{ name: "output", extensions: ["txt"], optional: false }],
+        };
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const source = stepStore.addStep(requiredDataInput);
+        const gated = addProbeGatedStep(stepStore);
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({ extensions: ["txt"] });
+
+        stepStore.updateStep({
+            ...source,
+            post_job_actions: {
+                ChangeDatatypeActionoutput: {
+                    action_type: "ChangeDatatypeAction",
+                    output_name: "output",
+                    action_arguments: { newtype: "tabular" },
+                },
+            },
+        });
+
+        expect(stepStore.getStepExtraInputs(gated.id)[0]).toMatchObject({ extensions: ["tabular"] });
+    });
+});
+
+describe("presenceGateIsSpellable", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    const toolStep = createTestStep(0, {
+        inputs: [],
+        outputs: [],
+    }) as NewStep;
+
+    function step(toolState: Record<string, unknown>): Step {
+        return { ...toolStep, tool_state: toolState } as Step;
+    }
+
+    it("spells a top-level input", () => {
+        expect(presenceGateIsSpellable(step({ input1: '{"__class__": "ConnectedValue"}' }), "input1")).toBe(true);
+    });
+
+    it("spells an input nested in a conditional", () => {
+        expect(presenceGateIsSpellable(step({ cond: { input1: {} } }), "cond|input1")).toBe(true);
+    });
+
+    it("spells an input nested in a json-encoded conditional", () => {
+        expect(presenceGateIsSpellable(step({ cond: '{"input1": {}}' }), "cond|input1")).toBe(true);
+    });
+
+    it("spells an input nested in a repeat", () => {
+        const repeatState = { queries: '[{"__index__": 0, "input2": {}}]' };
+        expect(presenceGateIsSpellable(step(repeatState), "queries_0|input2")).toBe(true);
+    });
+
+    it("refuses a flattened name with two valid interpretations", () => {
+        const ambiguousState = { queries_0: { input2: {} }, queries: [{ input2: {} }] };
+        expect(presenceGateIsSpellable(step(ambiguousState), "queries_0|input2")).toBe(false);
+    });
+
+    it("spells a probe, which is not a tool parameter at all", () => {
+        expect(presenceGateIsSpellable(step({}), "probe")).toBe(true);
+    });
+
+    it("refuses a nested name when tool state is unavailable", () => {
+        expect(presenceGateIsSpellable(step({}), "cond|input1")).toBe(false);
     });
 });

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -3,8 +3,14 @@ import { computed, del, ref, set } from "vue";
 import type { FieldDict, SampleSheetColumnDefinitions } from "@/api";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import type { CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
-import { expressionReferencesInput } from "@/components/Workflow/Editor/modules/whenExpression";
-import { resolveConnectionNameToInputPath } from "@/components/Workflow/Editor/modules/workflowInputPath";
+import {
+    BOOLEAN_GATE_INPUT_NAME,
+    expressionReferencesInput,
+} from "@/components/Workflow/Editor/modules/whenExpression";
+import {
+    type InputPath,
+    resolveConnectionNameToInputPath,
+} from "@/components/Workflow/Editor/modules/workflowInputPath";
 import { getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 
@@ -140,6 +146,13 @@ export interface ConnectionOutputLink {
     input_subworkflow_step_id?: number;
 }
 
+/** Normalize the persisted single-or-array connection shape for read-only traversal. */
+export function normalizeConnectionOutputLinks(
+    links: ConnectionOutputLink | ConnectionOutputLink[] | undefined,
+): readonly ConnectionOutputLink[] {
+    return Array.isArray(links) ? links : links ? [links] : [];
+}
+
 export interface WorkflowOutputs {
     [index: string]: {
         stepId: number;
@@ -160,6 +173,31 @@ export type WorkflowStepStore = ReturnType<typeof useWorkflowStepStore>;
 export function getCombinedStepInputs(step: Step, stepStore: WorkflowStepStore): InputTerminalSource[] {
     const extraInputs = stepStore.getStepExtraInputs(step.id);
     return [...extraInputs, ...step.inputs];
+}
+
+/**
+ * True when the value arriving on this input can be absent at run time, either because
+ * every source output is optional or because every source step is itself gated.
+ */
+export function connectedInputCanBeAbsent(step: Step, inputName: string, stepStore: WorkflowStepStore): boolean {
+    const links = step.input_connections?.[inputName];
+    if (!links) {
+        return false;
+    }
+    const linkArray = normalizeConnectionOutputLinks(links);
+    if (linkArray.length === 0) {
+        return false;
+    }
+    return linkArray.every((link) => {
+        const sourceStep = stepStore.getStep(link.id);
+        if (!sourceStep) {
+            return false;
+        }
+        if (sourceStep.when) {
+            return true;
+        }
+        return Boolean(sourceStep.outputs.find((output) => output.name === link.output_name)?.optional);
+    });
 }
 
 export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (workflowId) => {
@@ -246,7 +284,8 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
             stepToConnections(step).forEach((connection) => connectionStore.addConnection(connection));
         }
 
-        stepExtraInputs.value[step.id] = findStepExtraInputs(step);
+        refreshStepExtraInputs(step);
+        refreshGatePortsReadingSource(step.id);
 
         if (select) {
             stateStore.setStepMultiSelected(step.id, true);
@@ -277,12 +316,33 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
     }
 
     function updateStep(step: Step) {
+        const previousStep = steps.value[step.id.toString()];
         const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
             step.outputs.find((output) => workflowOutput.output_name == output.name),
         );
 
-        steps.value[step.id.toString()] = Object.freeze({ ...step, workflow_outputs });
-        stepExtraInputs.value[step.id] = findStepExtraInputs(step);
+        const updatedStep = Object.freeze({ ...step, workflow_outputs });
+        steps.value[step.id.toString()] = updatedStep;
+        refreshStepExtraInputs(updatedStep);
+
+        // A probe terminal mirrors its source's effective output shape. Recompute
+        // downstream gate ports only when that shape may have changed, so frequent
+        // updates to unrelated fields (notably position) avoid a full workflow scan.
+        if (!previousStep || gatePortSourceShapeChanged(previousStep, updatedStep)) {
+            refreshGatePortsReadingSource(updatedStep.id);
+        }
+    }
+
+    function refreshStepExtraInputs(step: Step) {
+        stepExtraInputs.value[step.id] = findStepExtraInputs(step, steps.value);
+    }
+
+    function refreshGatePortsReadingSource(sourceStepId: number) {
+        Object.values(steps.value).forEach((candidate) => {
+            if (candidate.id !== sourceStepId && stepReadsSource(candidate, sourceStepId)) {
+                refreshStepExtraInputs(candidate);
+            }
+        });
     }
 
     function updateStepValue<K extends keyof Step>(stepId: number, key: K, value: Step[K]) {
@@ -450,6 +510,22 @@ function makeConnection(inputId: number, inputName: string, outputId: number, ou
     };
 }
 
+/** Fields on a source step that determine the shape of a synthesized gate port. */
+function gatePortSourceShapeChanged(previousStep: Step, updatedStep: Step): boolean {
+    return (
+        previousStep.outputs !== updatedStep.outputs ||
+        previousStep.when !== updatedStep.when ||
+        previousStep.post_job_actions !== updatedStep.post_job_actions
+    );
+}
+
+/** True when any input connection on `step` comes from the named source step. */
+function stepReadsSource(step: Step, sourceStepId: number): boolean {
+    return Object.values(step.input_connections ?? {}).some((links) => {
+        return normalizeConnectionOutputLinks(links).some((link) => link.id === sourceStepId);
+    });
+}
+
 function stepToConnections(step: Step): Connection[] {
     const connections: Connection[] = [];
 
@@ -458,10 +534,7 @@ function stepToConnections(step: Step): Connection[] {
             if (outputArray === undefined) {
                 return;
             }
-            if (!Array.isArray(outputArray)) {
-                outputArray = [outputArray];
-            }
-            outputArray.forEach((output) => {
+            normalizeConnectionOutputLinks(outputArray).forEach((output) => {
                 const connection = makeConnection(step.id, inputName, output.id, output.output_name);
                 const connectionInput = step.inputs.find((input) => input.name == inputName);
                 if (connectionInput && "input_subworkflow_step_id" in connectionInput) {
@@ -475,28 +548,109 @@ function stepToConnections(step: Step): Connection[] {
     return connections;
 }
 
-function findStepExtraInputs(step: Step) {
+function findStepExtraInputs(step: Step, steps: Steps): InputTerminalSource[] {
     const extraInputs: InputTerminalSource[] = [];
     if (step.when === undefined) {
         return extraInputs;
     }
-    Object.keys(step.input_connections).forEach((inputName) => {
+    Object.keys(step.input_connections ?? {}).forEach((inputName) => {
         if (step.inputs.find((input) => input.name === inputName)) {
             return;
         }
-        const inputPath = resolveConnectionNameToInputPath(inputName, step.tool_state);
+        const inputPath = presenceGateInputPath(step, inputName);
         if (!inputPath || !expressionReferencesInput(step.when, inputPath)) {
             return;
         }
-        extraInputs.push({
+        extraInputs.push(gatePortTerminalSource(step, inputName, steps));
+    });
+    return extraInputs;
+}
+
+/**
+ * True when a connection name can be spelled as a JavaScript path into `inputs`.
+ *
+ * A conditional maps segment for segment, while a repeat connection such as
+ * `queries_0|input2` maps to `inputs.queries[0].input2`. Walk tool state so `_0`
+ * can be distinguished from a literal property suffix and ambiguous names declined.
+ */
+export function presenceGateIsSpellable(step: Step, inputName: string): boolean {
+    return presenceGateInputPath(step, inputName) !== null;
+}
+
+/** The actual `inputs` expression path for a connected input, when unambiguous. */
+export function presenceGateInputPath(step: Step, inputName: string): InputPath | null {
+    return resolveConnectionNameToInputPath(inputName, step.tool_state);
+}
+
+/**
+ * Shape a synthesized gate port after whatever feeds it.
+ *
+ * A probe carries a value into the expression and nothing consumes it, so its terminal
+ * has to accept what the source produces. Optionality matters as much as type: a probe
+ * fed by an optional input is otherwise a required parameter terminal, and the editor
+ * refuses the very connection the gate depends on.
+ */
+function gatePortTerminalSource(step: Step, inputName: string, steps: Steps): InputTerminalSource {
+    if (inputName === BOOLEAN_GATE_INPUT_NAME) {
+        // `when` is a convention with a fixed meaning: the gate's own boolean.
+        return {
             name: inputName,
+            label: inputName,
+            multiple: false,
             optional: false,
             input_type: "parameter",
             type: "boolean",
-            multiple: false,
-            label: inputName,
             extensions: [],
-        });
-    });
-    return extraInputs;
+        };
+    }
+    const links = step.input_connections[inputName];
+    const link = normalizeConnectionOutputLinks(links)[0];
+    const sourceStep = link ? steps[link.id.toString()] : undefined;
+    const output = sourceStep?.outputs.find((candidate) => candidate.name === link?.output_name);
+    const base = {
+        name: inputName,
+        label: inputName,
+        multiple: Boolean(output && isParameterOutput(output) && output.multiple),
+        optional: Boolean(output?.optional) || Boolean(sourceStep?.when),
+    };
+    if (!output || isParameterOutput(output)) {
+        return {
+            ...base,
+            input_type: "parameter",
+            type: output?.type ?? "boolean",
+            extensions: [],
+        };
+    }
+    if (isCollectionOutput(output)) {
+        return {
+            ...base,
+            input_type: "dataset_collection",
+            collection_types: output.collection_type ? [output.collection_type] : [],
+            fields: [],
+            column_definitions: null,
+            extensions: effectiveOutputExtensions(sourceStep, output),
+        };
+    }
+    return {
+        ...base,
+        input_type: "dataset",
+        extensions: effectiveOutputExtensions(sourceStep, output),
+    };
+}
+
+function effectiveOutputExtensions(sourceStep: Step | undefined, output: DataOutput | CollectionOutput): string[] {
+    const changeDatatype = sourceStep?.post_job_actions?.[`ChangeDatatypeAction${output.name}`];
+    if (changeDatatype) {
+        const newtype = changeDatatype.action_arguments.newtype;
+        return newtype ? [newtype] : [];
+    }
+    return output.extensions ?? [];
+}
+
+function isParameterOutput(output: OutputTerminalSource): output is ParameterOutput {
+    return "parameter" in output && Boolean(output.parameter);
+}
+
+function isCollectionOutput(output: OutputTerminalSource): output is CollectionOutput {
+    return "collection" in output && Boolean(output.collection);
 }

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -758,6 +758,11 @@ tool_form:
     parameter_checkbox: 'div.ui-form-element[id="form-element-${parameter}"] .ui-switch'
     parameter_checkbox_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="checkbox"]'
     parameter_select: 'div.ui-form-element[id="form-element-${parameter}"] .multiselect'
+    parameter_select_trigger: 'div.ui-form-element[id="form-element-${parameter}"] .multiselect__select'
+    parameter_select_option:
+      type: xpath
+      selector: >
+        //div[@id='form-element-${parameter}']//li[contains(@class, 'multiselect__element') and normalize-space()="${label}"]//*[contains(@class, 'multiselect__option')]
     parameter_input: 'div.ui-form-element[id="form-element-${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[id="form-element-${parameter}"] textarea'
     parameter_data_input_single: 'div.ui-form-element[id="form-element-${parameter}"] button[title="Single dataset"]'
@@ -1080,7 +1085,7 @@ workflow_editor:
     step_when:
       type: xpath
       selector: >
-       //div[@id='form-element-__conditional']//input
+       //div[@id='form-element-__conditional']
     param_type_form: '#parameter_definition\|parameter_type'
     configure_output:
       type: xpath

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -16,6 +16,7 @@ A multi-hour long video playlist covering these slides can be found at
   database_session_management
   build_a_job_runner
   collection_semantics
+  workflow_conditional_steps
   finding_and_improving_slow_code
   data_managers
   data_source

--- a/doc/source/dev/workflow_conditional_steps.md
+++ b/doc/source/dev/workflow_conditional_steps.md
@@ -1,0 +1,141 @@
+# Conditional Workflow Steps
+
+A workflow step may carry a `when` expression. Galaxy evaluates it before the step runs;
+if it evaluates false, the step is skipped and produces no outputs. This document covers
+what the expression can read, the two ways to decide whether a step should run, and what
+to do with the outputs of a step that might not run.
+
+## What a `when` expression can read
+
+The `when` condition is a `$(...)` expression evaluated with an `inputs` object in scope.
+`inputs` carries the step's tool state together with anything else connected to the step,
+so an expression can read:
+
+- **Tool parameters**, connected or not, in their tool-state shape. A parameter nested
+  inside a `<conditional>` is addressed as `inputs.cond.param` or
+  `inputs["cond"]["param"]`. Galaxy names the _connection_ with a flat, pipe-prefixed
+  name (`cond|param`), but that spelling is not exposed to the expression.
+- **Data inputs.** A connected dataset appears as an object with its metadata, so
+  `$(inputs.reference.format != "bwa_mem2_index")` is a valid condition.
+- **Extra connections** that are not tool parameters at all. Connecting an output to a
+  name the tool does not define makes that value available to the expression and nothing
+  else. This is how the `when` boolean convention works, and it generalizes.
+
+## Running based on a boolean parameter
+
+The common form, and the one the workflow editor writes when you pick _Run when a
+boolean parameter is true_:
+
+```yaml
+steps:
+  trim:
+    tool_id: trimmomatic
+    in:
+      input: reads
+      when: run_trimming
+    when: $(inputs.when)
+```
+
+`run_trimming` is a boolean workflow input. `when` is not a Trimmomatic parameter — it is
+an extra connection that exists only to be read by the expression.
+
+## Running when an input is provided
+
+A workflow input declared `optional: true` may be connected to a _required_ tool data
+parameter, as long as the step runs only when that input is present:
+
+```yaml
+inputs:
+  mapped: data
+  primer_scheme:
+    type: data
+    optional: true
+steps:
+  trim:
+    tool_id: ivar_trim
+    in:
+      input_bam: mapped
+      primer|input_bed: primer_scheme
+    when: $(inputs.primer.input_bed !== null)
+```
+
+When the dataset is supplied the step runs normally. When it is omitted the condition
+evaluates false and the step is skipped, so the tool never sees a missing required
+parameter.
+
+Without this condition the workflow fails: an omitted optional input is not implicitly
+skipped, it reaches parameter validation as null and the job errors. The skip comes from
+the expression and nothing else.
+
+The workflow editor writes this expression for you. Choose _Run when an input is
+provided_ on the step, or drop an optional output onto a required input and accept the
+offer to run the step only when the input is provided.
+
+For a parameter inside a `<repeat>`, the expression follows the list structure of the
+step's state. For example, the connection `queries_0|input2` is addressed as
+`inputs.queries[0].input2`. The workflow editor resolves this structure and writes the
+indexed expression for you.
+
+## Continue after a conditional step
+
+A conditional step's outputs are optional because the step might be skipped. Galaxy
+cannot connect such an output directly to a required downstream input: when the condition
+is false, there is no value for the downstream step to consume.
+
+Place a Pick Value step immediately after the conditional step to select its output when
+present and a fallback otherwise:
+
+```yaml
+merge:
+  type: pick_value
+  in:
+    input_0: trim/output_bam
+    input_1: mapped
+  state:
+    mode: first_non_null
+```
+
+`pick_value` takes the first input that is not null, so the workflow continues with the
+trimmed data when trimming ran and with the untrimmed data when it did not. Everything
+downstream of `merge` sees an ordinary required dataset.
+
+Two spellings exist. `type: pick_value` is the native workflow module described here; it
+has an editor palette entry and a step form. Many published workflows instead use the
+tool shed tool `iuc/pick_value`, which does the same job and reads the same way in a
+workflow file. Prefer the module for new work.
+
+## Running a tool in two different shapes
+
+Tool state is fixed per step, so a tool that must run with a reference in one case and
+without it in the other needs two steps with complementary conditions. An extra connection
+carries the dataset into both expressions, including the branch that does not consume it:
+
+```yaml
+with_ref:
+  tool_id: some_tool
+  in:
+    ref: maybe_reference
+    probe: maybe_reference
+  when: $(inputs.probe !== null)
+without_ref:
+  tool_id: some_tool
+  in:
+    probe: maybe_reference
+  when: $(inputs.probe === null)
+merged:
+  type: pick_value
+  in:
+    input_0: with_ref/out
+    input_1: without_ref/out
+  state:
+    mode: first_non_null
+```
+
+Exactly one of the two runs, and `pick_value` picks up whichever did.
+
+## Deleting an input used by a condition
+
+An expression that reads a connection which no longer exists fails quietly: on a tool
+parameter the state key survives as null, so the step is skipped on every run, and on an
+extra connection the evaluation raises. The workflow editor's best-practices panel
+reports it, so a condition that refers to a deleted connection does not go unnoticed.

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -36,6 +36,11 @@ from .framework import (
     UsesWorkflowAssertions,
 )
 
+# Gate modes offered by FormConditional.vue.
+GATE_MODE_NONE = "Always run this step"
+GATE_MODE_BOOLEAN = "Run when a boolean parameter is true"
+GATE_MODE_INPUT_PROVIDED = "Run when an input is provided"
+
 CHIPSEQ_COLUMNS = [
     ColumnDefinition(
         "Condition",
@@ -950,26 +955,12 @@ steps:
         workflow = self.workflow_populator.download_workflow(workflow_id)
         return workflow
 
-    def _pick_value_select_mode(self, label):
-        mode_selector = "div.ui-form-element[id='form-element-mode']"
-        container = self.wait_for_selector(mode_selector)
-        trigger = container.find_element(By.CSS_SELECTOR, ".multiselect__select")
-        trigger.click()
+    def _select_form_option(self, form_element_id, label):
+        """Pick an option by label from a FormElement select."""
+        tool_form = self.components.tool_form
+        tool_form.parameter_select_trigger(parameter=form_element_id).wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
-        js = """
-            var label = arguments[0];
-            var container = document.querySelector('#form-element-mode');
-            var items = container.querySelectorAll('.multiselect__element');
-            for (var i = 0; i < items.length; i++) {
-                if (items[i].textContent.trim() === label) {
-                    items[i].querySelector('.multiselect__option').click();
-                    return true;
-                }
-            }
-            return false;
-        """
-        result = self.execute_script(js, label)
-        assert result, f"Mode option '{label}' not found"
+        tool_form.parameter_select_option(parameter=form_element_id, label=label).wait_for_and_click()
 
     @selenium_test
     def test_pick_value_add_from_palette(self):
@@ -985,7 +976,7 @@ steps:
         editor = self.components.workflow_editor
         node = editor.node._(label="Pick Value")
         node.wait_for_and_click()
-        self._pick_value_select_mode("All non-null (as collection)")
+        self._select_form_option("mode", "All non-null (as collection)")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
         workflow = self._download_current_workflow()
@@ -1108,7 +1099,7 @@ steps:
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_and_click()
-        self._pick_value_select_mode("All non-null (as collection)")
+        self._select_form_option("mode", "All non-null (as collection)")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
         workflow = self._download_current_workflow()
@@ -1300,14 +1291,14 @@ steps:
         conditional_node.input_terminal(name="input").wait_for_present()
         # Assert no when input before making step conditional
         conditional_node.input_terminal(name="when").wait_for_absent()
-        conditional_toggle = editor.step_when.wait_for_present()
-        self.move_to_and_click(conditional_toggle)
-        # Toggling conditional should cause when input to appear
+        editor.step_when.wait_for_present()
+        self._select_form_option("__conditional", GATE_MODE_BOOLEAN)
+        # Choosing the boolean gate should cause the when input to appear
         conditional_node.input_terminal(name="when").wait_for_present()
-        self.move_to_and_click(conditional_toggle)
-        # Toggling conditional should cause when input to disappear
+        self._select_form_option("__conditional", GATE_MODE_NONE)
+        # Clearing the gate should cause the when input to disappear
         conditional_node.input_terminal(name="when").wait_for_absent()
-        self.move_to_and_click(conditional_toggle)
+        self._select_form_option("__conditional", GATE_MODE_BOOLEAN)
         conditional_node.input_terminal(name="when").wait_for_present()
         # Output connection should be invalid, as output from conditional step is potentially null
         self.assert_connection_invalid("conditional_step#out_file1", "downstream_step#input1")
@@ -1331,6 +1322,62 @@ steps:
         save_button.wait_for_visible()
         # TODO: hook up best practice panel, disable save when "when" not connected
         # assert save_button.has_class("g-disabled")
+
+    @selenium_test
+    def test_editor_gate_step_on_optional_input(self):
+        self.open_in_workflow_editor("""
+class: GalaxyWorkflow
+inputs:
+  fallback: data
+  maybe:
+    type: data
+    optional: true
+steps:
+  gated:
+    tool_id: cat
+    in:
+      input1: maybe
+""")
+        editor = self.components.workflow_editor
+        # Without a gate, an optional input feeding a required parameter is a real problem.
+        self.assert_connection_invalid("maybe#output", "gated#input1")
+        editor.node._(label="gated").wait_for_and_click()
+        self._select_form_option("__conditional", GATE_MODE_INPUT_PROVIDED)
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_connection_valid("maybe#output", "gated#input1")
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        gated_step = [s for s in workflow["steps"].values() if s.get("label") == "gated"][0]
+        assert gated_step["when"] == "$(inputs.input1 !== null)"
+
+    @selenium_test
+    def test_editor_twin_dispatch_connections_valid(self):
+        self.open_in_workflow_editor("""
+class: GalaxyWorkflow
+inputs:
+  base: data
+  maybe:
+    type: data
+    optional: true
+steps:
+  when_present:
+    tool_id: cat
+    in:
+      input1: maybe
+      probe: maybe
+    when: $(inputs.probe !== null)
+  when_absent:
+    tool_id: cat
+    in:
+      input1: base
+      probe: maybe
+    when: $(inputs.probe === null)
+""")
+        # The gate names `probe`, but `input1` is fed by the same optional input and is
+        # equally unreachable while it is absent. Neither connection is broken.
+        self.assert_connection_valid("maybe#output", "when_present#probe")
+        self.assert_connection_valid("maybe#output", "when_present#input1")
+        self.assert_connection_valid("maybe#output", "when_absent#probe")
 
     @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
@@ -1895,6 +1942,11 @@ steps:
     def assert_connection_invalid(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
         self.components.workflow_editor.connector_invalid_for(source_id=source_id, sink_id=sink_id).wait_for_present()
+
+    def assert_connection_valid(self, source, sink):
+        source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
+        self.components.workflow_editor.connector_invalid_for(source_id=source_id, sink_id=sink_id).wait_for_absent()
+        self.assert_connected(source, sink)
 
     def assert_not_connected(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)

--- a/lib/galaxy_test/workflow/optional_input_gating_nested_bracket.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nested_bracket.gxwf-tests.yml
@@ -1,0 +1,32 @@
+- doc: |
+    Optional input supplied - chained bracket access into nested tool state resolves the
+    connected parameter, the gate evaluates true, and the gated step runs.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional input omitted - chained bracket access yields null, the gate evaluates false,
+    and the step nested in a tool conditional is skipped.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "FALLBACK"

--- a/lib/galaxy_test/workflow/optional_input_gating_nested_bracket.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nested_bracket.gxwf.yml
@@ -1,0 +1,32 @@
+class: GalaxyWorkflow
+doc: |
+  Presence-gate a tool parameter nested inside a tool conditional, addressed with
+  chained bracket access. Connection names stay pipe-prefixed; the expression walks tool state.
+inputs:
+  fallback:
+    type: data
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: pick/output
+steps:
+  gated:
+    tool_id: format_source_in_conditional
+    tool_state:
+      cond:
+        select: no_extra_nesting
+    in:
+      cond|input1:
+        source: maybe
+    when: $(inputs["cond"]["input1"] !== null)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: gated/output1
+      input_1:
+        source: fallback
+    state:
+      mode: first_non_null

--- a/lib/galaxy_test/workflow/optional_input_gating_nested_dot.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nested_dot.gxwf-tests.yml
@@ -1,0 +1,32 @@
+- doc: |
+    Optional input supplied - dot access into nested tool state resolves the
+    connected parameter, the gate evaluates true, and the gated step runs.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional input omitted - dot access yields null, the gate evaluates false,
+    and the step nested in a tool conditional is skipped.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "FALLBACK"

--- a/lib/galaxy_test/workflow/optional_input_gating_nested_dot.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nested_dot.gxwf.yml
@@ -1,0 +1,32 @@
+class: GalaxyWorkflow
+doc: |
+  Presence-gate a tool parameter nested inside a tool conditional, addressed with
+  dot access. Connection names stay pipe-prefixed; the expression walks tool state.
+inputs:
+  fallback:
+    type: data
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: pick/output
+steps:
+  gated:
+    tool_id: format_source_in_conditional
+    tool_state:
+      cond:
+        select: no_extra_nesting
+    in:
+      cond|input1:
+        source: maybe
+    when: $(inputs.cond.input1 !== null)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: gated/output1
+      input_1:
+        source: fallback
+    state:
+      mode: first_non_null

--- a/lib/galaxy_test/workflow/optional_input_gating_nogate.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nogate.gxwf-tests.yml
@@ -1,0 +1,27 @@
+- doc: |
+    Optional input supplied - an ungated step consuming it runs normally. Nothing
+    about the connection itself is rejected.
+  job:
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: txt
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional input omitted with no gate - the invocation fails rather than skipping the
+    step. This is what proves the skip in the gated fixtures comes from the when
+    expression rather than from implicit null propagation. The harness only checks that
+    something failed, so the reason is not asserted here.
+  expect_failure: true
+  job: {}
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"

--- a/lib/galaxy_test/workflow/optional_input_gating_nogate.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_nogate.gxwf.yml
@@ -1,0 +1,18 @@
+class: GalaxyWorkflow
+doc: |
+  Control for the presence-gating fixtures. Identical topology to
+  optional_input_gating_toplevel minus the gate: an omitted optional input is not
+  implicitly skipped, it fails tool parameter validation.
+inputs:
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: consumer/out_file1
+steps:
+  consumer:
+    tool_id: cat
+    in:
+      input1:
+        source: maybe

--- a/lib/galaxy_test/workflow/optional_input_gating_repeat.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_repeat.gxwf-tests.yml
@@ -1,0 +1,32 @@
+- doc: |
+    Optional repeat input supplied - indexed access resolves the connected repeat
+    parameter, the gate evaluates true, and the step runs.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional repeat input omitted - indexed access yields null, the gate evaluates
+    false, and the repeat-bearing tool step is skipped.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: tabular
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "FALLBACK"

--- a/lib/galaxy_test/workflow/optional_input_gating_repeat.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_repeat.gxwf.yml
@@ -1,0 +1,35 @@
+class: GalaxyWorkflow
+doc: |
+  Presence-gate a tool parameter nested inside the first repeat instance. The
+  flattened connection name is queries_0|input2, while the expression follows the
+  tool-state list as inputs.queries[0].input2.
+inputs:
+  fallback:
+    type: data
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: pick/output
+steps:
+  gated:
+    tool_id: cat1
+    tool_state:
+      queries:
+        - input2: null
+    in:
+      input1:
+        source: fallback
+      queries_0|input2:
+        source: maybe
+    when: $(inputs.queries[0].input2 !== null)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: gated/out_file1
+      input_1:
+        source: fallback
+    state:
+      mode: first_non_null

--- a/lib/galaxy_test/workflow/optional_input_gating_toplevel.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_toplevel.gxwf-tests.yml
@@ -1,0 +1,33 @@
+- doc: |
+    Optional input supplied - the presence gate evaluates true, the gated step runs,
+    and pick_value takes the gated output over the fallback.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: txt
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: txt
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional input omitted - the presence gate evaluates false, the gated step is
+    skipped, and pick_value falls back. An optional workflow input may feed a
+    required tool data parameter as long as a presence gate guards the step.
+  job:
+    fallback:
+      class: File
+      contents: "FALLBACK"
+      filetype: txt
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "FALLBACK"

--- a/lib/galaxy_test/workflow/optional_input_gating_toplevel.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_toplevel.gxwf.yml
@@ -1,0 +1,29 @@
+class: GalaxyWorkflow
+doc: |
+  Gate a step on the presence of an optional workflow input wired straight into a
+  required tool data parameter, then merge the gated output with a fallback.
+inputs:
+  fallback:
+    type: data
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: pick/output
+steps:
+  gated:
+    tool_id: cat
+    in:
+      input1:
+        source: maybe
+    when: $(inputs.input1 !== null)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: gated/out_file1
+      input_1:
+        source: fallback
+    state:
+      mode: first_non_null

--- a/lib/galaxy_test/workflow/optional_input_gating_twin_probe.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_twin_probe.gxwf-tests.yml
@@ -1,0 +1,33 @@
+- doc: |
+    Optional input supplied - the probe is non-null, so the copy that consumes the
+    dataset runs and its twin is skipped.
+  job:
+    base:
+      class: File
+      contents: "BASE"
+      filetype: txt
+    maybe:
+      class: File
+      contents: "PROVIDED"
+      filetype: txt
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "PROVIDED"
+- doc: |
+    Optional input omitted - the probe is null, so the inverse gate fires and the copy
+    that never consumes the dataset runs. A probe carries a dataset into the
+    expression context without being a tool parameter.
+  job:
+    base:
+      class: File
+      contents: "BASE"
+      filetype: txt
+  outputs:
+    out:
+      class: File
+      asserts:
+        - that: has_text
+          text: "BASE"

--- a/lib/galaxy_test/workflow/optional_input_gating_twin_probe.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_input_gating_twin_probe.gxwf.yml
@@ -1,0 +1,42 @@
+class: GalaxyWorkflow
+doc: |
+  Twin dispatch. Tool state is frozen per step, so running a tool in two different
+  shapes needs two steps with complementary gates. A non-tool-parameter data
+  connection acts as a pure presence probe, letting the negative branch reference an
+  input it does not consume.
+inputs:
+  base:
+    type: data
+  maybe:
+    type: data
+    optional: true
+outputs:
+  out:
+    outputSource: pick/output
+steps:
+  when_present:
+    tool_id: cat
+    in:
+      input1:
+        source: maybe
+      probe:
+        source: maybe
+    when: $(inputs.probe !== null)
+  when_absent:
+    tool_id: cat
+    in:
+      input1:
+        source: base
+      probe:
+        source: maybe
+    when: $(inputs.probe === null)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: when_present/out_file1
+      input_1:
+        source: when_absent/out_file1
+    state:
+      # Fails unless exactly one twin ran, which is what makes the inverse gate testable.
+      mode: the_only_non_null


### PR DESCRIPTION


https://github.com/user-attachments/assets/685511f7-298d-40c5-aa54-80378caeb2af



<!-- Suggested title: Support optional-input workflow conditions in the editor -->

This is PR 3 of 3. It adds the user-facing optional-input authoring behavior on top of the normalized runtime expression context from PR 1 and the structural editor analysis from PR 2.

Galaxy can already evaluate a step condition such as:

```javascript
$(inputs.primer.input_bed !== null)
```

This makes it valid for an optional workflow input to feed a required tool or subworkflow input: the step runs when the value is supplied and is skipped before required-input validation when the value is absent. The workflow editor previously refused or marked that connection invalid, however, and offered no direct way to author the condition.

This PR makes that workflow shape first-class in the editor.

### Authoring conditions

The existing **Conditionally skip step?** control becomes a mode selector with:

- always run;
- run when a boolean parameter is true;
- run when a connected input is provided; and
- a read-only custom-expression state for conditions the editor did not generate.

Generated conditions round-trip through the same analyzer used for connection validity. Nested conditional inputs use their nested property path, and repeat members use indexed expressions such as `inputs.queries[0].input2`. If a flattened connection name is ambiguous, the editor declines to generate an expression rather than silently writing the wrong one. Replacing a hand-written expression requires confirmation.

Dropping an optional output onto a required tool or subworkflow input now previews as an accepted connection and explains that the step will run only when the input is provided. Confirming the drop creates the connection and condition as one undoable action. Step types that cannot execute conditionally, such as pause steps, remain rejected and are still shown as incompatible.

### Connection validity and downstream behavior

Existing imported connections are accepted when the step's condition protects the required input from an absent value. The same rule applies to data, collection, and parameter terminals. It also handles the twin-dispatch shape where a separate probe and a consumed input share one optional source, while retaining negative controls for unrelated conditions, inverse conditions on consumed required inputs, filled terminals, and genuine type mismatches.

A conditional step's outputs remain optional because the step may not run. The accompanying documentation shows how to use a Pick Value step to merge a conditional output with a fallback before feeding required downstream inputs.

Synthesized expression-only probe ports inherit the connected source's data or parameter shape. The conventional `when` port remains a required boolean, preserving the existing validation contract.

### Feedback, tests, and documentation

The workflow-editor lint panel now reports statically resolvable condition inputs that have no connection, without warning on missing tools or expressions that cannot be resolved safely.

Regression coverage includes:

- framework workflows for top-level, nested dot, nested bracket, repeat, ungated failure, and twin-probe behavior, each tested with the optional value both present and absent where applicable;
- component and store tests for condition modes, expression generation, repeat paths, custom-expression preservation, terminal validity, drop highlighting, subworkflow support, pause-step rejection, probe typing, and dangling-condition linting; and
- Selenium coverage for selecting condition modes, clearing invalid connection marking, saving and downloading the generated expression, and validating the twin-dispatch topology.

The new developer documentation describes boolean and presence conditions, repeat syntax, conditional-output handling with Pick Value, twin dispatch, and dangling condition inputs.

Follow-up to #23333.

## Stack

1. `issue_23333`: normalize the backend `when` expression context.
2. `when_expression_analysis`: add structural input-path and expression-reference analysis.
3. **This PR:** add optional-input presence-condition authoring and validation.

This PR should be reviewed against `when_expression_analysis`, not against `dev`.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Add an optional workflow input and a tool or subworkflow with a required compatible input.
  2. Drag the optional output over the required input and verify that the target is shown as accepted with the conditional-execution explanation.
  3. Drop it, accept **Run only when provided**, and verify that the step form shows **Run when an input is provided** for that input.
  4. Save and run once with the optional value supplied and once without it; the step should run in the first invocation and be skipped in the second.

The focused framework-workflow coverage can be run with:

```shell
pytest lib/galaxy_test/workflow/test_framework_workflows.py \
    -k optional_input_gating -m workflow
```

The focused client tests can be run from `client/` with:

```shell
pnpm exec vitest run \
    src/components/Workflow/Editor/Forms/FormConditional.test.ts \
    src/components/Workflow/Editor/Lint.test.ts \
    src/components/Workflow/Editor/NodeInput.test.ts \
    src/components/Workflow/Editor/modules/linting.test.ts \
    src/components/Workflow/Editor/modules/terminals.test.ts \
    src/components/Workflow/Editor/modules/whenExpression.test.ts \
    src/stores/workflowStepStore.test.ts
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
