### PR TITLE
[26.1] Bound expression.json read failures in the workflow scheduler

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -14,6 +14,7 @@ from typing import (
     get_args,
     Optional,
     TYPE_CHECKING,
+    TypeAlias,
     Union,
 )
 
@@ -165,13 +166,27 @@ class ConditionalStepWhen(BooleanToolParameter):
     pass
 
 
+ExpressionJsonValue: TypeAlias = Union[None, bool, int, float, str, list, dict]
+
+# Values accepted while connecting workflow outputs and defaults to tool inputs.
+StepInputReplacement: TypeAlias = Union[
+    NoReplacement,
+    model.HistoryItem,
+    model.DatasetCollectionElement,
+    PromoteCollectionElementToCollectionAdapter,
+    ExpressionJsonValue,
+]
+
+
 # Workflow schedulers may temporarily see a just-written expression.json as missing
 # or empty on shared filesystems. Bound retries by dataset update time so permanently
 # malformed datasets eventually fail.
 EXPRESSION_JSON_GRACE_PERIOD_SECONDS = 60
 
 
-def read_expression_json(dataset_instance: model.DatasetInstance, step: Optional[WorkflowStep] = None):
+def read_expression_json(
+    dataset_instance: model.DatasetInstance, step: Optional[WorkflowStep] = None
+) -> ExpressionJsonValue:
     """Return the value stored in an ``expression.json`` dataset.
 
     With a workflow step, delay a recent missing or invalid dataset and fail once its
@@ -207,7 +222,9 @@ def read_expression_json(dataset_instance: model.DatasetInstance, step: Optional
         )
 
 
-def replace_expression_json_dataset(replacement, step: Optional[WorkflowStep] = None):
+def replace_expression_json_dataset(
+    replacement: StepInputReplacement, step: Optional[WorkflowStep] = None
+) -> StepInputReplacement:
     """Resolve a non-data parameter connected to an ``expression.json`` output to its value.
 
     Anything not backed by an ``expression.json`` dataset is returned unchanged.
@@ -670,9 +687,9 @@ class WorkflowModule:
         for input_dict in all_inputs:
             name = input_dict["name"]
             data = progress.replacement_for_input(self.trans, step, input_dict)
-            can_map_over = hasattr(data, "collection") and data.collection.allow_implicit_mapping
-
-            if not can_map_over:
+            if not isinstance(data, (model.DatasetCollectionInstance, model.DatasetCollectionElement)):
+                continue
+            if not data.collection.allow_implicit_mapping:
                 continue
 
             is_data_param = input_dict["input_type"] == "dataset"
@@ -741,9 +758,7 @@ class WorkflowModule:
                     collections_to_match.add(name, data, subcollection_type=subcollection_type_description)
                 continue
 
-            if data is not NO_REPLACEMENT:
-                collections_to_match.add(name, data)
-                continue
+            collections_to_match.add(name, data)
 
         known_input_names = {input_dict["name"] for input_dict in all_inputs}
 
@@ -2855,9 +2870,7 @@ class ToolModule(WorkflowModule):
             def callback(input, prefixed_name: str, **kwargs):
                 input_dict = all_inputs_by_name[prefixed_name]
 
-                replacement: Union[model.Dataset, NoReplacement, PromoteCollectionElementToCollectionAdapter] = (
-                    NO_REPLACEMENT
-                )
+                replacement: StepInputReplacement = NO_REPLACEMENT
                 if iteration_elements and prefixed_name in iteration_elements:  # noqa: B023
                     replacement = iteration_elements[prefixed_name]  # noqa: B023
                     # When mapping flat collections over paired_or_unpaired via

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -62,6 +62,7 @@ from galaxy.schema.invocation import (
     InvocationFailureStepInputDeleted,
     InvocationFailureWhenNotBoolean,
     InvocationFailureWorkflowParameterInvalid,
+    InvocationUnexpectedFailure,
 )
 from galaxy.tool_util.cwl.util import set_basename_and_derived_properties
 from galaxy.tool_util.parser import get_input_source
@@ -164,6 +165,63 @@ class ConditionalStepWhen(BooleanToolParameter):
     pass
 
 
