### PR TITLE
[26.1] Fix workflow run-form option pagination

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
@@ -174,34 +174,17 @@ export default {
             }
             const optionsPagination = { [name]: { [src]: spec } };
             getTool(this.model.id, this.model.version, this.modelData, this.historyId, optionsPagination).then(
-                (newModel) => {
-                    const target = findInputByDottedName(this.modelInputs, name);
-                    const incoming = findInputByDottedName(newModel.inputs, name);
-                    if (!target || !incoming) {
-                        return;
-                    }
-                    const existing = (target.options && target.options[src]) || [];
-                    const newOptions = (incoming.options && incoming.options[src]) || [];
-                    const seen = new Set(existing.map((o) => `${o.id}_${o.src}`));
-                    const appended = existing.concat(newOptions.filter((o) => !seen.has(`${o.id}_${o.src}`)));
-                    target.options = { ...target.options, [src]: appended };
-                    if (incoming.options_meta && incoming.options_meta[src]) {
-                        target.options_meta = {
-                            ...(target.options_meta || {}),
-                            [src]: incoming.options_meta[src],
-                        };
-                    }
-                    this.modelInputs = JSON.parse(JSON.stringify(this.modelInputs));
-                },
+                (newModel) => this.mergeFetchedOptions(name, src, newModel),
                 (errorText) => {
                     this.errorText = errorText;
                 },
             );
         },
         /**
-         * Refetch the parameter's options filtered by the typed search query
-         * and **replace** (not append) the local options/meta — we want the
-         * narrowed list, not a union with whatever was previously loaded.
+         * Refetch the parameter's options filtered by the typed search query.
+         * The fetched matches are merged into the loaded options so the list
+         * cannot become empty and unmount the focused multiselect mid-typing;
+         * FormSelect's client-side filter still narrows the visible union.
          */
         onSearchChange({ name, src, query, limit }) {
             const spec = { offset: 0, limit };
@@ -210,25 +193,41 @@ export default {
             }
             const optionsPagination = { [name]: { [src]: spec } };
             getTool(this.model.id, this.model.version, this.modelData, this.historyId, optionsPagination).then(
-                (newModel) => {
-                    const target = findInputByDottedName(this.modelInputs, name);
-                    const incoming = findInputByDottedName(newModel.inputs, name);
-                    if (!target || !incoming) {
-                        return;
-                    }
-                    target.options = { ...target.options, [src]: incoming.options?.[src] || [] };
-                    if (incoming.options_meta && incoming.options_meta[src]) {
-                        target.options_meta = {
-                            ...(target.options_meta || {}),
-                            [src]: incoming.options_meta[src],
-                        };
-                    }
-                    this.modelInputs = JSON.parse(JSON.stringify(this.modelInputs));
-                },
+                (newModel) => this.mergeFetchedOptions(name, src, newModel),
                 (errorText) => {
                     this.errorText = errorText;
                 },
             );
+        },
+        mergeFetchedOptions(name, src, newModel) {
+            const target = findInputByDottedName(this.modelInputs, name);
+            const incoming = findInputByDottedName(newModel.inputs, name);
+            if (!target || !incoming) {
+                return;
+            }
+            const existing = (target.options && target.options[src]) || [];
+            const newOptions = (incoming.options && incoming.options[src]) || [];
+            const seen = new Set(existing.map((option) => `${option.id}_${option.src}`));
+            const merged = existing.concat(
+                newOptions.filter((option) => {
+                    const key = `${option.id}_${option.src}`;
+                    if (seen.has(key)) {
+                        return false;
+                    }
+                    seen.add(key);
+                    return true;
+                }),
+            );
+            target.options = { ...target.options, [src]: merged };
+            if (incoming.options_meta && incoming.options_meta[src]) {
+                target.options_meta = {
+                    ...(target.options_meta || {}),
+                    [src]: incoming.options_meta[src],
+                };
+            }
+            // FormDisplay renders from an internal clone and only syncs
+            // server-owned attributes when the inputs prop changes by identity.
+            this.modelInputs = [...this.modelInputs];
         },
     },
 };

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -55,6 +55,8 @@ interface Props {
     landingUuid?: string;
 }
 
