### PR TITLE
[26.1] Retry job output collection on a stale zero-length stat, not just errors

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1956,12 +1956,21 @@ class MinimalJobWrapper(HasResourceParameters):
         purged = dataset.dataset.purged
         if not purged and dataset.dataset.external_filename is None:
             trynum = 0
-            while trynum < self.app.config.retry_job_output_collection:
+            # +1 so retry_job_output_collection=0 still makes one attempt, matching the
+            # sibling retry loop in runners/__init__.py's _collect_job_output.
+            while trynum < self.app.config.retry_job_output_collection + 1:
                 try:
-                    # Attempt to short circuit NFS attribute caching
-                    os.stat(dataset.dataset.get_file_name())
-                    os.chown(dataset.dataset.get_file_name(), os.getuid(), -1)
-                    trynum = self.app.config.retry_job_output_collection
+                    # Attempt to short circuit NFS attribute caching. A stat that succeeds
+                    # but reports a zero-length file is treated the same as a transient
+                    # error: a remote writer (e.g. a GCP Batch task, whose output crosses
+                    # an NFS mount reached over a different network path than this
+                    # handler's own) can have already closed the file while this client
+                    # still serves a stale, empty cached view of it.
+                    file_name = dataset.dataset.get_file_name()
+                    os.chown(file_name, os.getuid(), -1)
+                    if os.stat(file_name).st_size == 0:
+                        raise OSError(f"{file_name} unexpectedly empty")
+                    break
                 except (OSError, ObjectNotFound) as e:
                     trynum += 1
                     log.warning("Error accessing dataset with ID %i, will retry: %s", dataset.dataset.id, unicodify(e))


### PR DESCRIPTION
## Problem

`_finish_dataset()` has a loop specifically intended to work around network
filesystem attribute caching when the handler reads a job's output right
after the job finishes:

```python
while trynum < self.app.config.retry_job_output_collection:
    try:
        # Attempt to short circuit NFS attribute caching
        os.stat(dataset.dataset.get_file_name())
        os.chown(dataset.dataset.get_file_name(), os.getuid(), -1)
        trynum = self.app.config.retry_job_output_collection
    except (OSError, ObjectNotFound) as e:
        ...
```

This has two problems:

1. **The loop bound is off by one against its own default.**
   `retry_job_output_collection` defaults to `0`, so
   `trynum < retry_job_output_collection` (`0 < 0`) is false immediately —
   the loop body, including the cache-busting `stat`/`chown`, never runs at
   all. The sibling retry loop in `runners/__init__.py`'s
   `_collect_job_output` uses `retry_job_output_collection + 1` for exactly
   this reason (so a count of `0` still makes one attempt); this loop didn't
   match that convention.

2. **It only retries on an exception.** The actual failure mode on a
   network filesystem isn't necessarily an `OSError` — it's a `stat()` that
   *succeeds* but returns a stale, cached view of a file a different host
   just wrote and closed (commonly reporting size 0). That falls straight
   through uncaught, and the dataset gets permanently marked `ok` with
   empty/wrong content.

This is most visible with job runners where the job's output is written by
a host other than the one running Galaxy, e.g. the GCP Batch runner: the
Batch task runs on its own VM and writes outputs over NFS through a
different network path (an internal load balancer) than the one the
Galaxy handler uses to read them back. Nothing guarantees the handler's
NFS client has a coherent view of the file the instant the Batch API
reports the task done, so metadata/output collection can race a write
that hasn't propagated yet.

## Fix

- Make the loop attempt at least once regardless of the configured retry
  count, matching the `+ 1` convention already used by the sibling retry
  loop.
- Treat a successful stat that reports a zero-length file the same as a
  transient error, so it's retried like any other failure instead of being
  accepted as the final (wrong) result.

This only changes the existing, purpose-built retry mechanism's
correctness; it doesn't change any defaults or add new configuration.

## Testing

- Reproduced the failure against a live GCP Batch-backed Galaxy instance
  under concurrent job load and confirmed the affected datasets' files
  were never actually empty on disk — the handler's read was just stale.
- Verified the corrected loop's control flow against synthetic
  stale-filesystem scenarios: it now recovers once the file becomes
  visible within the retry budget, still fails cleanly if a file is
  genuinely never populated, and adds no extra attempts when there's no
  staleness at all.