+# Workflow schedulers may temporarily see a just-written expression.json as missing
+# or empty on shared filesystems. Bound retries by dataset update time so permanently
+# malformed datasets eventually fail.
+EXPRESSION_JSON_GRACE_PERIOD_SECONDS = 60
+
+
+def read_expression_json(dataset_instance: model.DatasetInstance, step: Optional[WorkflowStep] = None):
+    """Return the value stored in an ``expression.json`` dataset.
+
+    With a workflow step, delay a recent missing or invalid dataset and fail once its
+    grace period elapses. Other read errors, and all errors without a step, propagate
+    unchanged.
+    """
+    try:
+        with open(dataset_instance.get_file_name()) as f:
+            # safe_loads preserves non-container JSON values as their source text.
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        if step is None:
+            # Job-side callers do not handle workflow-control exceptions.
+            raise
+        # str(e) can contain the dataset path, keep that out of the invocation message.
+        problem = e.msg if isinstance(e, json.JSONDecodeError) else "file not found"
+        details = f"Contents of expression.json dataset {dataset_instance.id} could not be read: {problem}"
+        log.exception("%s. Dataset was last updated at %s.", details, dataset_instance.update_time)
+        # A dataset without a known update time counts as old, so that a permanently
+        # unreadable dataset can never delay the invocation indefinitely.
+        recently_updated = (
+            dataset_instance.update_time is not None
+            and dataset_instance.seconds_since_updated < EXPRESSION_JSON_GRACE_PERIOD_SECONDS
+        )
+        if recently_updated:
+            raise DelayedWorkflowEvaluation(why=details)
+        raise FailWorkflowEvaluation(
+            why=InvocationUnexpectedFailure(
+                reason=FailureReason.unexpected_failure,
+                details=details,
+                workflow_step_id=step.id,
+            )
+        )
+
+
+def replace_expression_json_dataset(replacement, step: Optional[WorkflowStep] = None):
+    """Resolve a non-data parameter connected to an ``expression.json`` output to its value.
+
+    Anything not backed by an ``expression.json`` dataset is returned unchanged.
+    """
+    dataset_instance: Optional[model.DatasetInstance] = None
+    if isinstance(replacement, model.DatasetCollectionElement):
+        dataset_instance = replacement.hda
+    elif isinstance(replacement, model.DatasetInstance):
+        dataset_instance = replacement
+    if dataset_instance is not None and dataset_instance.extension == "expression.json":
+        return read_expression_json(dataset_instance, step=step)
+    return replacement
+
+
 def to_cwl(
     value, hda_references, step: Optional[WorkflowStep] = None, compute_environment: Optional[ComputeEnvironment] = None
 ):
@@ -196,9 +254,7 @@ def to_cwl(
                     )
                 )
         if value.ext == "expression.json":
-            with open(value.get_file_name()) as f:
-                # OUR safe_loads won't work, will not load numbers, etc...
-                return json.load(f)
+            return read_expression_json(value, step=step)
         else:
             hda_references.append(value)
             properties = {
@@ -2824,14 +2880,7 @@ class ToolModule(WorkflowModule):
                 if replacement is not NO_REPLACEMENT:
                     if not isinstance(input, BaseDataToolParameter):
                         # Probably a parameter that can be replaced
-                        dataset_instance: Optional[model.DatasetInstance] = None
-                        if isinstance(replacement, model.DatasetCollectionElement):
-                            dataset_instance = replacement.hda
-                        elif isinstance(replacement, model.DatasetInstance):
-                            dataset_instance = replacement
-                        if dataset_instance and dataset_instance.extension == "expression.json":
-                            with open(dataset_instance.get_file_name()) as f:
-                                replacement = json.load(f)
+                        replacement = replace_expression_json_dataset(replacement, step)
                     found_replacement_keys.add(prefixed_name)  # noqa: B023
 
                     # bool cast should be fine, can only have true/false on ConditionalStepWhen

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     Optional,
     TYPE_CHECKING,
-    Union,
 )
 
 from boltons.iterutils import get_path
@@ -48,7 +47,6 @@ from galaxy.workflow.run_request import (
 
 if TYPE_CHECKING:
     from galaxy.model import (
-        HistoryItem,
         Workflow,
         WorkflowOutput,
         WorkflowStep,
@@ -459,13 +457,10 @@ class WorkflowProgress:
                 remaining_steps.append((step, invocation_step))
         return remaining_steps
 
-    def replacement_for_input(self, trans, step: "WorkflowStep", input_dict: dict[str, Any]):
-        replacement: Union[
-            NoReplacement,
-            model.DatasetCollectionInstance,
-            list[model.DatasetCollectionInstance],
-            HistoryItem,
-        ] = NO_REPLACEMENT
+    def replacement_for_input(
+        self, trans, step: "WorkflowStep", input_dict: dict[str, Any]
+    ) -> modules.StepInputReplacement:
+        replacement: modules.StepInputReplacement = NO_REPLACEMENT
         prefixed_name = input_dict["name"]
         multiple = input_dict["multiple"]
         is_data = input_dict["input_type"] in ["dataset", "dataset_collection"]

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from typing import (
     Any,
     NamedTuple,
@@ -11,9 +12,13 @@ import pytest
 
 from galaxy import model
 from galaxy.managers.workflows import WorkflowContentsManager
+from galaxy.schema.invocation import FailureReason
 from galaxy.tool_util.parser.output_objects import ToolOutput
 from galaxy.tools.parameters.workflow_utils import NO_REPLACEMENT
-from galaxy.util import bunch
+from galaxy.util import (
+    bunch,
+    now,
+)
 from galaxy.workflow import modules
 from .workflow_support import (
     MockTrans,
@@ -310,6 +315,103 @@ def test_to_cwl_dataset_collection_element():
     result = modules.to_cwl(dce_outer, [], model.WorkflowStep())
     assert result[0]["class"] == "File"
     assert result[0]["basename"] == "inner"
+
+
+def _expression_json_hda(path, content: Optional[str], seconds_since_updated: int = 0):
+    hda = model.HistoryDatasetAssociation(extension="expression.json", create_dataset=True, flush=False)
+    hda.id = 1
+    assert hda.dataset is not None
+    hda.dataset.state = model.Dataset.states.OK
+    if content is not None:
+        path.write_text(content)
+    hda.dataset.external_filename = str(path)
+    hda.update_time = now() - timedelta(seconds=seconds_since_updated)
+    return hda
+
+
+def _workflow_step():
+    step = model.WorkflowStep()
+    step.id = 1
+    return step
+
+
+def test_to_cwl_expression_json(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", '"abs(c3)>0.5"')
+    assert modules.to_cwl(hda, [], _workflow_step()) == "abs(c3)>0.5"
+
+
+def test_to_cwl_expression_json_empty_file_recently_updated_delays(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", "")
+    with pytest.raises(modules.DelayedWorkflowEvaluation) as exc_info:
+        modules.to_cwl(hda, [], _workflow_step())
+    assert "could not be read" in exc_info.value.why
+
+
+def test_to_cwl_expression_json_malformed_fails_after_grace_period(tmp_path):
+    hda = _expression_json_hda(
+        tmp_path / "expression.json",
+        "{not json",
+        seconds_since_updated=modules.EXPRESSION_JSON_GRACE_PERIOD_SECONDS + 1,
+    )
+    step = _workflow_step()
+    with pytest.raises(modules.FailWorkflowEvaluation) as exc_info:
+        modules.to_cwl(hda, [], step)
+    why = exc_info.value.why
+    assert why.reason == FailureReason.unexpected_failure
+    assert why.workflow_step_id == step.id
+    assert "dataset 1" in why.details
+
+
+def test_to_cwl_expression_json_missing_file_fails_after_grace_period(tmp_path):
+    hda = _expression_json_hda(
+        tmp_path / "expression.json", None, seconds_since_updated=modules.EXPRESSION_JSON_GRACE_PERIOD_SECONDS + 1
+    )
+    with pytest.raises(modules.FailWorkflowEvaluation) as exc_info:
+        modules.to_cwl(hda, [], _workflow_step())
+    why = exc_info.value.why
+    assert why.reason == FailureReason.unexpected_failure
+    # Invocation details must not expose the dataset path.
+    assert str(tmp_path) not in why.details
+
+
+def test_read_expression_json_without_update_time_fails_immediately(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", "")
+    hda.update_time = None
+    with pytest.raises(modules.FailWorkflowEvaluation) as exc_info:
+        modules.read_expression_json(hda, _workflow_step())
+    assert exc_info.value.why.reason == FailureReason.unexpected_failure
+
+
+def test_read_expression_json_does_not_swallow_other_os_errors(tmp_path):
+    a_directory = tmp_path / "expression.json"
+    a_directory.mkdir()
+    hda = _expression_json_hda(a_directory, None)
+    with pytest.raises(IsADirectoryError):
+        modules.read_expression_json(hda, _workflow_step())
+
+
+def test_read_expression_json_without_step_reraises_read_error(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", "")
+    with pytest.raises(json.JSONDecodeError):
+        modules.read_expression_json(hda)
+
+
+def test_replace_expression_json_dataset(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", "0.5")
+    assert modules.replace_expression_json_dataset(hda, _workflow_step()) == 0.5
+
+
+def test_replace_expression_json_dataset_collection_element(tmp_path):
+    hda = _expression_json_hda(tmp_path / "expression.json", "true")
+    collection = model.DatasetCollection(collection_type="list")
+    element = model.DatasetCollectionElement(collection=collection, element_identifier="true", element=hda)
+    assert modules.replace_expression_json_dataset(element, _workflow_step()) is True
+
+
+def test_replace_expression_json_dataset_leaves_other_replacements_unchanged():
+    hda = model.HistoryDatasetAssociation(extension="txt", create_dataset=True, flush=False)
+    assert modules.replace_expression_json_dataset(hda, _workflow_step()) is hda
+    assert modules.replace_expression_json_dataset("a string", _workflow_step()) == "a string"
 
 
 class MapOverTestCase(NamedTuple):


### PR DESCRIPTION
## Summary

- Treat a recently updated expression.json dataset that is missing or contains invalid JSON as transient for up to 60 seconds.
- Fail permanently after the grace period with dataset and workflow-step context, without exposing filesystem paths.
- Use the bounded read policy for connected non-data tool parameters and scheduler-side CWL expression conversion while preserving job-side error behavior.
- Define the value types exchanged while connecting workflow step inputs.

## Testing

- 75 workflow module/progress unit tests
- Focused expression.json regression tests
- Ruff and flake8 lint checks
- isort and Black formatting checks
- mypy across 2,280 source files

Fixes #23257