### PR TITLE
[26.1] Set metadata externally in GCP Batch runner finish_job

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -784,6 +784,16 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             # Return job_state to continue monitoring - might be temporary error
             return job_state
 
+    def finish_job(self, job_state: AsynchronousJobState) -> None:
+        # The Batch task's job script is built with include_metadata=False
+        # (queue_job above), so the remote task never runs the metadata
+        # command and never writes the metadata/metadata_results_* files
+        # the default (directory) metadata strategy expects at finish.
+        # Run the external set_meta script handler-side instead, as the
+        # Kubernetes and Pulsar runners do.
+        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
+        super().finish_job(job_state)
+
     def stop_job(self, job_wrapper):
         """Stop a job running on Google Cloud Batch."""
         job = job_wrapper.get_job()


### PR DESCRIPTION
Jobs run by the GCP Batch runner (`galaxy.jobs.runners.gcp_batch`) never had their proper output metadata computed. The runner builds its job script with `include_metadata=False` (like the Kubernetes runner), but unlike Kubernetes it never calls `_handle_metadata_externally()` at finish time. So no metadata command runs on the Batch VM, and no external set_meta script runs handler-side.

With the default (`directory`) metadata strategy, `job_wrapper.finish()` then looks for `metadata/metadata_results_*` files that were never created, and every finished Batch job logs:

```
galaxy.metadata WARNING ... setting metadata externally failed for HistoryDatasetAssociation N:
Metadata results could not be read from '<job dir>/metadata/metadata_results_<output>'
```

Galaxy falls back to `retry_metadata_internally` (`dataset.datatype.set_meta()` in the handler), which usually recovers, but the fallback skips the external script's `set_extension=True` sniffing and related handling.

Observed in the AnVIL nightly tool tests (https://github.com/anvilproject/galaxy-tests): with per-destination attribution, **94% of gcp_batch jobs (329/349) hit the metadata failure vs 0% of k8s jobs (0/337)** on the same instance, same config, same NFS-backed job directories.

## The fix

Add a `finish_job()` override that runs the external set_meta script handler-side before the base class's finish handling.

The alternative (building the command with `include_metadata=True` so the Batch task computes metadata itself) is not viable: the Batch VM only mounts `<nfs>:/galaxy/server/database`, not the Galaxy code tree, so `metadata/set.py` cannot run there.

## Validation

Reproduced and validated live on a galaxy-k8s-boot single-node RKE2 deployment of the `26.1-auto` image (built from d372d708ec, the current `release_26.1` tip) with jobs routed to GCP Batch via TPV:

