### PR TITLE
[26.1] Add zlib1g-dev to k8s image build deps

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -46,6 +46,7 @@ RUN set -xe; \
         libc-dev \
         bzip2 \
         gcc \
+        zlib1g-dev \
     && pip install --no-cache virtualenv ansible==11.11.0 \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
## Summary
- \`bgzip\` (pulled in transitively via \`fs.anvilfs\` -> \`terra-notebook-utils\`) only ships a source distribution, so it compiles its C extension against \`zlib.h\` at install time.
- Stage 1 of \`.k8s_ci.Dockerfile\` was missing zlib headers, breaking the k8s image build once \`fs.anvilfs\` resolved to a newer version pulling in \`terra-notebook-utils\`/\`bgzip\`: https://github.com/galaxyproject/galaxy/actions/runs/32944570655/job/98324427965
- Adds \`zlib1g-dev\` to the stage 1 apt-get install list.

## Test plan
- [ ] Container image build workflow succeeds