### PR TITLE
[26.1] add title for job metric cgroups v1 memory.oom_control.oom_kill

### DIFF
--- a/lib/galaxy/job_metrics/instrumenters/cgroup.py
+++ b/lib/galaxy/job_metrics/instrumenters/cgroup.py
@@ -45,6 +45,7 @@ TITLES = {
     "memory.soft_limit_in_bytes": "Memory softlimit on cgroup",
     "memory.failcnt": "Failed to allocate memory count",
     "memory.oom_control.oom_kill_disable": "OOM Control enabled",
+    "memory.oom_control.oom_kill": "Number of processes belonging to this cgroup killed by any kind of OOM killer",
     "memory.oom_control.under_oom": "Was OOM Killer active?",
     "cpuacct.usage": "CPU Time",
     # cgroupsv2


### PR DESCRIPTION
We are still using cgroups v1 and I’d like to add oom_kill to our metrics conf. Adding a title makes it look cleaner in the user-facing job info. I believe this is equivalent the cgroups v2 memory.events.oom_kill so I’ve copied the title from that.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
