### PR TITLE
Support checkout-free Galaxy application and job execution

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -116,6 +116,7 @@ from galaxy.util import (
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.path import external_chown
+from galaxy.util.properties import running_from_source
 from galaxy.util.xml_macros import load
 from galaxy.web_stack.handlers import ConfiguresHandlers
 from galaxy.work.context import WorkRequestContext
@@ -1189,13 +1190,18 @@ class MinimalJobWrapper(HasResourceParameters):
 
     @property
     def galaxy_lib_dir(self):
-        if self.__galaxy_lib_dir is None:
+        if self.__galaxy_lib_dir is None and running_from_source:
             self.__galaxy_lib_dir = os.path.abspath("lib")  # cwd = galaxy root
         return self.__galaxy_lib_dir
 
     @property
     def galaxy_virtual_env(self):
-        return os.environ.get("VIRTUAL_ENV", None)
+        virtual_env = os.environ.get("VIRTUAL_ENV")
+        if virtual_env:
+            return virtual_env
+        if sys.prefix != sys.base_prefix:
+            return sys.prefix
+        return None
 
     # legacy naming
     get_job_runner = get_job_runner_url

--- a/lib/galaxy/webapps/galaxy/fast_factory.py
+++ b/lib/galaxy/webapps/galaxy/fast_factory.py
@@ -41,13 +41,73 @@ with the following command-line.
 
 """
 
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI
+
+from galaxy.app import UniverseApplication as GalaxyUniverseApplication
 from galaxy.main_config import (
     DEFAULT_CONFIG_SECTION,
     WebappConfigResolver,
     WebappSetupProps,
 )
+from galaxy.util.properties import load_app_properties
 from galaxy.webapps.galaxy.buildapp import app_pair
 from .fast_app import initialize_fast_app
+
+FastAppFactory = Callable[[Any, GalaxyUniverseApplication], FastAPI]
+
+
+@dataclass(frozen=True)
+class GalaxyWebApp:
+    """The application objects assembled for a Galaxy web process."""
+
+    galaxy_app: GalaxyUniverseApplication
+    wsgi_app: Any
+    asgi_app: FastAPI
+
+
+def build_galaxy_web_app(
+    galaxy_config: Mapping[str, Any] | None = None,
+    *,
+    global_conf: Mapping[str, Any] | None = None,
+    load_app_kwds: Mapping[str, Any] | None = None,
+    wsgi_preflight: bool = False,
+    register_shutdown_at_exit: bool = True,
+    init_fast_app: FastAppFactory = initialize_fast_app,
+) -> GalaxyWebApp:
+    """Build Galaxy's application objects from programmatic configuration.
+
+    Unlike the uvicorn ``factory`` below, this entry point does not require a
+    configuration file or environment-variable setup. It also returns the
+    underlying Galaxy application so embedding callers can own its lifecycle.
+    Application construction exceptions are allowed to propagate to the caller.
+    """
+    global_conf_dict = dict(global_conf or {})
+    app_kwds = load_app_properties(kwds=dict(galaxy_config or {}), **dict(load_app_kwds or {}))
+    app_kwds["register_shutdown_at_exit"] = register_shutdown_at_exit
+
+    galaxy_app = GalaxyUniverseApplication(global_conf=global_conf_dict, is_webapp=True, **app_kwds)
+    try:
+        wsgi_app, paired_galaxy_app = app_pair(
+            global_conf_dict,
+            app=galaxy_app,
+            wsgi_preflight=wsgi_preflight,
+            **app_kwds,
+        )
+        assert paired_galaxy_app is galaxy_app
+        asgi_app = init_fast_app(wsgi_app, galaxy_app)
+    except Exception:
+        with suppress(Exception):
+            galaxy_app.shutdown()
+        raise
+    return GalaxyWebApp(galaxy_app=galaxy_app, wsgi_app=wsgi_app, asgi_app=asgi_app)
 
 
 def factory():
@@ -60,7 +120,9 @@ def factory():
     )
     config_provider = WebappConfigResolver(props)
     config = config_provider.resolve_config()
-    gx_wsgi_webapp, gx_app = app_pair(
-        global_conf=config.global_conf, load_app_kwds=config.load_app_kwds, wsgi_preflight=config.wsgi_preflight
+    web_app = build_galaxy_web_app(
+        global_conf=config.global_conf,
+        load_app_kwds=config.load_app_kwds,
+        wsgi_preflight=config.wsgi_preflight,
     )
-    return initialize_fast_app(gx_wsgi_webapp, gx_app)
+    return web_app.asgi_app

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -40,9 +40,7 @@ from galaxy.util import (
     download_to_file,
     galaxy_directory,
 )
-from galaxy.util.properties import load_app_properties
 from galaxy.webapps.base.api import build_route_name_index
-from galaxy.webapps.galaxy import buildapp
 from galaxy.webapps.galaxy.fast_app import (
     _build_merged_openapi,
     add_galaxy_middleware,
@@ -50,6 +48,11 @@ from galaxy.webapps.galaxy.fast_app import (
     include_tus,
     initialize_fast_app as init_galaxy_fast_app,
     XFrameOptionsMiddleware,
+)
+from galaxy.webapps.galaxy.fast_factory import (
+    build_galaxy_web_app as build_galaxy_web_app_bundle,
+    FastAppFactory,
+    GalaxyWebApp,
 )
 from galaxy_test.base.api_util import (
     get_admin_api_key,
@@ -573,19 +576,18 @@ def cleanup_directory(tempdir: str) -> None:
         pass
 
 
-def build_galaxy_app(simple_kwargs) -> GalaxyUniverseApplication:
-    """Build a Galaxy app object from a simple keyword arguments.
-
-    Construct paste style complex dictionary and use load_app_properties so
-    Galaxy override variables are respected. Also setup "global" references
-    to sqlalchemy database context for Galaxy and install databases.
-    """
+def build_galaxy_web_app(simple_kwargs, init_fast_app: FastAppFactory = init_galaxy_fast_app) -> GalaxyWebApp:
+    """Build Galaxy's application objects for an embedded test server."""
     log.info("Galaxy database connection: %s", simple_kwargs["database_connection"])
-    simple_kwargs["global_conf"] = get_webapp_global_conf()
-    simple_kwargs["global_conf"]["__file__"] = "lib/galaxy/config/sample/galaxy.yml.sample"
-    simple_kwargs = load_app_properties(kwds=simple_kwargs)
-    # Build the Universe Application
-    app = GalaxyUniverseApplication(**simple_kwargs, is_webapp=True)
+    global_conf = get_webapp_global_conf()
+    global_conf["__file__"] = "lib/galaxy/config/sample/galaxy.yml.sample"
+    web_app = build_galaxy_web_app_bundle(
+        simple_kwargs,
+        global_conf=global_conf,
+        register_shutdown_at_exit=False,
+        init_fast_app=init_fast_app,
+    )
+    app = web_app.galaxy_app
     log.info("Embedded Galaxy application started")
 
     global install_context
@@ -598,7 +600,12 @@ def build_galaxy_app(simple_kwargs) -> GalaxyUniverseApplication:
     # pretty fast with the limited toolset
     app.reindex_tool_search()
 
-    return app
+    return web_app
+
+
+def build_galaxy_app(simple_kwargs):
+    """Compatibility wrapper returning only the Galaxy application object."""
+    return build_galaxy_web_app(simple_kwargs).galaxy_app
 
 
 def explicitly_configured_host_and_port(prefix, config_object):
@@ -917,12 +924,13 @@ def caching_fast_app_factory(gx_wsgi_webapp, gx_app):
 
 
 def launch_server(
-    app_factory,
-    webapp_factory,
+    app_factory=None,
+    webapp_factory=None,
     prefix=DEFAULT_CONFIG_PREFIX,
     galaxy_config=None,
     config_object=None,
     init_fast_app=init_galaxy_fast_app,
+    webapp_bundle_factory=None,
 ):
     name = prefix.lower()
     host, port = explicitly_configured_host_and_port(prefix, config_object)
@@ -948,16 +956,23 @@ def launch_server(
         gravity_wrapper.wait_for_server()
         return gravity_wrapper
 
-    app = app_factory()
+    if webapp_bundle_factory is None:
+        assert app_factory is not None
+        assert webapp_factory is not None
+        app = app_factory()
+        wsgi_webapp = webapp_factory(
+            galaxy_config["global_conf"],
+            app=app,
+            use_translogger=False,
+            static_enabled=True,
+            register_shutdown_at_exit=False,
+        )
+        asgi_app = init_fast_app(wsgi_webapp, app)
+    else:
+        web_app = webapp_bundle_factory()
+        app = web_app.galaxy_app
+        asgi_app = web_app.asgi_app
     url_prefix = getattr(app.config, f"{name}_url_prefix", "/")
-    wsgi_webapp = webapp_factory(
-        galaxy_config["global_conf"],
-        app=app,
-        use_translogger=False,
-        static_enabled=True,
-        register_shutdown_at_exit=False,
-    )
-    asgi_app = init_fast_app(wsgi_webapp, app)
 
     server, port, thread = uvicorn_serve(asgi_app, host=host, port=port)
     set_and_wait_for_http_target(prefix, host, port, url_prefix=url_prefix)
@@ -1108,16 +1123,15 @@ class GalaxyTestDriver(TestDriver):
                 if handle_galaxy_config_kwds is not None:
                     handle_galaxy_config_kwds(galaxy_config)
 
-            launch_kwargs: dict[str, Any] = dict(
-                app_factory=lambda: self.build_galaxy_app(galaxy_config),
-                webapp_factory=lambda *args, **kwd: buildapp.app_factory(*args, wsgi_preflight=False, **kwd),
-                galaxy_config=galaxy_config,
-                config_object=config_object,
-                init_fast_app=caching_fast_app_factory,
-            )
+            init_fast_app = caching_fast_app_factory
             custom_init_fast_app = getattr(config_object, "init_fast_app", None)
             if custom_init_fast_app is not None:
-                launch_kwargs["init_fast_app"] = custom_init_fast_app
+                init_fast_app = custom_init_fast_app
+            launch_kwargs: dict[str, Any] = dict(
+                webapp_bundle_factory=lambda: self.build_galaxy_web_app(galaxy_config, init_fast_app=init_fast_app),
+                galaxy_config=galaxy_config,
+                config_object=config_object,
+            )
             server_wrapper = launch_server(**launch_kwargs)
             self.server_wrappers.append(server_wrapper)
         else:
@@ -1125,7 +1139,12 @@ class GalaxyTestDriver(TestDriver):
             # Ensure test file directory setup even though galaxy config isn't built.
             ensure_test_file_dir_set()
 
-    def build_galaxy_app(self, galaxy_config) -> GalaxyUniverseApplication:
+    def build_galaxy_web_app(self, galaxy_config, init_fast_app: FastAppFactory = init_galaxy_fast_app) -> GalaxyWebApp:
+        web_app = build_galaxy_web_app(galaxy_config, init_fast_app=init_fast_app)
+        self.app = web_app.galaxy_app
+        return web_app
+
+    def build_galaxy_app(self, galaxy_config):
         self.app = build_galaxy_app(galaxy_config)
         return self.app
 

--- a/lib/tool_shed/test/base/driver.py
+++ b/lib/tool_shed/test/base/driver.py
@@ -5,8 +5,6 @@ import os
 import string
 import tempfile
 
-# This is for the tool shed application.
-from galaxy.webapps.galaxy.buildapp import app_factory as galaxy_app_factory
 from galaxy_test.driver import driver_util
 from tool_shed.test.base.api_util import get_admin_api_key
 from tool_shed.webapp import buildapp as toolshedbuildapp
@@ -209,8 +207,7 @@ class ToolShedTestDriver(driver_util.TestDriver):
 
             # ---- Run galaxy webserver ------------------------------------------------------
             galaxy_server_wrapper = driver_util.launch_server(
-                app_factory=lambda: driver_util.build_galaxy_app(kwargs),
-                webapp_factory=galaxy_app_factory,
+                webapp_bundle_factory=lambda: driver_util.build_galaxy_web_app(kwargs),
                 galaxy_config=kwargs,
             )
             log.info(f"Galaxy tests will be run against {galaxy_server_wrapper.host}:{galaxy_server_wrapper.port}")

--- a/packages/web_apps/tests/fast_factory_test.py
+++ b/packages/web_apps/tests/fast_factory_test.py
@@ -1,15 +1,38 @@
+import json
+import os
+import sys
+import time
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+from galaxy.jobs import MinimalJobWrapper
+from galaxy.model import Job
 from galaxy.util import in_packages
 from galaxy.webapps.galaxy import fast_factory
+
+
+def wait_for_job(client, job_id, headers):
+    deadline = time.monotonic() + 90
+    while time.monotonic() < deadline:
+        response = client.get(f"/api/jobs/{job_id}", headers=headers)
+        assert response.status_code == 200
+        state = response.json()["state"]
+        if state in {"ok", "error", "deleted"}:
+            return state
+        time.sleep(0.5)
+    pytest.fail(f"job {job_id} did not finish within 90 seconds")
 
 
 @pytest.mark.skipif(not in_packages(), reason="requires package-installed Galaxy")
 def test_build_galaxy_web_app_starts_without_a_checkout(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    galaxy_bin = str(Path(sys.executable).parent)
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join(path for path in os.environ["PATH"].split(os.pathsep) if path != galaxy_bin)
+    )
     paths = {name: tmp_path / name for name in ("config", "data", "files", "jobs", "new")}
     for path in paths.values():
         path.mkdir()
@@ -32,12 +55,55 @@ def test_build_galaxy_web_app_starts_without_a_checkout(tmp_path, monkeypatch):
     )
 
     try:
+        job_wrapper = MinimalJobWrapper(Job(), web_app.galaxy_app)
+        assert job_wrapper.galaxy_lib_dir is None
+        assert job_wrapper.galaxy_virtual_env == sys.prefix
+
         tool_path = Path(web_app.galaxy_app.config.tool_path)
         assert tool_path.name == "bundled"
         assert "site-packages" in tool_path.parts
         with TestClient(web_app.asgi_app) as client:
             response = client.get("/api/version")
-        assert response.status_code == 200
-        assert response.json()["version_major"]
+            assert response.status_code == 200
+            assert response.json()["version_major"]
+
+            admin_headers = {"x-api-key": "package-test-key"}
+            user_response = client.post(
+                "/api/users",
+                json={
+                    "email": "package-test@example.org",
+                    "password": "package-test-password",
+                    "username": "package-test",
+                },
+                headers=admin_headers,
+            )
+            assert user_response.status_code == 200, user_response.text
+            user_id = user_response.json()["id"]
+            api_key_response = client.post(f"/api/users/{user_id}/api_key", headers=admin_headers)
+            assert api_key_response.status_code == 200, api_key_response.text
+            headers = {"x-api-key": api_key_response.json()}
+            history_response = client.post("/api/histories", json={"name": "package smoke test"}, headers=headers)
+            assert history_response.status_code == 200, history_response.text
+            history_id = history_response.json()["id"]
+            upload_response = client.post(
+                "/api/tools",
+                data={
+                    "history_id": history_id,
+                    "tool_id": "upload1",
+                    "upload_type": "upload_dataset",
+                    "inputs": json.dumps(
+                        {
+                            "dbkey": "?",
+                            "file_type": "txt",
+                            "files_0|NAME": "hello.txt",
+                            "files_0|url_paste": "hello, wheel-installed Galaxy!\n",
+                        }
+                    ),
+                },
+                headers=headers,
+            )
+            assert upload_response.status_code == 200, upload_response.text
+            job_id = upload_response.json()["jobs"][0]["id"]
+            assert wait_for_job(client, job_id, headers) == "ok"
     finally:
         web_app.galaxy_app.shutdown()

--- a/packages/web_apps/tests/fast_factory_test.py
+++ b/packages/web_apps/tests/fast_factory_test.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from galaxy.util import in_packages
+from galaxy.webapps.galaxy import fast_factory
+
+
+def test_factory_uses_shared_web_app_builder(monkeypatch):
+    config = Mock(global_conf={"from": "file"}, load_app_kwds={"config_file": "galaxy.yml"}, wsgi_preflight=True)
+    monkeypatch.setattr(
+        fast_factory,
+        "WebappConfigResolver",
+        Mock(return_value=Mock(resolve_config=Mock(return_value=config))),
+    )
+    web_app = Mock()
+    builder = Mock(return_value=web_app)
+    monkeypatch.setattr(fast_factory, "build_galaxy_web_app", builder)
+
+    assert fast_factory.factory() is web_app.asgi_app
+    builder.assert_called_once_with(
+        global_conf=config.global_conf,
+        load_app_kwds=config.load_app_kwds,
+        wsgi_preflight=config.wsgi_preflight,
+    )
+
+
+def test_build_galaxy_web_app_assembles_and_returns_all_layers(monkeypatch):
+    galaxy_app = Mock()
+    wsgi_app = Mock()
+    asgi_app = Mock()
+    observed = {}
+
+    def create_galaxy_app(**kwds):
+        observed["app_kwds"] = kwds
+        return galaxy_app
+
+    def create_app_pair(global_conf, **kwds):
+        observed["global_conf"] = global_conf
+        observed["pair_kwds"] = kwds
+        return wsgi_app, galaxy_app
+
+    def create_fast_app(actual_wsgi_app, actual_galaxy_app):
+        assert actual_wsgi_app is wsgi_app
+        assert actual_galaxy_app is galaxy_app
+        return asgi_app
+
+    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", create_galaxy_app)
+    monkeypatch.setattr(fast_factory, "app_pair", create_app_pair)
+
+    web_app = fast_factory.build_galaxy_web_app(
+        {"database_connection": "sqlite:///:memory:"},
+        global_conf={"static_enabled": False},
+        register_shutdown_at_exit=False,
+        init_fast_app=create_fast_app,
+    )
+
+    assert web_app.galaxy_app is galaxy_app
+    assert web_app.wsgi_app is wsgi_app
+    assert web_app.asgi_app is asgi_app
+    assert observed["app_kwds"]["database_connection"] == "sqlite:///:memory:"
+    assert observed["app_kwds"]["register_shutdown_at_exit"] is False
+    assert observed["global_conf"] == {"static_enabled": False}
+    assert observed["pair_kwds"]["app"] is galaxy_app
+    assert observed["pair_kwds"]["register_shutdown_at_exit"] is False
+
+
+def test_build_galaxy_web_app_does_not_mutate_input(monkeypatch):
+    config = {"database_connection": "sqlite:///:memory:"}
+    galaxy_app = Mock()
+    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", Mock(return_value=galaxy_app))
+    monkeypatch.setattr(fast_factory, "app_pair", Mock(return_value=(Mock(), galaxy_app)))
+
+    fast_factory.build_galaxy_web_app(config, init_fast_app=Mock())
+
+    assert config == {"database_connection": "sqlite:///:memory:"}
+
+
+def test_build_galaxy_web_app_propagates_construction_errors(monkeypatch):
+    class ExpectedError(Exception):
+        pass
+
+    def fail_to_create_app(**kwds):
+        raise ExpectedError()
+
+    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", fail_to_create_app)
+
+    with pytest.raises(ExpectedError):
+        fast_factory.build_galaxy_web_app()
+
+
+def test_build_galaxy_web_app_shuts_down_partially_built_app(monkeypatch):
+    class ExpectedError(Exception):
+        pass
+
+    galaxy_app = Mock()
+    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", Mock(return_value=galaxy_app))
+    monkeypatch.setattr(fast_factory, "app_pair", Mock(side_effect=ExpectedError))
+
+    with pytest.raises(ExpectedError):
+        fast_factory.build_galaxy_web_app()
+
+    galaxy_app.shutdown.assert_called_once_with()
+
+
+@pytest.mark.skipif(not in_packages(), reason="requires package-installed Galaxy")
+def test_build_galaxy_web_app_starts_without_a_checkout(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    paths = {name: tmp_path / name for name in ("config", "data", "files", "jobs", "new")}
+    for path in paths.values():
+        path.mkdir()
+
+    web_app = fast_factory.build_galaxy_web_app(
+        {
+            "config_dir": str(paths["config"]),
+            "managed_config_dir": str(paths["config"]),
+            "data_dir": str(paths["data"]),
+            "database_connection": f"sqlite:///{paths['data'] / 'galaxy.sqlite'}?isolation_level=IMMEDIATE",
+            "database_auto_migrate": True,
+            "file_path": str(paths["files"]),
+            "job_working_directory": str(paths["jobs"]),
+            "new_file_path": str(paths["new"]),
+            "bootstrap_admin_api_key": "package-test-key",
+            "id_secret": "package-test-secret",
+            "use_heartbeat": False,
+        },
+        register_shutdown_at_exit=False,
+    )
+
+    try:
+        tool_path = Path(web_app.galaxy_app.config.tool_path)
+        assert tool_path.name == "bundled"
+        assert "site-packages" in tool_path.parts
+        with TestClient(web_app.asgi_app) as client:
+            response = client.get("/api/version")
+        assert response.status_code == 200
+        assert response.json()["version_major"]
+    finally:
+        web_app.galaxy_app.shutdown()

--- a/packages/web_apps/tests/fast_factory_test.py
+++ b/packages/web_apps/tests/fast_factory_test.py
@@ -1,108 +1,10 @@
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from galaxy.util import in_packages
 from galaxy.webapps.galaxy import fast_factory
-
-
-def test_factory_uses_shared_web_app_builder(monkeypatch):
-    config = Mock(global_conf={"from": "file"}, load_app_kwds={"config_file": "galaxy.yml"}, wsgi_preflight=True)
-    monkeypatch.setattr(
-        fast_factory,
-        "WebappConfigResolver",
-        Mock(return_value=Mock(resolve_config=Mock(return_value=config))),
-    )
-    web_app = Mock()
-    builder = Mock(return_value=web_app)
-    monkeypatch.setattr(fast_factory, "build_galaxy_web_app", builder)
-
-    assert fast_factory.factory() is web_app.asgi_app
-    builder.assert_called_once_with(
-        global_conf=config.global_conf,
-        load_app_kwds=config.load_app_kwds,
-        wsgi_preflight=config.wsgi_preflight,
-    )
-
-
-def test_build_galaxy_web_app_assembles_and_returns_all_layers(monkeypatch):
-    galaxy_app = Mock()
-    wsgi_app = Mock()
-    asgi_app = Mock()
-    observed = {}
-
-    def create_galaxy_app(**kwds):
-        observed["app_kwds"] = kwds
-        return galaxy_app
-
-    def create_app_pair(global_conf, **kwds):
-        observed["global_conf"] = global_conf
-        observed["pair_kwds"] = kwds
-        return wsgi_app, galaxy_app
-
-    def create_fast_app(actual_wsgi_app, actual_galaxy_app):
-        assert actual_wsgi_app is wsgi_app
-        assert actual_galaxy_app is galaxy_app
-        return asgi_app
-
-    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", create_galaxy_app)
-    monkeypatch.setattr(fast_factory, "app_pair", create_app_pair)
-
-    web_app = fast_factory.build_galaxy_web_app(
-        {"database_connection": "sqlite:///:memory:"},
-        global_conf={"static_enabled": False},
-        register_shutdown_at_exit=False,
-        init_fast_app=create_fast_app,
-    )
-
-    assert web_app.galaxy_app is galaxy_app
-    assert web_app.wsgi_app is wsgi_app
-    assert web_app.asgi_app is asgi_app
-    assert observed["app_kwds"]["database_connection"] == "sqlite:///:memory:"
-    assert observed["app_kwds"]["register_shutdown_at_exit"] is False
-    assert observed["global_conf"] == {"static_enabled": False}
-    assert observed["pair_kwds"]["app"] is galaxy_app
-    assert observed["pair_kwds"]["register_shutdown_at_exit"] is False
-
-
-def test_build_galaxy_web_app_does_not_mutate_input(monkeypatch):
-    config = {"database_connection": "sqlite:///:memory:"}
-    galaxy_app = Mock()
-    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", Mock(return_value=galaxy_app))
-    monkeypatch.setattr(fast_factory, "app_pair", Mock(return_value=(Mock(), galaxy_app)))
-
-    fast_factory.build_galaxy_web_app(config, init_fast_app=Mock())
-
-    assert config == {"database_connection": "sqlite:///:memory:"}
-
-
-def test_build_galaxy_web_app_propagates_construction_errors(monkeypatch):
-    class ExpectedError(Exception):
-        pass
-
-    def fail_to_create_app(**kwds):
-        raise ExpectedError()
-
-    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", fail_to_create_app)
-
-    with pytest.raises(ExpectedError):
-        fast_factory.build_galaxy_web_app()
-
-
-def test_build_galaxy_web_app_shuts_down_partially_built_app(monkeypatch):
-    class ExpectedError(Exception):
-        pass
-
-    galaxy_app = Mock()
-    monkeypatch.setattr(fast_factory, "GalaxyUniverseApplication", Mock(return_value=galaxy_app))
-    monkeypatch.setattr(fast_factory, "app_pair", Mock(side_effect=ExpectedError))
-
-    with pytest.raises(ExpectedError):
-        fast_factory.build_galaxy_web_app()
-
-    galaxy_app.shutdown.assert_called_once_with()
 
 
 @pytest.mark.skipif(not in_packages(), reason="requires package-installed Galaxy")

--- a/test/unit/test_driver/test_driver_util.py
+++ b/test/unit/test_driver/test_driver_util.py
@@ -13,6 +13,32 @@ def test_attempt_ports():
     assert port >= 8000 and port <= 10000
 
 
+def test_launch_server_accepts_built_galaxy_web_app(monkeypatch):
+    galaxy_app = Mock(config=Mock(galaxy_url_prefix="/"))
+    asgi_app = Mock()
+    server = Mock()
+    thread = Mock()
+    web_app = Mock(galaxy_app=galaxy_app, asgi_app=asgi_app)
+
+    monkeypatch.setattr(driver_util, "explicitly_configured_host_and_port", lambda *args: ("127.0.0.1", None))
+    monkeypatch.setattr(driver_util, "attempt_ports", lambda port: "8123")
+    uvicorn_serve = Mock(return_value=(server, "8123", thread))
+    monkeypatch.setattr(driver_util, "uvicorn_serve", uvicorn_serve)
+    wait_for_target = Mock()
+    monkeypatch.setattr(driver_util, "set_and_wait_for_http_target", wait_for_target)
+
+    wrapper = driver_util.launch_server(
+        galaxy_config={},
+        webapp_bundle_factory=lambda: web_app,
+    )
+
+    uvicorn_serve.assert_called_once_with(asgi_app, host="127.0.0.1", port="8123")
+    wait_for_target.assert_called_once_with("GALAXY", "127.0.0.1", "8123", url_prefix="/")
+    assert wrapper.app is galaxy_app
+    assert wrapper._server is server
+    assert wrapper._thread is thread
+
+
 def _gx_app(new_file_path: str) -> Mock:
     # Spell out every setting caching_fast_app_factory reads: an unset Mock attribute is
     # a truthy Mock, which sends the factory down the uncached path.

--- a/test/unit/test_driver/test_driver_util.py
+++ b/test/unit/test_driver/test_driver_util.py
@@ -13,32 +13,6 @@ def test_attempt_ports():
     assert port >= 8000 and port <= 10000
 
 
-def test_launch_server_accepts_built_galaxy_web_app(monkeypatch):
-    galaxy_app = Mock(config=Mock(galaxy_url_prefix="/"))
-    asgi_app = Mock()
-    server = Mock()
-    thread = Mock()
-    web_app = Mock(galaxy_app=galaxy_app, asgi_app=asgi_app)
-
-    monkeypatch.setattr(driver_util, "explicitly_configured_host_and_port", lambda *args: ("127.0.0.1", None))
-    monkeypatch.setattr(driver_util, "attempt_ports", lambda port: "8123")
-    uvicorn_serve = Mock(return_value=(server, "8123", thread))
-    monkeypatch.setattr(driver_util, "uvicorn_serve", uvicorn_serve)
-    wait_for_target = Mock()
-    monkeypatch.setattr(driver_util, "set_and_wait_for_http_target", wait_for_target)
-
-    wrapper = driver_util.launch_server(
-        galaxy_config={},
-        webapp_bundle_factory=lambda: web_app,
-    )
-
-    uvicorn_serve.assert_called_once_with(asgi_app, host="127.0.0.1", port="8123")
-    wait_for_target.assert_called_once_with("GALAXY", "127.0.0.1", "8123", url_prefix="/")
-    assert wrapper.app is galaxy_app
-    assert wrapper._server is server
-    assert wrapper._thread is thread
-
-
 def _gx_app(new_file_path: str) -> Mock:
     # Spell out every setting caching_fast_app_factory reads: an unset Mock attribute is
     # a truthy Mock, which sends the factory down the uncached path.


### PR DESCRIPTION
This introduces a supported programmatic entry point for constructing and running Galaxy's application stack without requiring a Galaxy checkout, configuration file, or environment-based launcher setup.

`build_galaxy_web_app()` returns the underlying Galaxy application together with its WSGI and ASGI applications. This lets embedding clients own server startup, readiness checks, and shutdown while reusing Galaxy's application assembly.

The existing uvicorn factory and Galaxy test driver now use this shared builder. The Tool Shed test driver also uses it when launching its embedded Galaxy instance.

If WSGI or ASGI initialization fails after the Galaxy application has been constructed, the partially initialized application is shut down before the original exception is propagated.

The wheel-installed job path is also made checkout-free:

- `GALAXY_LIB` is left unset for package installs instead of pointing at a nonexistent CWD-relative `lib` directory. Source checkouts retain their existing absolute `lib` path.
- When `VIRTUAL_ENV` is absent but Galaxy is running inside a venv, job scripts recover that environment from `sys.prefix`. This supports invoking the venv's Python by absolute path without pre-activating it.

Together these changes provide the Galaxy-side API and ordinary job path needed for a future Planemo prototype without coupling Galaxy to Planemo's server lifecycle or configuration policy.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

The package test constructs Galaxy from an empty temporary directory using wheel-installed Galaxy packages. It removes `VIRTUAL_ENV` and the venv's `bin` directory from `PATH`, verifies packaged bundled-tool discovery and `/api/version`, then creates a user and history and runs the bundled upload tool through a successful job and external-metadata cycle.

The test runs as part of:

    tox -e test_galaxy_packages

The focused package-installed test was also run against rebuilt wheels in a clean external venv.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