+type PaginatedDataOption = Pick<DataOption, "id" | "src" | "name" | "hid" | "keep" | "tags">;
+
 const props = withDefaults(defineProps<Props>(), {
     targetHistory: "current",
     useJobCache: false,
@@ -133,14 +135,6 @@ const computedActiveNodeId = computed<number | undefined>(() => {
     return undefined;
 });
 
-// Build the form inputs once into a stable ref so paginated mutations
-// (``onLoadMore`` / ``onSearchChange`` set ``input.options`` / ``options_meta``
-// on the matching step-input object below) don't rebuild the array. Vue's
-// ``v-for`` in the child ``FormDisplay`` then doesn't unmount the dropdown's
-// ``<input>`` element across paginated refreshes — important for selenium
-// tests like ``test_workflow_rerun`` that ``select_set_value`` against the
-// dropdown (type → wait UX_RENDER → send Enter on the same element ref).
-//
 // ``stepInputByIndex`` maps ``step.step_index`` (as string) to the live
 // step-input object inside ``formInputs.value`` so the paginated-fetch
 // handlers can locate and mutate it in O(1) without walking the array.
@@ -315,7 +309,7 @@ function onChange(data: any) {
     formData.value = data;
 }
 
-function shapeContentsRow(row: any) {
+function shapeContentsRow(row: any): PaginatedDataOption {
     const src = row.history_content_type === "dataset_collection" ? "hdca" : "hda";
     return {
         id: row.id,
@@ -331,14 +325,9 @@ async function fetchStepOptions(
     name: string,
     src: string,
     payload: { offset?: number; limit?: number; search?: string } = {},
-    mode: "append" | "replace" = "append",
 ) {
-    // Locate the live step-input object inside ``formInputs.value`` and
-    // mutate it in place — ``formInputs`` is a stable ref built once, so
-    // mutating ``input.options`` / ``input.options_meta`` doesn't rebuild
-    // the array and doesn't unmount the dropdown's ``<input>`` element.
-    // (``stepAsInput`` is a local copy built in ``buildFormInputs``; this
-    // is not prop mutation.)
+    // ``stepAsInput`` is a local copy built in ``buildFormInputs``, so this
+    // does not mutate the model prop.
     const input = stepInputByIndex.get(String(name));
     if (!input) {
         return;
@@ -355,27 +344,29 @@ async function fetchStepOptions(
             offset,
             limit,
         });
-        const shaped = (rows || []).map(shapeContentsRow);
-        let merged: any[];
-        if (mode === "replace") {
-            merged = shaped;
-        } else {
-            const seen = new Set<string>();
-            const base = (input.options?.[src] as any[]) || [];
-            merged = [...base, ...shaped].filter((item) => {
-                const k = `${item.id}_${item.src}`;
-                if (seen.has(k)) {
+        const shaped: PaginatedDataOption[] = (rows || []).map(shapeContentsRow);
+        const base = (input.options?.[src] as PaginatedDataOption[]) || [];
+        const seen = new Set<string>(base.map((item) => `${item.id}_${item.src}`));
+        const merged = base.concat(
+            shaped.filter((item) => {
+                const key = `${item.id}_${item.src}`;
+                if (seen.has(key)) {
                     return false;
                 }
-                seen.add(k);
+                seen.add(key);
                 return true;
-            });
-        }
+            }),
+        );
         input.options = { ...(input.options || {}), [src]: merged };
         input.options_meta = {
             ...(input.options_meta || {}),
             [src]: { offset, limit, has_more: shaped.length === limit },
         };
+        // FormDisplay renders from an internal clone and only syncs
+        // server-owned attributes when the inputs prop changes by identity.
+        // A shallow array copy triggers that sync while preserving the clone's
+        // client-owned value and focused multiselect input.
+        formInputs.value = [...formInputs.value];
     } catch (e) {
         // intentionally silent — paging failures don't block the rest of the form
         console.warn("history-contents pagination failed", e);
@@ -395,11 +386,11 @@ function onLoadMore({
     limit: number;
     search?: string;
 }) {
-    fetchStepOptions(name, src, { offset, limit, search }, "append");
+    fetchStepOptions(name, src, { offset, limit, search });
 }
 
 function onSearchChange({ name, src, query, limit }: { name: string; src: string; query: string; limit?: number }) {
-    fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query }, "replace");
+    fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query });
 }
 
 function onStorageUpdate(objectStoreId: string, intermediate: boolean) {

--- a/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
@@ -69,15 +69,6 @@ export default {
             return this._isSimpleInputType(this.model.step_type);
         },
         inputs() {
-            // Keep the array reference stable across paginated refreshes:
-            // ``_fetchStepOptions`` mutates a single ``localInputs[i]``'s
-            // ``options`` / ``options_meta`` properties (not the array), so
-            // Vue's ``v-for`` in the child ``FormDisplay`` doesn't unmount
-            // its rendered children. That matters because
-            // ``select_set_value`` (used by ``test_execution_with_multiple_inputs``)
-            // types into vue-multiselect's input, sleeps ``UX_RENDER``, then
-            // sends Enter on the same element reference — a remount during
-            // that window would invalidate it.
             return this.localInputs;
         },
         hasInputs() {
@@ -135,7 +126,7 @@ export default {
                 tags: row.tags || [],
             };
         },
-        async _fetchStepOptions(name, src, payload = {}, mode = "append") {
+        async _fetchStepOptions(name, src, payload = {}) {
             const input = this._findInputByName(name);
             if (!input || !this.historyId) {
                 return;
@@ -153,42 +144,37 @@ export default {
                     limit,
                 });
                 const shaped = (rows || []).map(this._shapeContentsRow);
-                let merged;
-                if (mode === "replace") {
-                    merged = shaped;
-                } else {
-                    const base = (input.options && input.options[src]) || [];
-                    const seen = new Set();
-                    merged = [...base, ...shaped].filter((item) => {
-                        const k = `${item.id}_${item.src}`;
-                        if (seen.has(k)) {
+                const base = (input.options && input.options[src]) || [];
+                const seen = new Set(base.map((item) => `${item.id}_${item.src}`));
+                const merged = base.concat(
+                    shaped.filter((item) => {
+                        const key = `${item.id}_${item.src}`;
+                        if (seen.has(key)) {
                             return false;
                         }
-                        seen.add(k);
+                        seen.add(key);
                         return true;
-                    });
-                }
-                // Mutate the local copy in place; ``localInputs`` is
-                // component-owned (declared in ``data()``), so this is not
-                // prop mutation. The ``localInputs`` array reference stays
-                // stable across paginated refreshes — Vue's ``v-for`` in the
-                // child ``FormDisplay`` doesn't unmount its children, so
-                // vue-multiselect's ``<input>`` survives across the
-                // search-change debounce.
+                    }),
+                );
                 input.options = { ...(input.options || {}), [src]: merged };
                 input.options_meta = {
                     ...(input.options_meta || {}),
                     [src]: { offset, limit, has_more: shaped.length === limit },
                 };
+                // FormDisplay renders from an internal clone and only syncs
+                // server-owned attributes when the inputs prop changes by
+                // identity. Bump the array reference so the fetched options
+                // reach that clone without replacing its client-owned value.
+                this.localInputs = [...this.localInputs];
             } catch (e) {
                 console.warn("history-contents pagination failed", e);
             }
         },
         onLoadMore({ name, src, offset, limit, search }) {
-            this._fetchStepOptions(name, src, { offset, limit, search }, "append");
+            this._fetchStepOptions(name, src, { offset, limit, search });
         },
         onSearchChange({ name, src, query, limit }) {
-            this._fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query }, "replace");
+            this._fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query });
         },
     },
 };

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -121,21 +121,17 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
 
     @selenium_test
     def test_workflow_run_pagination_legacy_form(self):
-        """Pagination + backend search on a workflow run form's tool-step
-        dropdown. Uses the legacy/expanded form (the default), where the
-        tool step is rendered via ``WorkflowRunDefaultStep`` — this is the
-        component we wired ``onLoadMore`` / ``onSearchChange`` into. Seeds 60
-        HDAs so the default 50-per-page cap is in effect, then types a query
-        and asserts the dropdown narrows to the backend-matched options."""
+        """Backend search updates a legacy workflow tool-step dropdown."""
         history_id = self.current_history_id()
-        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
-        # Sentinel-named HDA so we can prove options are *actually rendering*
-        # (a vacuous pass — empty dropdown — would clear the ``<= 50`` upper bound).
         legacy_sentinel = "unique-pagination-sentinel"
+        # Create the sentinel first so the 60 newer datasets push it beyond
+        # the initial page. Finding it requires the backend search response to
+        # reach FormDisplay's cloned input tree.
         self.dataset_populator.fetch_hdas(
             history_id,
             [{"src": "pasted", "paste_content": "y", "name": legacy_sentinel}],
         )
+        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
         self.home()
         # A single cat1 step with no workflow-level inputs — the step's
         # ``input1`` is unconnected, so it renders as a dropdown the user
@@ -146,18 +142,15 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         # Open the dropdown so its options render in the DOM, then type into
         # the multiselect's search input. The debounced ``search-change``
         # bubbles through ``FormDisplay → WorkflowRunDefaultStep`` and refetches
-        # via ``getTool`` with ``options_pagination[input1][hda].search="1"``.
+        # via ``getTool`` with the sentinel as the server-side search query.
         select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
         self.sleep_for(self.wait_types.UX_RENDER)
         baseline_options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-        assert len(baseline_options) <= 50, f"Expected default page to cap at 50 options, got {len(baseline_options)}"
-        # Positive lower-bound: the sentinel HDA is newest (hid=61) so it must
-        # appear in the first page of (newest-first) options. Without this the
-        # ``<= 50`` upper bound passes vacuously on an empty dropdown.
+        assert len(baseline_options) == 50, f"Expected default page to contain 50 options, got {len(baseline_options)}"
         baseline_labels = [opt.text for opt in baseline_options]
-        assert any(legacy_sentinel in label for label in baseline_labels), baseline_labels
+        assert all(legacy_sentinel not in label for label in baseline_labels), baseline_labels
         search_input = select_field.find_element(By.CSS_SELECTOR, "input.multiselect__input")
-        search_input.send_keys("1")
+        search_input.send_keys(legacy_sentinel)
         # Wait past the FormSelect search debounce (300 ms) plus the network
         # round-trip — UX_TRANSITION is a generous ~1s.
         self.sleep_for(self.wait_types.UX_TRANSITION)
@@ -165,22 +158,42 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         @retry_assertion_during_transitions
         def assert_search_narrowed():
             options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-            assert len(options) > 0, "Expected at least one match for query '1' (e.g. hid=1)"
-            # All visible labels should contain '1' somewhere — either in the
-            # numeric hid prefix (hid=1, 10, 11, ...) or in the name.
             labels = [opt.text for opt in options]
-            assert all("1" in label for label in labels), labels
+            assert any(legacy_sentinel in label for label in labels), labels
 
         assert_search_narrowed()
 
     @selenium_test
