### PR TITLE
[26.1] Bump gravity pin to v1.2.4 to apply a gravity bug fix

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -98,7 +98,7 @@ google-auth==2.53.0
 google-cloud-batch==0.21.0
 google-genai==2.3.0
 googleapis-common-protos==1.75.0
-gravity==1.2.3
+gravity==1.2.4
 greenlet==3.5.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
 griffelib==2.0.2
 groq==1.2.0


### PR DESCRIPTION
Bump gravity pin to apply a gravity bug fix https://github.com/galaxyproject/gravity/pull/162

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
