### PR TITLE
Fix remaining inaccuracies in the custom tool prompts and harden their tests

### DIFF
--- a/lib/galaxy/agents/custom_tool.py
+++ b/lib/galaxy/agents/custom_tool.py
@@ -206,8 +206,8 @@ class CustomToolAgent(BaseGalaxyAgent):
       re-rolled once with the critique. Cap of one refine; if refinement
       breaks validation, the original tool is kept.
 
-    Container selection is a separate, opt-in concern (default off): the
-    producer prompt says nothing about choosing an image. Instead a dedicated
+    Container resolution is a separate, opt-in concern (default off): the
+    producer prompt only asks for a plausible image. When enabled, a dedicated
     **container critic** infers the conda packages from the tool's
     ``shell_command``/configfiles alone, a verified ``quay.io/biocontainers``
     image is resolved from them, and a deterministic gate applies it.
@@ -419,8 +419,8 @@ class CustomToolAgent(BaseGalaxyAgent):
                         log.info("CustomTool: critic edits not applicable; falling back to full refine")
                         tool, tool_yaml, result = await self._full_refine(query, critique, tool, tool_yaml, result)
 
-            # Container selection (opt-in, critic-independent). The producer prompt
-            # says nothing about images; instead a dedicated container critic infers
+            # Container resolution (opt-in, critic-independent). The producer's own
+            # image choice is a best guess; a dedicated container critic infers
             # the conda packages from the final tool's shell_command/configfiles, the
             # recommender resolves a verified quay.io image, and the deterministic
             # gate applies it. Run last so it sees the post-refine command.

--- a/lib/galaxy/agents/prompts/custom_tool_critic.md
+++ b/lib/galaxy/agents/prompts/custom_tool_critic.md
@@ -17,11 +17,12 @@ You receive the original user request, the produced tool YAML, and you return a 
 **Idiomaticity issues** -- shape of the tool:
 
 - `shell_command` mixes shell quoting that won't escape correctly (e.g., bare `$(date)` instead of `\$(date)`)
-- Optional **text**, **integer**, **float** or **boolean** parameters have no `value`,
-  forcing the user to supply values that should be sensible (the field is `value`;
-  `default` is not accepted and fails validation). **select** parameters take no
-  `value` at all -- their default is `selected: true` on one of their `options` -- and
-  **data** parameters take none either, so never ask for one on those.
+- Optional **text**, **integer** or **float** parameters have no `value`, forcing the
+  user to supply values that should be sensible (the field is `value`; `default` is
+  not accepted and fails validation). **boolean** already defaults to false without
+  one. **select** parameters take no `value` at all -- their default is
+  `selected: true` on one of their `options` -- and **data** parameters take none
+  either, so never ask for one on those.
 - Common analysis options aren't exposed (e.g., a BWA tool with no `-t` threads input)
 - File outputs declared without `from_work_dir` or matching command output (the validator should have caught these, but flag any borderline cases)
 

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -114,8 +114,9 @@ Each output must have a `type` field. Common types:
   collection with only `from_work_dir` is rejected, since nothing would claim its
   elements from the working directory.
 
-Note `format` on an output is a single string, unlike a data input's `format`, which
-is a list.
+Note `format` on a **data** output is a single string, unlike a data input's `format`,
+which is a list. A **collection** output has no `format` of its own -- set it per
+element on the `discover_datasets` entry instead.
 
 Example output:
 
