### PR TITLE
[25.1] Create /etc/cni/net.d before minikube's none driver chmods it [25.1]

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,6 +44,11 @@ jobs:
       - name: Install packages
         # ffmpeg: ffprobe needed by media datatypes
         run: sudo apt-get update && sudo apt-get -y install ffmpeg
+      - name: Create the CNI config directory minikube's none driver expects
+        # The action chmods /etc/cni/net.d without creating it, and current
+        # runner images no longer ship the directory. See
+        # https://github.com/medyagh/setup-minikube/issues/835
+        run: sudo mkdir -p /etc/cni/net.d
       - name: Setup Minikube
         uses: medyagh/setup-minikube@latest
         with:


### PR DESCRIPTION
Backports only the Minikube setup fix from #23316 / commit 7b7240e0e579d0b1698aae08a581b256abb8e6bc to release_25.1.

The setup-minikube action uses `sudo chmod 755 /etc/cni/net.d` for the `none` driver without creating the directory first. Current `ubuntu-latest` runner images no longer provide it, causing every Integration matrix shard to fail during Setup Minikube. Pre-create the directory immediately before invoking the action.

Upstream action issue: https://github.com/medyagh/setup-minikube/issues/835

Validation:
- Repository `check-github-workflows` hook passes
- Workflow parses as valid YAML
- `git diff --check` passes
- Diff against `release_25.1` is limited to the five-line workflow change