+    def test_workflow_run_input_step_load_more_appends(self):
+        """Scrolling a workflow input-step dropdown appends its second page.
+
+        Regression test for the workflow-run equivalent of issue #23135:
+        the request and pagination metadata updated, but FormDisplay's cloned
+        input tree kept rendering the first 50 options.
+        """
+        history_id = self.current_history_id()
+        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.home()
+        self.workflow_run_open_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.workflow_run_ensure_expanded()
+        select_field = self.components.workflow_run.input_data_div(label="input1").wait_for_visible()
+        select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        assert len(select_field.find_elements(By.CSS_SELECTOR, "[role='option']")) == 50
+
+        @retry_assertion_during_transitions
+        def assert_more_options_loaded():
+            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
+            if sentinels:
+                self.scroll_into_view(sentinels[0])
+            options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
+            assert len(options) > 50, f"Expected the dropdown to append a second page, got {len(options)} options"
+
+        assert_more_options_loaded()
+
+    @selenium_test
     def test_workflow_run_pagination_simplified_form(self):
-        """The simplified workflow run form (``WorkflowRunFormSimple``) only
-        renders workflow-level inputs. With 60 datasets in history and the
-        backend's default 50-per-page cap, the dropdown for a workflow
-        ``input1: data`` step must show no more than 50 options — proves
-        pagination is in effect even though the simplified form's step
-        component doesn't yet wire interactive load-more."""
+        """Scrolling a simplified workflow-run dropdown appends its second page."""
         history_id = self.current_history_id()
         self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
         # Sentinel for positive lower-bound (see legacy-form test).
@@ -211,14 +224,24 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
         self.sleep_for(self.wait_types.UX_RENDER)
         options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-        assert (
-            len(options) <= 50
-        ), f"Simplified form dropdown must respect the 50-per-page cap; got {len(options)} options"
+        assert len(options) == 50, f"Expected the first page to contain 50 options, got {len(options)}"
         # Positive lower-bound: the sentinel HDA is newest (hid=61) so it must
         # appear in the first page of options. Without this the ``<= 50`` upper
         # bound passes vacuously on an empty dropdown.
         labels = [opt.text for opt in options]
         assert any(simplified_sentinel in label for label in labels), labels
+
+        @retry_assertion_during_transitions
+        def assert_more_options_loaded():
+            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
+            if sentinels:
+                self.scroll_into_view(sentinels[0])
+            loaded_options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
+            assert (
+                len(loaded_options) > 50
+            ), f"Expected the simplified dropdown to append a second page, got {len(loaded_options)} options"
+
+        assert_more_options_loaded()
 
     @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test


### PR DESCRIPTION
## Problem

Workflow run-form data inputs fetch additional pages when the load-more sentinel is scrolled into view, but the dropdown remains stuck on the initial 50 options. Backend search results can likewise fail to reach the rendered select.

This is the workflow-run equivalent of #23135, fixed for tool forms in #23136.

## Root cause

`WorkflowRunInputStep` and `WorkflowRunFormSimple` mutate nested `options` and `options_meta` on their input arrays. `FormDisplay` renders from an internal clone and only synchronizes server-owned attributes when the top-level `inputs` prop changes identity, so those nested updates never reach the rendered dropdown.

## Fix

- Bump the top-level input-array identity after paginated updates so `FormDisplay` synchronizes its clone while preserving client-owned values.
- Merge and deduplicate search and pagination results so an empty backend response cannot unmount the focused multiselect.
- Apply the same merge/refresh behavior consistently to expanded tool steps, expanded workflow input steps, and the simplified run form.
- Add Selenium coverage for loading page two in both workflow-input renderers and strengthen the backend-search test with an HDA outside page one.

## Verification

The two load-more tests fail on the test-only commit, each remaining at exactly 50 options:

- `test_workflow_run_input_step_load_more_appends`
- `test_workflow_run_pagination_simplified_form`

With the fix applied:

- Focused Selenium tests: 3 passed
- `tox -e lint,format,mypy`: passed