@@ -144,7 +145,7 @@ You have exactly two ways to run a script. Pick one and complete it fully:
 declare:
 
 ```yaml
-container: quay.io/biocontainers/pandas:2.1.1
+container: quay.io/biocontainers/pandas:2.2.1
 shell_command: >-
     python -c "import pandas as pd; d = pd.read_csv('$(inputs.table.path)', sep='\t');
     d['group'] = d['sample_id'].str.startswith('Tx').map({True: 'Treatment', False: 'Vehicle'});
@@ -180,7 +181,9 @@ image when the command is a bioinformatics tool, otherwise any sensible base
 image). Pick an image you are confident exists rather than inventing a tag. Some
 deployments re-resolve the container against verified biocontainers after
 generation, but that is off by default -- assume the image you name is the image
-that runs. If you don't know a suitable image, say so instead of guessing.
+that runs. `container` is required, so if you are unsure of the exact tag prefer a
+widely used image you do know (a plain `python:3.12` or `r-base` base image) over a
+guessed biocontainers tag.
 
 ## Resource requirements
 
@@ -205,9 +208,8 @@ it, so don't assume the two are equal.
 - Use biocontainers images when available for bioinformatics tools
 - Escape shell variables that aren't Galaxy expressions: `\$(date)`
 - Keep shell_command focused and simple
-- Give optional text, integer, float and boolean parameters a sensible `value` (and a
-  select a `selected` option) -- the field is `value`, never `default`, and an unknown
-  key is rejected outright
+- Give optional parameters a sensible default: `value` (never `default`) for text,
+  integer, float and boolean, `selected: true` on an option for select
 - Use descriptive labels for inputs and outputs
 
 ## CRITICAL: Accuracy Requirements
@@ -215,7 +217,8 @@ it, so don't assume the two are equal.
 - Outputs are captured via `from_work_dir` or `discover_datasets` in output definitions.
   `$(outputs.param_name.path)` is not valid syntax.
 - Only use container images you are certain exist (e.g., verified biocontainers)
-- If you don't know the correct container image for a tool, say so rather than guessing
+- If you don't know the exact biocontainers tag for a tool, fall back to a base image you
+  do know rather than inventing one
 - Never fabricate command-line arguments or tool capabilities
 - If the user's request is unclear or you're uncertain how to implement it, ask for clarification
 - It's better to generate a simpler, correct tool than a complex, incorrect one

--- a/test/unit/app/test_agent_prompts.py
+++ b/test/unit/app/test_agent_prompts.py
@@ -21,22 +21,20 @@ import jsonschema
 import pytest
 import yaml
 
-from galaxy.tool_util_models import UserToolSourceAuthoringView
+from galaxy.tool_util_models import (
+    _command_input_refs,
+    UserToolSourceAuthoringView,
+)
 from galaxy.util import galaxy_directory
 
 PROMPT_DIR = Path(galaxy_directory()) / "lib" / "galaxy" / "agents" / "prompts"
 CUSTOM_TOOL_PROMPT = PROMPT_DIR / "custom_tool_structured.md"
 
 YAML_FENCE = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
-INPUT_REF = re.compile(r"\$\(inputs\.([A-Za-z_][A-Za-z0-9_]*)")
 
 
-def _yaml_blocks(path: Path) -> list[tuple[int, Any]]:
-    """Parse every ```yaml fence in a prompt, keyed by position for readable failures."""
-    blocks = []
-    for index, raw in enumerate(YAML_FENCE.findall(path.read_text())):
-        blocks.append((index, yaml.safe_load(raw)))
-    return blocks
+def _yaml_blocks(path: Path) -> list[Any]:
+    return [yaml.safe_load(raw) for raw in YAML_FENCE.findall(path.read_text())]
 
 
 def _as_tool(fragment: dict[str, Any]) -> dict[str, Any]:
@@ -58,33 +56,42 @@ def _as_tool(fragment: dict[str, Any]) -> dict[str, Any]:
         "outputs": [],
         **fragment,
     }
-    referenced = set(INPUT_REF.findall(tool["shell_command"]))
+    # Same extractor the model's cross-reference validator uses, so the test never
+    # under-declares an input the validator would insist on.
+    referenced = _command_input_refs(tool["shell_command"])
     for configfile in tool.get("configfiles") or []:
-        referenced |= set(INPUT_REF.findall(configfile.get("content", "")))
+        referenced |= _command_input_refs(configfile.get("content"))
     declared = {declared_input["name"] for declared_input in tool["inputs"]}
     for name in sorted(referenced - declared):
         tool["inputs"].append({"name": name, "type": "data"})
     return tool
 
 
-def _prompt_examples() -> list[tuple[int, dict[str, Any]]]:
-    return [(index, _as_tool(block)) for index, block in _yaml_blocks(CUSTOM_TOOL_PROMPT) if isinstance(block, dict)]
+def _prompt_examples() -> list[dict[str, Any]]:
+    examples = [_as_tool(block) for block in _yaml_blocks(CUSTOM_TOOL_PROMPT) if isinstance(block, dict)]
+    # An empty parametrize list skips rather than fails, so a fence regex that quietly
+    # stops matching would otherwise turn the whole module green.
+    assert examples, f"no ```yaml examples found in {CUSTOM_TOOL_PROMPT}"
+    return examples
 
 
-@pytest.mark.parametrize("index,tool", _prompt_examples())
-def test_custom_tool_prompt_examples_satisfy_pydantic(index: int, tool: dict[str, Any]) -> None:
+PROMPT_EXAMPLES = _prompt_examples()
+AUTHORING_SCHEMA_VALIDATOR = jsonschema.Draft202012Validator(UserToolSourceAuthoringView.model_json_schema())
+
+
+@pytest.mark.parametrize("tool", PROMPT_EXAMPLES)
+def test_custom_tool_prompt_examples_satisfy_pydantic(tool: dict[str, Any]) -> None:
     """Every YAML example in the prompt must validate as a tool."""
     UserToolSourceAuthoringView.model_validate(tool)
 
 
-@pytest.mark.parametrize("index,tool", _prompt_examples())
-def test_custom_tool_prompt_examples_satisfy_json_schema(index: int, tool: dict[str, Any]) -> None:
+@pytest.mark.parametrize("tool", PROMPT_EXAMPLES)
+def test_custom_tool_prompt_examples_satisfy_json_schema(tool: dict[str, Any]) -> None:
     """And must satisfy the dumped schema, which has no before-validators to lean on.
 
     This is the half that catches a scalar where the model declares a list.
     """
-    schema = UserToolSourceAuthoringView.model_json_schema()
-    errors = sorted(jsonschema.Draft202012Validator(schema).iter_errors(tool), key=str)
+    errors = sorted(AUTHORING_SCHEMA_VALIDATOR.iter_errors(tool), key=str)
     assert not errors, "\n".join(f"{list(error.absolute_path)}: {error.message}" for error in errors)
 
 
@@ -96,7 +103,7 @@ def test_custom_tool_prompt_documents_a_data_input_format() -> None:
     """
     formats = [
         declared_input["format"]
-        for _, tool in _prompt_examples()
+        for tool in PROMPT_EXAMPLES
         for declared_input in tool["inputs"]
         if "format" in declared_input
     ]


