### PR TITLE
Add new datatype (mzlite) to galaxy

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -425,6 +425,7 @@
     <datatype extension="mzq" type="galaxy.datatypes.proteomics:MzQuantML" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="sqlite" type="galaxy.datatypes.binary:SQlite" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="mz.sqlite" type="galaxy.datatypes.binary:MzSQlite" mimetype="application/octet-stream" display_in_upload="true"/>
+    <datatype extension="mzlite" type="galaxy.datatypes.binary:Mzlite" display_in_upload="true"/>
     <datatype extension="osw" type="galaxy.datatypes.binary:OSW" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="pqp" type="galaxy.datatypes.binary:PQP" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="traml" type="galaxy.datatypes.proteomics:TraML" mimetype="application/xml" display_in_upload="true"/>
@@ -1279,6 +1280,7 @@
     <sniffer type="galaxy.datatypes.binary:GeminiSQLite"/>
     <sniffer type="galaxy.datatypes.binary:SQmass"/>
     <sniffer type="galaxy.datatypes.binary:MzSQlite"/>
+    <sniffer type="galaxy.datatypes.binary:Mzlite"/>
     <sniffer type="galaxy.datatypes.binary:OSW"/>
     <sniffer type="galaxy.datatypes.binary:PQP"/>
     <sniffer type="galaxy.datatypes.binary:IdpDB"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -3115,10 +3115,12 @@ class MzSQlite(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
-class Mzlite(SQlite): 
+
+class Mzlite(SQlite):
     """Class describing a Proteomics mzlite database"""
 
-    file_ext ="mzlite"
+    file_ext = "mzlite"
+
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
 
@@ -3131,6 +3133,7 @@ class Mzlite(SQlite):
             ]
             return self.sniff_table_names(filename, table_names)
         return False
+
 
 class PQP(SQlite):
     """

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -3115,6 +3115,22 @@ class MzSQlite(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
+class Mzlite(SQlite): 
+    """Class describing a Proteomics mzlite database"""
+
+    file_ext ="mzlite"
+     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
+        super().set_meta(dataset, overwrite=overwrite, **kwd)
+
+    def sniff(self, filename: str) -> bool:
+        if super().sniff(filename):
+            table_names = [
+                "Chromatogram",
+                "Model",
+                "Spectrum",
+            ]
+            return self.sniff_table_names(filename, table_names)
+        return False
 
 class PQP(SQlite):
     """

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -3119,7 +3119,7 @@ class Mzlite(SQlite):
     """Class describing a Proteomics mzlite database"""
 
     file_ext ="mzlite"
-     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
+    def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
 
     def sniff(self, filename: str) -> bool:


### PR DESCRIPTION
Added a new datatype (mzlite) to galaxy. The Mzlite data type is required for the ProteomIQon toolchain and makes it easier to use, as it makes it clear that Mzlite files are required as input.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
