### PR TITLE
More model fixes stemming from select model changes in 23351.

### DIFF
--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -282,6 +282,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             return DrillDownParameterModel(
                 type="drill_down",
                 name=input_source.parse_name(),
+                optional=input_source.parse_optional(),
                 multiple=multiple,
                 hierarchy=hierarchy,
                 options=static_options,
@@ -328,8 +329,8 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 **_common_param_kwargs(input_source),
             )
         elif param_type == "genomebuild":
-            optional = input_source.parse_optional()
             multiple = input_source.get_bool("multiple", False)
+            optional = input_source.parse_optional(multiple)
             return GenomeBuildParameterModel(
                 type="genomebuild",
                 name=input_source.parse_name(),

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -2075,7 +2075,10 @@ class DrillDownParameterModel(BaseGalaxyToolParameterModelDefinition):
         if self.multiple:
             py_type = list_type(py_type)
 
-        return py_type
+        # unlike select, multiple does not imply optional here - DrillDownSelectToolParameter
+        # calls ToolParameter.__init__ rather than SelectToolParameter.__init__, so at runtime
+        # it reads a bare parse_optional() with no multiple-derived default.
+        return optional_if_needed(py_type, self.optional)
 
     @property
     def py_type_test_case_xml(self) -> builtins.type:
@@ -2095,6 +2098,8 @@ class DrillDownParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     @property
     def request_requires_value(self) -> bool:
+        if self.optional:
+            return False
         if options := self.options:
             # if any of these are selected, they seem to serve as defaults - check out test_tools -> test_drill_down_first_by_default
             return not any_drill_down_options_selected(options)

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -785,6 +785,7 @@ def test_select_optional_null_by_default(required_tools: list[RequiredTool], too
 
 @requires_tool_id("gx_select_multiple")
 @requires_tool_id("gx_select_multiple_optional")
+@requires_tool_id("gx_select_multiple_no_options_validation")
 def test_select_multiple_does_not_select_first_by_default(
     required_tools: list[RequiredTool], tool_input_format: DescribeToolInputs
 ):
@@ -798,6 +799,17 @@ def test_select_multiple_does_not_select_first_by_default(
         required_tool.execute().with_inputs(null_parameter).assert_has_single_job.with_output(
             "output"
         ).with_contents_stripped("None")
+
+
+@requires_tool_id("gx_genomebuild_multiple")
+def test_genomebuild_multiple_is_optional_by_default(
+    required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
+    # genomebuild is a SelectToolParameter subclass, so multiple implies optional here too
+    for inputs in [tool_input_format.when.any({}), tool_input_format.when.any({"parameter": None})]:
+        required_tool.execute().with_inputs(inputs).assert_has_single_job.with_output("output").with_contents_stripped(
+            "parameter: None"
+        )
 
 
 @requires_tool_id("gx_select_multiple_one_default")

--- a/test/functional/tools/parameters/gx_drill_down_exact_optional.xml
+++ b/test/functional/tools/parameters/gx_drill_down_exact_optional.xml
@@ -1,0 +1,25 @@
+<tool id="gx_drill_down_exact_optional" name="gx_drill_down_exact_optional" version="1.0.0">
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <command><![CDATA[
+echo "parameter: $parameter" > '$output'
+    ]]></command>
+    <inputs>
+        <!-- an explicitly optional drill_down - no selection is required and null is accepted -->
+        <param name="parameter" type="drill_down" hierarchy="exact" optional="true">
+            <expand macro="drill_down_static_options" />
+        </param>
+    </inputs>
+    <expand macro="simple_text_output" />
+    <tests>
+        <test>
+            <param name="parameter" value="a"/>
+            <expand macro="assert_output">
+                <has_line line="parameter: a"/>
+            </expand>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -754,6 +754,8 @@ gx_select_multiple:
   - parameter: ["--ex1"]
   - parameter: ["ex2"]
   - {}  # could come in linked...
+  # unrelated to optional-by-default: py_type_workflow_step is unconditionally optional,
+  # so this stays valid even for a required select. Still unclear it should be.
   - parameter: null
   job_internal_valid:
   - parameter: ["--ex1"]
@@ -779,12 +781,15 @@ gx_select_multiple:
   - parameter: "--ex1,ex2"
   - parameter: "--ex1"
   - parameter: ["--ex1"]
+  # optional-by-default reaches the test case states too
+  - parameter: null
   test_case_xml_invalid:
   - parameter: {}
   test_case_json_valid:
   # JSON test cases accept lists directly (no string splitting)
   - parameter: ["--ex1"]
   - parameter: ["--ex1", "ex2"]
+  - parameter: null
   test_case_json_invalid:
   - parameter: "--ex1"
   - parameter: {}
@@ -822,6 +827,15 @@ gx_select_no_options_validation:
   - {}
 
 gx_select_multiple_no_options_validation:
+  request_valid:
+  - parameter: ["--ex1"]
+  # optional-by-default reaches the no_options validator - this is invalid for the
+  # single-select sibling gx_select_no_options_validation
+  - parameter: null
+  - {}
+  request_invalid:
+  - parameter: ["Ex1"]
+  - parameter: 5
   job_internal_valid:
   - parameter: ["--ex1"]
   - parameter: null
@@ -894,19 +908,20 @@ gx_genomebuild_optional:
 
 gx_genomebuild_multiple:
   request_valid:
-  - parameter: ["hg18", hg19"]
-  # I don't love this but this is how the legacy API works and the tool parameters
-  # wrappers work this way also. Not sure how I would change this.
+  - parameter: ["hg18", "hg19"]
+  # multiple genomebuilds are optional by default, matching multiple selects -
+  # GenomeBuildParameter subclasses SelectToolParameter and inherits parse_optional(self.multiple)
   - parameter: null
+  - {}
   request_invalid:
   - parameter: 6
   job_internal_valid:
-  - parameter: ["hg18", hg19"]
+  - parameter: ["hg18", "hg19"]
   - parameter: null
   job_internal_invalid:
   - {}
   job_runtime_valid:
-  - parameter: ["hg18", hg19"]
+  - parameter: ["hg18", "hg19"]
   - parameter: null
   job_runtime_invalid:
   - {}
@@ -2307,6 +2322,29 @@ gx_drill_down_exact:
   - {}
   job_runtime_valid:
   - parameter: aa
+  job_runtime_invalid:
+  - parameter: c
+  - {}
+
+gx_drill_down_exact_optional:
+  request_valid:
+  - parameter: aa
+  - parameter: a
+  # explicitly optional - unlike gx_drill_down_exact these are accepted
+  - {}
+  - parameter: null
+  request_invalid:
+  - parameter: c
+  - parameter: {}
+  job_internal_valid:
+  - parameter: aa
+  - parameter: null
+  job_internal_invalid:
+  - parameter: c
+  - {}
+  job_runtime_valid:
+  - parameter: aa
+  - parameter: null
   job_runtime_invalid:
   - parameter: c
   - {}

--- a/test/unit/tool_util/test_input_models.py
+++ b/test/unit/tool_util/test_input_models.py
@@ -10,3 +10,30 @@ def test_input_collection_type():
     tool_input = tool.inputs[0]
     assert isinstance(tool_input, DataCollectionParameterModel)
     assert tool_input.collection_type == "list"
+
+
+def _parameter_model(tool_file: str):
+    tool_source = get_tool_source(functional_test_tool_path(f"parameters/{tool_file}"))
+    return parse_tool(tool_source).inputs[0]
+
+
+def test_multiple_selects_are_optional_by_default():
+    # galaxy.xsd documents this: optional "Defaults to false except when the type attribute
+    # value is select and multiple is true".
+    assert _parameter_model("gx_select_multiple.xml").optional is True
+    assert _parameter_model("gx_select.xml").optional is False
+
+
+def test_multiple_genomebuilds_are_optional_by_default():
+    # GenomeBuildParameter subclasses SelectToolParameter, so it inherits the same rule.
+    assert _parameter_model("gx_genomebuild_multiple.xml").optional is True
+    assert _parameter_model("gx_genomebuild.xml").optional is False
+    assert _parameter_model("gx_genomebuild_optional.xml").optional is True
+
+
+def test_drill_down_optional_attribute_is_parsed():
+    # multiple does not imply optional here - DrillDownSelectToolParameter goes through
+    # ToolParameter.__init__, which reads a bare parse_optional().
+    assert _parameter_model("gx_drill_down_exact_optional.xml").optional is True
+    assert _parameter_model("gx_drill_down_exact.xml").optional is False
+    assert _parameter_model("gx_drill_down_exact_multiple.xml").optional is False


### PR DESCRIPTION
PR message from agent. -John

Follow-up to #23351, which made `select multiple="true"` optional by default in the parameter
model. That fix was right — `galaxy.xsd` already documented the rule ("Defaults to `false`
except when the `type` attribute value is `select` and `multiple` is `true`") and
`SelectToolParameter` has read `parse_optional(self.multiple)` since 2013. But the model layer
derives `optional` in eleven independent places, and reviewing that PR turned up two more
sites that had drifted from runtime the same way.

## The divergences

**`genomebuild`** — `GenomeBuildParameter` subclasses `SelectToolParameter`, so at runtime it
inherits `parse_optional(self.multiple)`. The model called `parse_optional()` bare and read
`multiple` on the very next line. `genomebuild multiple="true"` therefore modelled as required
while the runtime treated it as optional. This is the same bug #23351 fixed, five lines away in
the same function.

**`drill_down`** — the branch never called `parse_optional` at all, and `_common_param_kwargs`
only carries `label`/`help`, so an explicit `optional="true"` was silently dropped and the model
fell back to the base default of `False`. `DrillDownParameterModel` also never consulted
`optional`, so this wires it into `py_type` and `request_requires_value`.

Note the asymmetry: for `drill_down`, `multiple` does **not** imply optional.
`DrillDownSelectToolParameter.__init__` calls `ToolParameter.__init__` rather than
`SelectToolParameter.__init__`, so it reads a bare `parse_optional()` with no multiple-derived
default. The fix matches that rather than copying the select rule.

No tool in the tree sets `drill_down optional="true"`, so that half cannot regress an existing
tool — `gx_drill_down_exact_optional.xml` is added to exercise it.

## Coverage gaps from #23351

Measuring what that one-line change actually altered — 9 state representations × 4 value shapes,
run with the commit applied and reverted — showed the affected states were narrower than the
title suggests. `request`, `request_internal`, `landing_request`, `job_internal`, `job_runtime`,
`workflow_step` and `workflow_step_linked` are byte-identical for a plain multiple select,
because those paths already read `self.optional or self.multiple` and `request_requires_value`
returns `False` unconditionally. What actually moved:

- `test_case_xml` / `test_case_json` `null`, for every multiple select — the widest-reaching
  change, and it had no spec cases. Added.
- `request::null` for the `no_options`-bearing tool, which is where the real bug was. It flips
  there but not for the single-select sibling, so that surface is worth asserting. Added.
- `gx_select_multiple_no_options_validation` had no execution coverage at all. It now rides the
  existing multi-select test, following how `gx_select_optional_no_options_validation` is stacked
  onto the single-select test 15 lines above.

Also restores a comment #23351 deleted rather than answered — the `workflow_step_valid` question
is about `py_type_workflow_step` being unconditionally optional, which is a separate issue from
optional-by-default.

## Drive-by

`gx_genomebuild_multiple`'s spec values read `["hg18", hg19"]` — a missing opening quote, three
times, which YAML parses as the string `hg19"`. Fixed.

## How to test the changes?

- [x] I've included appropriate [[automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html)](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

Both fixes are red-to-green against the new unit assertions in `test_input_models.py`.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [[MIT license](https://opensource.org/licenses/MIT)](https://opensource.org/licenses/MIT).