### PR TITLE
[26.1] Fix visualization plugin URLs when Galaxy is served under a URL prefix

### DIFF
--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -298,6 +298,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.vault_config_file = kwargs.get("vault_config_file")
         self.url_headers_config_file = None
         self.max_discovered_files = 10000
+        self.galaxy_url_prefix = "/"
         self.display_builtin_converters = True
         self.enable_notification_system = True
         self.config_dict = self.dict()

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -7,8 +7,6 @@ import logging
 import os
 from typing import Any
 
-from galaxy.web import url_for
-
 log = logging.getLogger(__name__)
 
 
@@ -17,10 +15,11 @@ class VisualizationPlugin:
     A plugin that instantiates resources, serves static files.
     """
 
-    def __init__(self, path: str, name: str, config: dict[str, Any]) -> None:
+    def __init__(self, path: str, name: str, config: dict[str, Any], url_prefix: str = "") -> None:
         self.path = path
         self.name = name
         self.config = config
+        self.url_prefix = url_prefix
         self.static_path = os.path.join("/static/plugins/visualizations/", name, "static")
         self._set_logo()
 
@@ -32,7 +31,7 @@ class VisualizationPlugin:
             "embeddable": self.config.get("embeddable"),
             "entry_point": self.config.get("entry_point"),
             "html": self.config.get("name"),
-            "href": url_for(self.static_path),
+            "href": self.url_prefix + self.static_path,
             "help": self.config.get("help"),
             "logo": self.config.get("logo"),
             "params": self.config.get("params"),

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -139,7 +139,9 @@ class VisualizationsRegistry:
         if os.path.exists(config_file):
             config = self.config_parser.parse_file(config_file)
             if config is not None:
-                return VisualizationPlugin(plugin_path, plugin_name, config)
+                app = self.app()
+                url_prefix = app.config.galaxy_url_prefix.rstrip("/") if app is not None else ""
+                return VisualizationPlugin(plugin_path, plugin_name, config, url_prefix=url_prefix)
         raise ObjectNotFound(f"Visualization XML not found in config or static paths for: {plugin_name}.")
 
     def get_plugin(self, key):

--- a/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
@@ -23,3 +23,15 @@ class TestVisualizationsPlugin(VisualizationsBase_TestCase):
         assert plugin.name == "myvis"
         assert plugin.path == vis_dir.root_path
         assert plugin.config == {}
+        assert plugin.url_prefix == ""
+
+    def test_href_without_url_prefix(self):
+        """Without a url_prefix, href is just the static path."""
+        plugin = VisualizationPlugin("/path", "myvis", {})
+        assert plugin.to_dict()["href"] == plugin.static_path
+        assert plugin.to_dict()["href"] == "/static/plugins/visualizations/myvis/static"
+
+    def test_href_with_url_prefix(self):
+        """A url_prefix is prepended to the static path when building href."""
+        plugin = VisualizationPlugin("/path", "myvis", {}, url_prefix="/galaxy")
+        assert plugin.to_dict()["href"] == "/galaxy/static/plugins/visualizations/myvis/static"


### PR DESCRIPTION
Visualization plugin `href` values were built with the legacy `galaxy.web.url_for` helper, which does not apply `galaxy_url_prefix` when Galaxy runs as an **ASGI** app behind a proxy prefix (e.g. `/galaxy`). The static plugin URLs (`/static/plugins/visualizations/...`) were therefore generated without the prefix and returned 404s, breaking all visualizations on prefixed deployments.

## The Fix

- `VisualizationPlugin` accepts a `url_prefix` argument and prepends it to `static_path` when building the `href` in `to_dict()`, replacing the `url_for` call.
- `VisualizationsRegistry._load_plugin` passes `app.config.galaxy_url_prefix` (with the trailing slash stripped) to the plugin constructor.
- `MockAppConfig` gains a `galaxy_url_prefix` attribute so unit tests exercise the same code path.

## Testing

- New unit tests in `test/unit/app/visualizations/plugins/test_VisualizationPlugin.py` cover `href` generation with and without a prefix.
- Run with: `./run_tests.sh -unit test/unit/app/visualizations/`
- To verify manually: set `galaxy_url_prefix: /galaxy`, serve Galaxy behind a proxy at that prefix, and confirm visualizations load.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
