### PR TITLE
More tool critic fixes - 23341 review followups

### DIFF
--- a/lib/galaxy/agents/prompts/custom_tool_critic.md
+++ b/lib/galaxy/agents/prompts/custom_tool_critic.md
@@ -1,6 +1,6 @@
 # Galaxy Custom Tool Critic
 
-You are a senior reviewer of Galaxy tool definitions. Another model has produced a tool definition that already passed structural validation -- IDs are well-formed, all referenced inputs are declared, container shape is recognized, citations are present. Your job is the **fuzzy quality** pass that validation can't do: clarity, idiomaticity, sensible defaults, helpful text.
+You are a senior reviewer of Galaxy tool definitions. Another model has produced a tool definition that already passed structural validation -- IDs are well-formed, all referenced inputs are declared, the `container` is non-empty, and every output declares how its bytes are claimed. Your job is the **fuzzy quality** pass that validation can't do: clarity, idiomaticity, sensible defaults, helpful text.
 
 You receive the original user request, the produced tool YAML, and you return a structured critique.
 
@@ -23,7 +23,7 @@ You receive the original user request, the produced tool YAML, and you return a 
   `value` at all -- their default is `selected: true` on one of their `options` -- and
   **data** parameters take none either, so never ask for one on those.
 - Common analysis options aren't exposed (e.g., a BWA tool with no `-t` threads input)
-- File outputs declared without `from_work_dir` or matching command output (the validator should have caught these, but flag any borderline cases)
+- File outputs declared without `from_work_dir` or `discover_datasets`, or without matching command output (the validator should have caught these, but flag any borderline cases)
 
 ## Containers are not your concern
 
@@ -35,7 +35,7 @@ critique here is redundant and may conflict with it. Leave container choice out 
 
 ## What NOT to flag
 
-- Anything the deterministic validator already catches (undeclared `inputs.X` references, container shape, citations, tool id format) -- assume it passed
+- Anything the deterministic validator already catches (undeclared `inputs.X` references, an empty `container`, outputs that claim no bytes, tool id format) -- assume it passed
 - Style preferences that don't affect correctness or clarity ("I'd name this differently")
 
 ## Supply the fix, not just the diagnosis

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -23,7 +23,9 @@ You are a Galaxy tool generator. Generate valid Galaxy tool definitions that mat
 - **description**: Brief description displayed in the tool menu
 - **license**: SPDX license identifier (e.g., "MIT")
 - **help**: Help shown below the tool interface. An object, not a string -- set both
-  `format` (`markdown`, `restructuredtext` or `plain_text`) and `content`:
+  `format` (`markdown`, `restructuredtext` or `plain_text`) and `content`. This is the
+  tool-level `help` only; an **input's** `help` is plain text, and the object form is
+  rejected there:
 
 ```yaml
 help:
@@ -35,7 +37,10 @@ help:
 ## Input/Output Syntax in shell_command
 
 - Input file paths: `$(inputs.param_name.path)` for single files
-- Input values: `$(inputs.param_name)` for text, integer, float, boolean
+- Input values: `$(inputs.param_name)` for text, integer, float, boolean. Quote the
+  scalar -- `'$(inputs.param_name)'` -- whenever it is or may become **text**: the
+  value is whatever the end user typed and it is spliced in verbatim, so an unquoted
+  `$(inputs.text_param)` turns `hello; rm -rf /` into two commands.
 - For `multiple: true` data inputs the value is a list of file objects, so map over
   it and join, quoting each path:
   ``$(inputs.param_name.map((input) => `'${input.path}'`).join(" "))``. The result is
@@ -76,7 +81,7 @@ outputs:
 
 ## Input Parameter Types
 
-Each input must have a `type` field. Valid types:
+Each input must have a `type` field. These are the common types:
 
 - **data**: File input. Set `format` to a **list** of allowed file types
   (e.g., `[fastq]`, `[fasta, fasta.gz]`) -- always a list, even for a single format.
@@ -86,10 +91,14 @@ Each input must have a `type` field. Valid types:
 - **boolean**: True/false checkbox
 - **select**: Dropdown with options
 
+`color`, `data_collection`, `repeat`, `conditional` and `section` also validate, but
+the six above cover almost every tool -- prefer them unless the request genuinely
+needs a repeat or a conditional.
+
 `value` sets the default for **text**, **integer**, **float** and **boolean** inputs
 only. A **select** has no `value`; mark its default with `selected: true` on one of
-its `options`. A **data** input has no `value` either. Any other key -- including
-`default` -- is rejected as an unknown field.
+its `options`. A **data** input has no `value` either. On an input, any other key --
+including `default` -- is rejected as an unknown field.
 
 Example input:
 
@@ -109,7 +118,8 @@ inputs:
 
 Each output must have a `type` field. Common types:
 
-- **data**: Single output file. Capture it with `from_work_dir`.
+- **data**: Single output file. Capture it with `from_work_dir`, or with
+  `discover_datasets` when the name isn't known until the job runs.
 - **collection**: Collection of output files. Requires `discover_datasets` -- a
   collection with only `from_work_dir` is rejected, since nothing would claim its
   elements from the working directory.


### PR DESCRIPTION
Follow-up to #23341, which corrected prompt guidance that contradicted the models. Same class of thing, in the parts it didn't reach.

`custom_tool_critic.md` tells the critic three checks already passed that never run.

`custom_tool_structured.md`, five clauses:

- `$(inputs.param_name)` now says to quote it. #23341's "spliced in verbatim" argument applies equally here, and this is the value an end user types: `do_eval` on `text_param = "hello; rm -rf /"` gives `echo hello; rm -rf /`. `shell_command` is the one `_build_command_line` branch that skips `shlex.quote`, and `UserToolEvaluator.__sanitize_param_dict` is a name-mangled no-op, so the prompt is the only guard. Not proposing a code change -- unquoted interpolation is what makes `>` and `|` work.
- "Any other key is rejected" scoped to inputs; only `_YamlParamBase` and the tool root are `extra="forbid"`.
- The new `inputs.some_repeat[0].x` carve-out documented indexing into a type the "Valid types" list didn't admit exists. List now names the other five.
- "help is an object" scoped to tool level -- an input's `help` is `str | None`.
- `data` outputs take either capture mechanism, as `:215` in the same file already said.

No new tests: the guard #23341 added covers the structured prompt's YAML examples and stays green (15 passed). The critic prompt's claims are prose, so nothing tests them -- which is how they drifted.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows: existing `test/unit/app/test_agent_prompts.py` passes unchanged.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
