### PR TITLE
Exclude generated collection_semantics.md from prettier

### DIFF
--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -21,6 +21,9 @@ repos:
       exclude_types:  # .prettierignore ignored apparently ...
         - yaml
         - json
+      # Generated from collection_semantics.yml by semantics.py; prettier both
+      # fights the generator and strips \_ escapes that LaTeX math spans need.
+      exclude: ^doc/source/dev/collection_semantics\.md$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0  # Use the ref you want to point at
     hooks:


### PR DESCRIPTION
`prettier` rewrites `doc/source/dev/collection_semantics.md`, which is generated from `collection_semantics.yml` by `semantics.py`. Two problems: it fights the generator, and it corrupts the content.

Prettier's markdown parser doesn't recognize `$...$` math spans, so it strips the `\_` escapes LaTeX needs inside them:

```
\text{paired\_or\_unpaired}   ->   \text{paired_or_unpaired}
```

Running it over the current file drops the escaped underscores from 36 to 5, and reformats ~690 lines of the generated output along the way.

This only bites people who opt into the sample config — there's no `.pre-commit-config.yaml` on `dev`, so CI has never run prettier here and the committed doc has never been prettier-formatted.

`exclude_types` already carries a note that `.prettierignore` is ignored, so this uses `exclude`.

### Scope

`collection_semantics.md` is both the only file `semantics.py` generates and the only LaTeX-escaped markdown under `doc/source`, so a single-file exclusion is the right size rather than a directory glob.

### Verification

| Check | Result |
| --- | --- |
| Excluded file alone | `(no files to check) Skipped` — untouched |
| Without the exclusion | `files were modified by this hook`; escaped `\_` drop 36 -> 5 |
| Other markdown (`data_types.md`, `debugging_galaxy.md`) | still selected and reformatted — exclusion is not over-broad |
| Both passed together | only the non-excluded file is modified |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuVLSKbSts49EWpNMcz7gP