### PR DESCRIPTION
Follow-up to #23341 and #23349 (no overlap with either -- different sections of the file). Four more places where the prompts disagree with the models they feed:

- The inline-script exemplar named `quay.io/biocontainers/pandas:2.1.1`, which doesn't exist on quay -- the prompt's own example violated its "only name images you're sure of" rule. Now `2.2.1`, the tag the recommend tests already treat as real.
- "If you don't know a suitable image, say so" had no way to be followed: `container` is required and blank-rejected, so the model could only emit `""` (burning the retry) or a placeholder. It now says to fall back to a widely used base image over a guessed biocontainers tag.
- The critic was told to flag booleans with no `value`, but `YamlBooleanParameter` already defaults to `False`, so that only ever triggered a pointless full refine.
- The output `format` note is scoped to data outputs; a collection output has no `format` field (pydantic silently drops it) -- per-element format goes on the `discover_datasets` entry.

The test #23341 added also gets hardened: an empty parametrize list skips rather than fails, so a fence regex that quietly stopped matching would have turned the module green. Examples are asserted non-empty at collection time, the input-reference extractor is the validator's own `_command_input_refs`, and the schema validator is built once.

Deliberately not touched: the critic still can't judge the container while re-resolution is off by default -- a pipeline design question, not a prompt fix.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows: `pytest test/unit/app/test_agent_prompts.py` (15 pass).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).