### PR TITLE
[26.1] Qualify GCP Batch network and subnet names with the project ID

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -362,16 +362,27 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
         # Configure network for NFS access (required when using NFS volumes)
         if parsed_volumes:
             network_interface = batch_v1.AllocationPolicy.NetworkInterface()
-            network_interface.network = f"global/networks/{params.get('network', 'default')}"
-            network_interface.subnetwork = f"regions/{params['region']}/subnetworks/{params.get('subnet', 'default')}"
+            # Qualify bare names with the project so Batch resolves them in project_id's
+            # VPC, not the (possibly different, e.g. a Terra pet) project the Batch VMs are
+            # provisioned in -- a relative "global/networks/<name>" resolves against the
+            # latter and 404s. A value that is already a full/relative path is passed through.
+            project_id = params["project_id"]
+            network = params.get("network", "default")
+            subnet = params.get("subnet", "default")
+            network_interface.network = (
+                network if "/" in network else f"projects/{project_id}/global/networks/{network}"
+            )
+            network_interface.subnetwork = (
+                subnet if "/" in subnet else f"projects/{project_id}/regions/{params['region']}/subnetworks/{subnet}"
+            )
 
             network_policy = batch_v1.AllocationPolicy.NetworkPolicy()
             network_policy.network_interfaces = [network_interface]
             allocation_policy.network = network_policy
             log.debug(
-                "Configured network for NFS access: %s/%s for job %s",
-                params.get("network", "default"),
-                params.get("subnet", "default"),
+                "Configured network for NFS access: %s / %s for job %s",
+                network_interface.network,
+                network_interface.subnetwork,
                 job_wrapper.get_id_tag(),
             )
 


### PR DESCRIPTION
The GCP Batch runner builds network interface paths as `global/networks/{name}` and `regions/{region}/subnetworks/{name}`. These relative paths resolve against the project the Batch VMs are provisioned in, which is not necessarily the project that owns the VPC (e.g. Terra pet projects). When the two differ, job submission fails with a 404 on the network resource.

## The Fix

Bare `network` and `subnet` names are now qualified as `projects/{project_id}/global/networks/{name}` and `projects/{project_id}/regions/{region}/subnetworks/{name}` using the runner's `project_id` parameter. Values that already contain a `/` (full or relative resource paths) are passed through unchanged, so existing configurations keep working. The debug log now reports the fully qualified paths actually sent to the Batch API.

## Testing

- All 144 existing runner unit tests pass: `./run_tests.sh -unit test/unit/app/jobs/test_gcp_batch_runner.py`
- To verify manually: configure the runner with bare `network`/`subnet` names and a `project_id` whose VPC lives in a different project than the Batch VMs, submit a job, and confirm the network resolves instead of returning a 404.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
