### PR TITLE
Keep subworkflow ``when`` state with the collection it was computed over

### DIFF
--- a/doc/source/dev/collection_semantics.md
+++ b/doc/source/dev/collection_semantics.md
@@ -1118,3 +1118,160 @@ $$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
 
 
 
+## Subworkflows
+
+A collection can be mapped over a data input of a subworkflow step the same way
+it is mapped over a data input of a tool. Unlike a tool though, this does not run
+the subworkflow once per element of that collection. The collection is handed to
+the subworkflow's input step and the child workflow runs as a single invocation -
+the mapping is applied inside it, step by step.
+
+Each step of the child workflow maps over the collections connected to its own
+inputs, exactly as it would in a top-level workflow. A step consuming the mapped
+input maps over that collection and produces implicit collections matching it. A
+step with nothing mapped over its own inputs inherits the outer mapping instead,
+so it still runs once per element of the collection mapped over the subworkflow.
+
+Steps inside the subworkflow that map over different collections stay
+independent; the subworkflow introduces no extra dimensionality. If a step maps
+over a collection connected to a collection input of the subworkflow, its outputs
+match only that collection. It is not multiplied by the collection mapped over the
+subworkflow and the two are not matched up element by element, so they need not
+even have the same number of elements.
+
+A subworkflow step can also be conditional, with a ``when`` expression evaluated
+once per element of the collection mapped over it. Those per-element conditions
+travel with that mapping. A step inside the subworkflow that maps over the same
+collection - or over an implicit collection created from it, which has the same
+element identifiers in the same order - skips the same elements. A step that maps
+over an unrelated collection has no such correspondence, and Galaxy fails the
+invocation rather than pairing conditions with elements they do not describe.
+
+
+(UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING`
+:class: note
+
+Assuming,
+
+* $ a_1,...,a_m $, $ b_1,...,b_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ A $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ a1 }=a_1, ..., \text{ am }=a_m \right\}\text{>} $
+* $ B $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ b1 }=b_1, ..., \text{ bn }=b_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(B)) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{b1}=tool(i=b_1)[o],...,\text{bn}=tool(i=b_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## Type Compatibility Algebra
+
+This section is for implementers. It describes the three operations that
+answer "do these collection types fit together?" — used at workflow
+editor connection time and at runtime when sibling inputs are matched
+under a common map-over.
+
+### The lattice
+
+The base types form a small subtype lattice:
+
+```
+list                paired_or_unpaired
+ |                    |
+sample_sheet         paired
+```
+
+Edges are subtype relations. A `sample_sheet` value carries column
+metadata that a `list` does not, so it can be substituted where a
+`list` is required (information is preserved); the reverse is not safe.
+A `paired` value always has two elements; `paired_or_unpaired` admits
+1 or 2, so a `paired` can be substituted where `paired_or_unpaired` is
+required, but not the reverse.
+
+Nesting composes. `list:paired_or_unpaired` is a supertype of both
+`list:paired` and `list` (the latter via the "single-dataset wrapped
+as unpaired" interpretation), so it has two incomparable subtypes.
+
+### Three operations
+
+| Operation | Symmetry | Question | Used at |
+|---|---|---|---|
+| `accepts(other)` | Asymmetric | Does an input slot of type `self` accept an output of type `other`? | Workflow-editor edge validation |
+| `compatible(other)` | Symmetric | Do `self` and `other` match such that they could drive a common map-over over sibling inputs of one tool? | Sibling-matching: matching sibling HDCAs / sibling map-over states under a common mapping |
+| `can_map_over(other)` | Asymmetric | Does `self` have proper subcollections of type `other` — i.e. can `self` be mapped over to feed an `other` slot? | Connection-time map-over decisions; runtime `effective_collection_type` arithmetic |
+
+Conventions: `input_type.accepts(output_type)` for direct edges;
+`output_type.can_map_over(input_type)` for map-over. `accepts` and
+`can_map_over` differ in that `accepts` is the direct-edge case
+where ranks already align, while `can_map_over` is the strict nesting
+case where the output has *more* rank than the input. `compatible`
+is symmetric and either side may go first.
+
+`compatible(a, b)` is implemented as `a.accepts(b) or b.accepts(a)`.
+
+### Where each is used
+
+- `accepts` is called at single-edge validation: connecting one output
+  to one input. The asymmetry between input and output sides matters
+  here. Examples: `connection_types.can_match`,
+  `query.HistoryQuery.direct_match`, and the workflow-editor input
+  attachment paths in `terminals.ts`.
+
+- `compatible` is called when two collections must drive a common
+  map-over as siblings. Neither side is the input slot; both are
+  concrete shapes (observed HDCA shapes at runtime, sibling map-over
+  states at connection time). Order of arrival must not change the
+  answer. Examples: Python `Tree.compatible_shape` (matching.py,
+  execute.py) and the `mappingConstraints` checks in `terminals.ts`.
+
+- `can_map_over` is called when deciding whether an output of higher
+  rank can drive a map-over into a lower-rank input — for instance, a
+  `list:paired` output feeding a `paired` input by iterating the outer
+  list. The Python and TypeScript names match
+  (`can_map_over` / `canMapOver`) because it is the same operational
+  question in both layers.
+
+Routing a sibling-matching question through `accepts` instead of
+`compatible` produces order-dependent behavior — which sibling input
+arrived first changes whether the workflow validates. This was a real
+bug in earlier revisions of both the Python and TypeScript code.
+
+### Worked examples
+
+- `paired.accepts(paired_or_unpaired)` is `False`. A 1-element
+  paired_or_unpaired output cannot be connected to an input slot
+  that strictly requires a pair. Test: `test_paired_accepts_relation`.
+
+- `paired.compatible(paired_or_unpaired)` is `True`. If both observed
+  sibling collections happen to align in cardinality, they match for
+  sibling iteration; cardinality checking happens later at the
+  children level. Test:
+  `test_paired_and_paired_or_unpaired_match_symmetric`.
+
+- `sample_sheet.accepts(list)` is `False`; `list.accepts(sample_sheet)`
+  is `True`. Tests:
+  `test_sample_sheet_accepts_relation`, workflow editor
+  `"rejects list -> sample_sheet connection (asymmetry)"`.
+
+- `sample_sheet.compatible(list)` and `list.compatible(sample_sheet)`
+  are both `True`. Tests: `test_compatible`,
+  `test_tree_compatible_shape_sample_sheet_list_symmetric`.
+
+### Cross-language synchronization
+
+The Python implementation lives in
+`lib/galaxy/model/dataset_collections/type_description.py`. The
+TypeScript implementation lives in
+`client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts`.
+Both must stay in sync; method names and conventions are identical.
+

--- a/doc/source/dev/collection_semantics.md
+++ b/doc/source/dev/collection_semantics.md
@@ -1147,6 +1147,11 @@ element identifiers in the same order - skips the same elements. A step that map
 over an unrelated collection has no such correspondence, and Galaxy fails the
 invocation rather than pairing conditions with elements they do not describe.
 
+In the formal example below, ``A`` is mapped over a data input of the containing
+subworkflow, while ``tool`` is a step inside that subworkflow connected only to
+``B``. The equation intentionally shows the inner step: its result is shaped by
+``B``, not ``A``.
+
 
 (UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING)=
 <details><summary>Examples</summary>

--- a/lib/galaxy/model/dataset_collections/matching.py
+++ b/lib/galaxy/model/dataset_collections/matching.py
@@ -46,8 +46,8 @@ def mapped_collection_provenance(collection_instance) -> set[tuple[str, int]]:
             pending.append(adapting)
 
         if isinstance(current, DatasetCollectionElement):
-            if current.collection is not None:
-                provenance.add(_dataset_collection_key(current.collection))
+            # Matching a DCE operates on its contained child collection. The
+            # parent records where the element lives, not what is mapped over.
             if current.child_collection is not None:
                 provenance.add(_dataset_collection_key(current.child_collection))
         elif isinstance(current, HistoryDatasetCollectionAssociation):

--- a/lib/galaxy/model/dataset_collections/matching.py
+++ b/lib/galaxy/model/dataset_collections/matching.py
@@ -1,6 +1,10 @@
 from typing import Optional
 
 from galaxy import exceptions
+from galaxy.model import (
+    DatasetCollectionElement,
+    HistoryDatasetCollectionAssociation,
+)
 from galaxy.util import bunch
 from .structure import (
     get_collection,
@@ -9,6 +13,58 @@ from .structure import (
 )
 
 CANNOT_MATCH_ERROR_MESSAGE = "Cannot match collection types."
+
+
+def _dataset_collection_key(dataset_collection) -> tuple[str, int]:
+    collection_id = getattr(dataset_collection, "id", None)
+    if collection_id is not None:
+        return ("id", collection_id)
+    return ("object", id(dataset_collection))
+
+
+def mapped_collection_provenance(collection_instance) -> set[tuple[str, int]]:
+    """Return the identities of the collections this instance was mapped from.
+
+    Includes the collection itself, whatever it was copied from, and the inputs
+    of any implicit collection creation that produced it. Implicit collections
+    have the same element identifiers in the same order as the collections
+    mapped over to create them, so two instances sharing an identity here can be
+    matched up element by element.
+    """
+    provenance = set()
+    pending = [collection_instance]
+    visited = set()
+    while pending:
+        current = pending.pop()
+        current_object_id = id(current)
+        if current_object_id in visited:
+            continue
+        visited.add(current_object_id)
+
+        adapting = getattr(current, "adapting", None)
+        if adapting is not None:
+            pending.append(adapting)
+
+        if isinstance(current, DatasetCollectionElement):
+            if current.collection is not None:
+                provenance.add(_dataset_collection_key(current.collection))
+            if current.child_collection is not None:
+                provenance.add(_dataset_collection_key(current.child_collection))
+        elif isinstance(current, HistoryDatasetCollectionAssociation):
+            if current.collection is not None:
+                provenance.add(_dataset_collection_key(current.collection))
+            copied_from = current.copied_from_history_dataset_collection_association
+            if copied_from is not None:
+                pending.append(copied_from)
+            pending.extend(
+                implicit_input.input_dataset_collection
+                for implicit_input in current.implicit_input_collections
+                if implicit_input.input_dataset_collection is not None
+            )
+        elif (collection := getattr(current, "collection", None)) is not None:
+            provenance.add(_dataset_collection_key(collection))
+
+    return provenance
 
 
 class CollectionsToMatch:
@@ -95,6 +151,24 @@ class MatchingCollections:
 
     def is_mapped_over(self, input_name):
         return input_name in self.collections
+
+    def is_aligned_with(self, other: "MatchingCollections") -> bool:
+        """Whether these collections match ``other`` element by element.
+
+        True when the two matches share a collection they were mapped from,
+        which means the same element identifiers in the same order. Only linked
+        collections are considered - they share one structure and have already
+        passed ``compatible_shape``, so a match on any one of them holds for all
+        of them. Callers use this before moving positionally indexed state such
+        as ``when_values`` from one match to the other.
+        """
+        other_provenance = set().union(
+            *(mapped_collection_provenance(collection) for collection in other.collections.values())
+        )
+        return any(
+            other_provenance.intersection(mapped_collection_provenance(collection))
+            for collection in self.collections.values()
+        )
 
     @staticmethod
     def for_collections(collections_to_match, collection_type_descriptions) -> Optional["MatchingCollections"]:

--- a/lib/galaxy/model/dataset_collections/types/collection_semantics.yml
+++ b/lib/galaxy/model/dataset_collections/types/collection_semantics.yml
@@ -1249,6 +1249,68 @@
             framework_test: "collection_semantics_cat_sample_sheet_0"
         workflow_editor: "accepts sample_sheet -> sample_sheet connection"
 
+- doc: "## Subworkflows"
+- doc: |
+    A collection can be mapped over a data input of a subworkflow step the same way
+    it is mapped over a data input of a tool. Unlike a tool though, this does not run
+    the subworkflow once per element of that collection. The collection is handed to
+    the subworkflow's input step and the child workflow runs as a single invocation -
+    the mapping is applied inside it, step by step.
+
+    Each step of the child workflow maps over the collections connected to its own
+    inputs, exactly as it would in a top-level workflow. A step consuming the mapped
+    input maps over that collection and produces implicit collections matching it. A
+    step with nothing mapped over its own inputs inherits the outer mapping instead,
+    so it still runs once per element of the collection mapped over the subworkflow.
+
+    Steps inside the subworkflow that map over different collections stay
+    independent; the subworkflow introduces no extra dimensionality. If a step maps
+    over a collection connected to a collection input of the subworkflow, its outputs
+    match only that collection. It is not multiplied by the collection mapped over the
+    subworkflow and the two are not matched up element by element, so they need not
+    even have the same number of elements.
+
+    A subworkflow step can also be conditional, with a ``when`` expression evaluated
+    once per element of the collection mapped over it. Those per-element conditions
+    travel with that mapping. A step inside the subworkflow that maps over the same
+    collection - or over an implicit collection created from it, which has the same
+    element identifiers in the same order - skips the same elements. A step that maps
+    over an unrelated collection has no such correspondence, and Galaxy fails the
+    invocation rather than pairing conditions with elements they do not describe.
+
+- example:
+    label: UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING
+    assumptions:
+    - datasets: ["a_1,...,a_m", "b_1,...,b_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        A: [list, {a1: a_1, ..., am: a_m}]
+        B: [list, {b1: b_1, ..., bn: b_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: B}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    b1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: b_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    bn:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: b_n}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "subworkflow_mapping_per_step_0"
+
 - doc: "## Type Compatibility Algebra"
 - doc: |
     This section is for implementers. It describes the three operations that

--- a/lib/galaxy/model/dataset_collections/types/collection_semantics.yml
+++ b/lib/galaxy/model/dataset_collections/types/collection_semantics.yml
@@ -1278,6 +1278,11 @@
     over an unrelated collection has no such correspondence, and Galaxy fails the
     invocation rather than pairing conditions with elements they do not describe.
 
+    In the formal example below, ``A`` is mapped over a data input of the containing
+    subworkflow, while ``tool`` is a step inside that subworkflow connected only to
+    ``B``. The equation intentionally shows the inner step: its result is shaped by
+    ``B``, not ``A``.
+
 - example:
     label: UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING
     assumptions:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -627,8 +627,15 @@ class WorkflowModule:
         if collection_info:
             if progress.subworkflow_collection_info:
                 # We've mapped over a subworkflow. Slices of the invocation might be conditional
-                # and progress.subworkflow_collection_info.when_values holds the appropriate when_values
-                collection_info.when_values = progress.subworkflow_collection_info.when_values
+                # and progress.subworkflow_collection_info.when_values holds the appropriate when_values.
+                inherited_when_values = progress.subworkflow_collection_info.when_values
+                if inherited_when_values:
+                    if not collection_info.is_aligned_with(progress.subworkflow_collection_info):
+                        raise exceptions.MessageException(
+                            "This step maps over a collection that cannot be matched up element by element "
+                            "with the collection mapped over the conditional subworkflow containing it."
+                        )
+                    collection_info.when_values = inherited_when_values
             else:
                 # The invocation is not mapped over, but it might still be conditional.
                 # Multiplication and linking should be handled by slice_collection()
@@ -931,15 +938,18 @@ class SubWorkflowModule(WorkflowModule):
                         progress, step, execution_state={}, extra_step_state=extra_step_state
                     )
                 )
+
+        # A subworkflow without a condition has no conditional state, not one None per mapped element.
+        conditional_values = when_values if any(value is not None for value in when_values) else None
         if collection_info:
-            collection_info.when_values = when_values
+            collection_info.when_values = conditional_values
 
         subworkflow_invoker = progress.subworkflow_invoker(
             trans,
             step,
             use_cached_job=use_cached_job,
             subworkflow_collection_info=collection_info,
-            when_values=when_values,
+            when_values=conditional_values,
         )
         subworkflow_invoker.invoke()
         subworkflow = subworkflow_invoker.workflow

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4195,6 +4195,88 @@ test_data:
                 assert outer_hdca["job_state_summary"]["all_jobs"] == 0
                 assert outer_hdca["collection_type"] == "list:list:list"
 
+    def test_conditional_subworkflow_rejects_independent_child_mapping(self):
+        workflow = """
+class: GalaxyWorkflow
+inputs:
+  outer_mapping_source: collection
+  inner_mapping_source:
+    type: collection
+    collection_type: list
+steps:
+  create_boolean_values:
+    tool_id: param_value_from_file
+    in:
+      input1: outer_mapping_source
+    state:
+      param_type: boolean
+  subworkflow:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        mapped_dataset: data
+        should_run: boolean
+        independent_collection:
+          type: collection
+          collection_type: list
+      steps:
+        consume_independent_collection:
+          tool_id: cat1
+          in:
+            input1: independent_collection
+      outputs:
+        independent_output:
+          outputSource: consume_independent_collection/out_file1
+    in:
+      mapped_dataset: outer_mapping_source
+      should_run: create_boolean_values/boolean_param
+      independent_collection: inner_mapping_source
+    when: $(inputs.should_run)
+outputs:
+  output:
+    outputSource: subworkflow/independent_output
+"""
+        for optional_third_element in (
+            "",
+            """    - identifier: R
+      content: R
+""",
+        ):
+            with self.dataset_populator.test_history() as history_id:
+                summary = self._run_workflow(
+                    workflow,
+                    test_data=f"""
+outer_mapping_source:
+  collection_type: list
+  elements:
+    - identifier: run
+      content: true
+    - identifier: skip
+      content: false
+inner_mapping_source:
+  collection_type: list
+  elements:
+    - identifier: P
+      content: P
+    - identifier: Q
+      content: Q
+{optional_third_element}""",
+                    history_id=history_id,
+                    assert_ok=False,
+                    wait=True,
+                )
+                invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+                assert invocation["state"] == "failed"
+                assert invocation["messages"] == [
+                    {
+                        "details": "This step maps over a collection that cannot be matched up element by element "
+                        "with the collection mapped over the conditional subworkflow containing it.",
+                        "reason": "unexpected_failure",
+                        "workflow_step_id": 3,
+                        "workflow_step_index_path": [3],
+                    }
+                ]
+
     def test_run_workflow_conditional_step_map_over_expression_tool_pick_value(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(
@@ -6595,6 +6677,81 @@ test_data:
         assert len(elements) == 1
         assert elements[0]["element_identifier"] == "test_level_1"
         assert elements[0]["element_type"] == "hda"
+
+    @skip_without_tool("identifier_multiple")
+    def test_invocation_conditional_map_over_inner_collection(self, history_id):
+        # Same shape as test_invocation_map_over_inner_collection, but the subworkflow step
+        # is conditional. Steps inside map over a sub-collection of the collection the
+        # subworkflow was mapped over, so the outer condition has to follow that mapping.
+        workflow = """
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    collection_type: list:list
+    type: collection
+  should_run:
+    type: boolean
+outputs:
+  main_out:
+    outputSource: subworkflow/sub_out
+steps:
+  subworkflow:
+    in:
+      list_input: input_collection
+      should_run: should_run
+    when: $(inputs.should_run)
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        list_input:
+          type: collection
+          collection_type: list
+        should_run:
+          type: boolean
+      outputs:
+        sub_out:
+          outputSource: output_step/output1
+      steps:
+        intermediate_step:
+          tool_id: identifier_multiple
+          in:
+            input1: list_input
+        output_step:
+          tool_id: identifier_multiple
+          in:
+            input1: intermediate_step/output1
+test_data:
+  input_collection:
+    collection_type: list:list
+  should_run:
+    value: {should_run}
+    type: raw
+"""
+        summary = self._run_workflow(
+            workflow.format(should_run="true"), history_id=history_id, assert_ok=True, wait=True
+        )
+        invocation = self.workflow_populator.get_invocation(summary.invocation_id)
+        hdca_details = self.dataset_populator.get_history_collection_details(
+            history_id, content_id=invocation["output_collections"]["main_out"]["id"]
+        )
+        assert hdca_details["collection_type"] == "list"
+        elements = hdca_details["elements"]
+        assert len(elements) == 1
+        assert elements[0]["element_identifier"] == "test_level_1"
+        assert elements[0]["element_type"] == "hda"
+
+        summary = self._run_workflow(
+            workflow.format(should_run="false"), history_id=history_id, assert_ok=True, wait=True
+        )
+        invocation = self.workflow_populator.get_invocation(summary.invocation_id)
+        hdca_details = self.dataset_populator.get_history_collection_details(
+            history_id, content_id=invocation["output_collections"]["main_out"]["id"]
+        )
+        assert hdca_details["collection_type"] == "list"
+        elements = hdca_details["elements"]
+        assert len(elements) == 1
+        assert elements[0]["element_identifier"] == "test_level_1"
+        assert elements[0]["object"]["misc_blurb"] == "skipped"
 
     @skip_without_tool("identifier_multiple")
     def test_invocation_map_over_inner_collection_with_tool_collection_input(self, history_id):

--- a/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf-tests.yml
@@ -1,0 +1,57 @@
+- doc: |
+    Two elements are mapped over the subworkflow and three are connected to its
+    collection input, so the outputs come back as flat lists of two and three
+    elements rather than being multiplied or matched up element by element.
+  job:
+    outer_mapping_source:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: X
+          class: File
+          contents: "from_X"
+        - identifier: Y
+          class: File
+          contents: "from_Y"
+    inner_mapping_source:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: P
+          class: File
+          contents: "P_content"
+        - identifier: Q
+          class: File
+          contents: "Q_content"
+        - identifier: R
+          class: File
+          contents: "R_content"
+  outputs:
+    inherited_mapping_output:
+      class: Collection
+      collection_type: list
+      elements:
+        X:
+          asserts:
+          - that: has_text
+            text: "from_X"
+        Y:
+          asserts:
+          - that: has_text
+            text: "from_Y"
+    local_mapping_output:
+      class: Collection
+      collection_type: list
+      elements:
+        P:
+          asserts:
+          - that: has_text
+            text: "P_content"
+        Q:
+          asserts:
+          - that: has_text
+            text: "Q_content"
+        R:
+          asserts:
+          - that: has_text
+            text: "R_content"

--- a/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
@@ -1,0 +1,49 @@
+class: GalaxyWorkflow
+doc: |
+  Test that mapping is resolved per step inside a mapped subworkflow. The child
+  workflow runs as a single invocation, so consume_outer_mapping_source maps over
+  the collection mapped over the subworkflow while consume_inner_mapping_source
+  maps over the collection connected to the subworkflow's own collection input.
+  Each output matches only the collection its step mapped over - the differing
+  element counts show the two are neither multiplied together nor matched up
+  element by element.
+inputs:
+  outer_mapping_source:
+    type: collection
+    collection_type: list
+  inner_mapping_source:
+    type: collection
+    collection_type: list
+outputs:
+  inherited_mapping_output:
+    outputSource: sub/inherited_mapping_output
+  local_mapping_output:
+    outputSource: sub/local_mapping_output
+steps:
+  sub:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        mapped_dataset: data
+        inner_collection:
+          type: collection
+          collection_type: list
+      outputs:
+        inherited_mapping_output:
+          outputSource: consume_outer_mapping_source/out_file1
+        local_mapping_output:
+          outputSource: consume_inner_mapping_source/out_file1
+      steps:
+        consume_outer_mapping_source:
+          tool_id: cat
+          in:
+            input1:
+              source: mapped_dataset
+        consume_inner_mapping_source:
+          tool_id: cat
+          in:
+            input1:
+              source: inner_collection
+    in:
+      mapped_dataset: outer_mapping_source
+      inner_collection: inner_mapping_source

--- a/test/unit/data/dataset_collections/test_matching.py
+++ b/test/unit/data/dataset_collections/test_matching.py
@@ -1,3 +1,4 @@
+from galaxy import model
 from galaxy.model.dataset_collections import (
     matching,
     query,
@@ -111,6 +112,47 @@ def test_query_always_direct_match_if_no_collection_type_on_input_specified():
     q = query.HistoryQuery.from_collection_types([], TYPE_DESCRIPTION_FACTORY)
     assert q.can_map_over(list_of_lists) is False
     assert q.direct_match(list_of_lists) is True
+
+
+def test_alignment_accepts_same_collection():
+    source = real_collection_instance(1)
+
+    assert matched(source).is_aligned_with(matched(source))
+
+
+def test_alignment_accepts_implicit_output_lineage():
+    source = real_collection_instance(1)
+    derived = real_collection_instance(2)
+    derived.add_implicit_input_collection("input", source)
+
+    assert matched(derived).is_aligned_with(matched(source))
+
+
+def test_alignment_rejects_independent_collection():
+    source = real_collection_instance(1)
+    independent = real_collection_instance(2)
+
+    assert not matched(independent).is_aligned_with(matched(source))
+
+
+def test_alignment_is_symmetric():
+    source = real_collection_instance(1)
+    derived = real_collection_instance(2)
+    derived.add_implicit_input_collection("input", source)
+
+    assert matched(source).is_aligned_with(matched(derived))
+
+
+def real_collection_instance(collection_id):
+    """A persisted-looking HDCA - alignment keys off DatasetCollection identity."""
+    collection = model.DatasetCollection(id=collection_id, collection_type="list")
+    return model.HistoryDatasetCollectionAssociation(collection=collection)
+
+
+def matched(collection_instance):
+    matching_collections = matching.MatchingCollections()
+    matching_collections.collections["input"] = collection_instance
+    return matching_collections
 
 
 def assert_can_match(*items):


### PR DESCRIPTION
## What's wrong

When a collection is mapped over a data input of a subworkflow step, Galaxy does not run the
subworkflow once per element of that collection. The child workflow runs as a single invocation
with the whole collection handed to its input step, and each step inside it then maps over whatever
collections are connected to its own inputs.

`MatchingCollections.when_values` is a flat list read by element position — `_walk_collections`
does `when_value = self.when_values[index]` as it walks the collection. Those values mean something
only for the collection they were computed over.

`WorkflowModule.compute_collection_info` copied the subworkflow's list onto every step inside it,
including steps that had mapped over some entirely different collection. Reading one collection's
conditions at another collection's element positions gives:

- **same number of elements** → every element silently gets the wrong condition
- **different number of elements** → `IndexError` out of `_walk_collections`

Separately, `SubWorkflowModule.execute` built one `None` per mapped element even when the
subworkflow step had no `when` expression at all. An all-`None` list is still truthy, so a
completely unconditional mapped subworkflow started reading conditions by position and failed as
soon as a step inside it mapped over a longer collection.

## What this changes

1. **No condition means no condition.** `SubWorkflowModule.execute` collapses an all-`None` list to
   `None`, so a subworkflow with no `when` expression carries no condition state at all instead of a
   placeholder per mapped element.

2. **Conditions only follow collections whose elements correspond.** New
   `MatchingCollections.is_aligned_with` asks whether two matches share a collection they were
   mapped from — the same collection, or one that an implicit collection was created from, followed
   through `implicit_input_collections`, `copied_from_history_dataset_collection_association`, and
   adapter `adapting`. An implicit collection has the same element identifiers in the same order as
   the collection mapped over to create it, which is exactly what reading conditions by element
   position needs.

   Only linked collections are consulted. They share one structure and have already passed
   `compatible_shape`, so a match on any one of them holds for all of them — which is why the
   existing `..._with_extra_nesting` conditional-subworkflow regression still gets its conditions:
   that step has two collections in one match.

3. **Fail with an explanation instead of guessing.** When a step inside a conditional subworkflow
   maps over a collection whose elements don't correspond, the invocation fails:

   > This step maps over a collection that cannot be matched up element by element with the
   > collection mapped over the conditional subworkflow containing it.

## Tests

- **Framework workflow** `subworkflow_mapping_per_step` — one subworkflow with two unrelated
  collections mapped inside it: a step reading the data input the subworkflow was mapped over
  (2 elements) and a sibling reading the subworkflow's own collection input (3 elements). Both
  outputs are exported and asserted flat at 2 and 3 elements, so the test fails if the two are
  multiplied together or matched up element by element. Verified red→green: it fails against the
  pre-fix `modules.py` and passes at HEAD.

  The differing element counts are the point. An earlier 2-and-2 version of this test passed even
  with the bug present, because `[None, None]` read harmlessly against a 2-element collection.

- **API** `test_conditional_subworkflow_rejects_independent_child_mapping` — a genuinely conditional
  subworkflow with an unrelated collection mapped inside it, tested with two- and three-element
  independent collections. It asserts that the invocation fails with the message above rather than
  crashing or quietly mismatching.

- **API** `test_invocation_conditional_map_over_inner_collection` — the conditional counterpart of
  the existing `test_invocation_map_over_inner_collection`: a `list:list` mapped over a subworkflow
  that declares a `list` input, so the steps inside map over a sub-collection of what the
  subworkflow was mapped over. Asserts the same output as the unconditional sibling when the
  condition holds, and a skipped output when it doesn't. Nothing covered this combination before —
  every existing conditional-subworkflow test maps over a flat list, and every sub-collection
  mapping test is subworkflow-free.

  Verified red→green against the guard rather than the original bug: with `is_aligned_with` forced
  to `False` the invocation fails on `intermediate_step` with the rejection message, so the test
  really does exercise alignment on a legitimate case.

- **Unit** `test/unit/data/dataset_collections/test_matching.py` — four cases over
  `is_aligned_with`: the same collection, an implicit collection created from it, two unrelated
  collections, and symmetry.

## Docs

Registers the rule in `collection_semantics.yml`, which had no subworkflow examples at all, as
`UNCONDITIONAL_SUBWORKFLOW_INDEPENDENT_LOCAL_MAPPING`, along with prose for the Subworkflows section
covering how mapping resolves per step inside a subworkflow and how `when` results travel with it.

Regenerating `doc/source/dev/collection_semantics.md` also picks up the **Type Compatibility
Algebra** section, which was added to the YAML in `39597b3366` without regenerating the doc — that's
why the generated-doc diff is larger than the new prose alone.

## Where the correspondence can't be established

Following how a collection was created relies on `implicit_input_collections`, which
`collections.py` records only when the mapped-over input is an HDCA — a dataset collection element
is skipped, with an in-tree comment noting the association is kept "for extracting workflows
currently."

That gap doesn't appear to be reachable from a workflow. A step's mapped-over input comes from
`replacement_for_input`, which resolves to a prior step's output, and those are HDCAs; elements
arrive as a mapped-over input through `meta.py` on the direct tool-execution path, where a user drags
a sub-collection (`src: "dce"`). The guard, meanwhile, only runs inside a conditional subworkflow
that has been mapped over — workflow-only. The two don't meet.

The case with the best claim to reaching it is sub-collection mapping inside a conditional
subworkflow, and `test_invocation_conditional_map_over_inner_collection` confirms it does not: both
steps inside get HDCAs and both align. If that provenance record were missing, the step would be
rejected with the message above — an explicit error, never a quiet mismatch.

## Not addressed here

`when` results are still kept as a flat list rather than being attached to the collection elements
and jobs they were computed for. This change makes the by-position reading safe to rely on —
carried where the elements correspond, refused where they don't — but it does not change how the
results are stored.
