### PR TITLE
Add config-driven Galaxy subdomain switcher

### DIFF
--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -6,7 +6,7 @@ import { setupMockConfig } from "@tests/vitest/mockConfig";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { PiniaVuePlugin } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useUserStore } from "@/stores/userStore";
 
@@ -30,6 +30,7 @@ describe("Masthead.vue", () => {
     let localVue;
     let windowTab;
     let testPinia;
+    let originalUrl;
 
     function stubLoadWebhooks(items) {
         items.push({
@@ -42,6 +43,8 @@ describe("Masthead.vue", () => {
     loadMastheadWebhooks.mockImplementation(stubLoadWebhooks);
 
     beforeEach(async () => {
+        setupMockConfig({});
+        originalUrl = window.location.href;
         localVue = getLocalVue();
         localVue.use(PiniaVuePlugin);
         testPinia = createTestingPinia({ createSpy: vi.fn });
@@ -70,6 +73,24 @@ describe("Masthead.vue", () => {
         await flushPromises();
     });
 
+    afterEach(() => {
+        wrapper.destroy();
+        window.location.href = originalUrl;
+    });
+
+    async function remount(config, user = currentUser) {
+        wrapper.destroy();
+        setupMockConfig(config);
+        const userStore = useUserStore();
+        userStore.currentUser = user;
+        wrapper = mount(Masthead, {
+            propsData: { windowTab },
+            localVue,
+            pinia: testPinia,
+        });
+        await flushPromises();
+    }
+
     it("should render simple tab item links", () => {
         expect(wrapper.findAll("li.nav-item").length).toBe(4);
         // Ensure specified link title respected.
@@ -86,5 +107,82 @@ describe("Masthead.vue", () => {
 
     it("should load webhooks on creation", async () => {
         expect(wrapper.find("#extension a").text()).toBe("Extension Point");
+    });
+
+    it("does not render the site switcher without destinations", async () => {
+        expect(wrapper.find("#subdomain_switcher").exists()).toBe(false);
+
+        await remount({
+            subdomain_switcher: [{ label: "Current site", url: `${window.location.origin}/` }],
+        });
+
+        expect(wrapper.find("#subdomain_switcher").exists()).toBe(false);
+    });
+
+    it("renders exact destination URLs in configured order and omits the current origin", async () => {
+        window.location.href = "http://galaxy.example.org:80/current/path?query=kept-out";
+        await remount({
+            subdomain_switcher: [
+                { label: "Current site", url: "http://galaxy.example.org/" },
+                { label: "Invalid site", url: "http://[" },
+                { label: "Single Cell <Omics>", url: "https://singlecell.example.org/root/?exact=true#destination" },
+                { label: "Climate", url: "https://climate.example.org" },
+            ],
+        });
+
+        const switcher = wrapper.find("#subdomain_switcher");
+        const links = switcher.findAll("a.dropdown-item");
+        expect(switcher.exists()).toBe(true);
+        expect(switcher.attributes("title")).toBe("Switch sites");
+        expect(links.wrappers.map((link) => link.text())).toEqual(["Single Cell <Omics>", "Climate"]);
+        expect(links.wrappers.map((link) => link.attributes("href"))).toEqual([
+            "https://singlecell.example.org/root/?exact=true#destination",
+            "https://climate.example.org",
+        ]);
+        expect(switcher.find("em").exists()).toBe(false);
+    });
+
+    it.each([
+        ["registered", currentUser, {}],
+        ["anonymous", { id: "anonymous", isAnonymous: true }, {}],
+        ["single-user", currentUser, { single_user: true }],
+    ])("renders the optional switcher for the %s masthead", async (_variant, user, variantConfig) => {
+        await remount(
+            {
+                ...variantConfig,
+                subdomain_switcher: [{ label: "Another site", url: "https://another.example.org" }],
+            },
+            user,
+        );
+
+        expect(wrapper.find("#subdomain_switcher").exists()).toBe(true);
+    });
+
+    it.each([["javascript:alert(1)"], ["data:text/html,<script>alert(1)</script>"], ["vbscript:msgbox(1)"]])(
+        "drops destinations using the unsafe scheme %s",
+        async (url) => {
+            await remount({
+                subdomain_switcher: [
+                    { label: "Unsafe", url },
+                    { label: "Safe", url: "https://safe.example.org" },
+                ],
+            });
+
+            const links = wrapper.findAll("#subdomain_switcher a.dropdown-item");
+            expect(links.wrappers.map((link) => link.attributes("href"))).toEqual(["https://safe.example.org"]);
+        },
+    );
+
+    it("drops destinations without a usable label instead of failing to render", async () => {
+        await remount({
+            subdomain_switcher: [
+                { url: "https://unlabelled.example.org" },
+                { label: "   ", url: "https://blank.example.org" },
+                { label: "Safe", url: "https://safe.example.org" },
+            ],
+        });
+
+        const links = wrapper.findAll("#subdomain_switcher a.dropdown-item");
+        expect(links.wrappers.map((link) => link.text())).toEqual(["Safe"]);
     });
 });

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { faConnectdevelop } from "@fortawesome/free-brands-svg-icons";
 import { faQuestion, faSignOutAlt, faSpinner, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BNavbar, BNavbarBrand, BNavbarNav } from "bootstrap-vue";
@@ -27,6 +28,26 @@ const { isAnonymous, currentUser } = storeToRefs(useUserStore());
 
 const router = useRouter();
 const { config, isConfigLoaded } = useConfig();
+
+const subdomainSwitcherMenu = computed(() => {
+    const currentOrigin = window.location.origin;
+    return (config.value.subdomain_switcher ?? [])
+        .filter((site) => {
+            if (typeof site?.label !== "string" || !site.label.trim()) {
+                return false;
+            }
+            try {
+                const { protocol, origin } = new URL(site.url);
+                return (protocol === "http:" || protocol === "https:") && origin !== currentOrigin;
+            } catch {
+                return false;
+            }
+        })
+        .map((site) => ({
+            title: site.label,
+            href: site.url,
+        }));
+});
 
 const hasOIDCRegistration = computed(() => {
     const oIDCIdps = isConfigLoaded.value ? config.value.oidc : {};
@@ -162,6 +183,12 @@ onMounted(() => {
                 :tooltip="tab.tooltip"
                 :target="tab.target"
                 @click="extensionTabClick(tab)" />
+            <MastheadDropdown
+                v-if="subdomainSwitcherMenu.length"
+                id="subdomain_switcher"
+                :icon="faConnectdevelop"
+                tooltip="Switch sites"
+                :menu="subdomainSwitcherMenu" />
             <MastheadItem
                 id="help"
                 :icon="faQuestion"

--- a/client/src/components/Masthead/MastheadDropdown.test.ts
+++ b/client/src/components/Masthead/MastheadDropdown.test.ts
@@ -1,0 +1,28 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import MastheadDropdown from "./MastheadDropdown.vue";
+
+describe("MastheadDropdown.vue", () => {
+    it("supports callback-backed and URL-backed menu items", async () => {
+        const handler = vi.fn();
+        const wrapper = mount(MastheadDropdown as object, {
+            localVue: getLocalVue(),
+            propsData: {
+                id: "mixed-menu",
+                menu: [
+                    { title: "Callback", handler },
+                    { title: "Destination", href: "https://example.org/root/?exact=true" },
+                ],
+            },
+        });
+
+        const items = wrapper.findAll("a.dropdown-item");
+        expect(items.at(0).attributes("href")).toBe("#");
+        expect(items.at(1).attributes("href")).toBe("https://example.org/root/?exact=true");
+
+        await items.at(0).trigger("click");
+        expect(handler).toHaveBeenCalledOnce();
+    });
+});

--- a/client/src/components/Masthead/MastheadDropdown.vue
+++ b/client/src/components/Masthead/MastheadDropdown.vue
@@ -9,11 +9,22 @@ import TextShort from "@/components/Common/TextShort.vue";
 
 const dropdown = ref(null);
 
-interface MenuItem {
+interface BaseMenuItem {
     title: string;
     icon?: IconLike;
-    handler: () => void;
 }
+
+interface HandlerMenuItem extends BaseMenuItem {
+    handler: () => void;
+    href?: never;
+}
+
+interface AnchorMenuItem extends BaseMenuItem {
+    href: string;
+    handler?: never;
+}
+
+type MenuItem = HandlerMenuItem | AnchorMenuItem;
 
 /* props */
 defineProps({
@@ -51,8 +62,9 @@ defineProps({
                 v-for="(item, idx) in menu"
                 :key="idx"
                 :data-description="`${id} ${item.title.toLowerCase()}`"
+                :href="item.href"
                 role="menuitem"
-                @click="item.handler">
+                @click="item.handler && item.handler()">
                 <FontAwesomeIcon v-if="item.icon" fixed-width :icon="item.icon" />
                 <span>{{ item.title }}</span>
             </BDropdownItem>

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2531,6 +2531,22 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~
+``subdomain_switcher``
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Sites to display in the masthead's "Switch sites" menu. Each entry
+    requires a non-empty label and an absolute HTTP or HTTPS URL.
+    Entries are displayed in the configured order, excluding the site
+    matching the current URL origin.
+    Example value: ``[{label: Base site, url:
+    https://usegalaxy.example.org}, {label: Single Cell Omics, url:
+    https://singlecell.usegalaxy.example.org}]``
+:Default: ``[]``
+:Type: seq
+
+
 ~~~~~~~~~~~~~~~~
 ``helpsite_url``
 ~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -194,6 +194,7 @@ class GalaxyAppConfigurationAttributes:
     logo_url: str
     logo_src: str
     logo_src_secondary: str | None
+    subdomain_switcher: list[dict[str, str]]
     helpsite_url: str
     wiki_url: str
     quota_url: str

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -581,6 +581,7 @@ _ATTR_TYPE_OVERRIDES: dict[str, dict[str, str]] = {
         # seq attrs with more specific element types
         "file_source_templates": "list[dict[str, Any]] | None",
         "object_store_templates": "list[dict[str, Any]] | None",
+        "subdomain_switcher": "list[dict[str, str]]",
         # Stored as float despite int schema type
         "object_store_cache_size": "float",
         # Converted from int (days) to timedelta by _process_config

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1601,6 +1601,15 @@ galaxy:
   # The custom brand image source.
   #logo_src_secondary: null
 
+  # Sites to display in the masthead's "Switch sites" menu. Each entry
+  # requires a non-empty label and an absolute HTTP or HTTPS URL.
+  # Entries are displayed in the configured order, excluding the site
+  # matching the current URL origin.
+  # Example value: ``[{label: Base site, url:
+  # https://usegalaxy.example.org}, {label: Single Cell Omics, url:
+  # https://singlecell.usegalaxy.example.org}]``
+  #subdomain_switcher: []
+
   # The URL linked by the "Galaxy Help" link in the "Help" menu.
   #helpsite_url: https://help.galaxyproject.org/
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1888,6 +1888,29 @@ mapping:
         desc: |
           The custom brand image source.
 
+      subdomain_switcher:
+        type: seq
+        default: []
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              label:
+                type: str
+                required: true
+                pattern: '.+'
+              url:
+                type: str
+                required: true
+                pattern: '^https?://[^/?#\s]+(?:[/?#][^\s]*)?$'
+        desc: |
+          Sites to display in the masthead's "Switch sites" menu. Each entry requires
+          a non-empty label and an absolute HTTP or HTTPS URL. Entries are displayed
+          in the configured order, excluding the site matching the current URL origin.
+
+          Example value: ``[{label: Base site, url: https://usegalaxy.example.org},
+          {label: Single Cell Omics, url: https://singlecell.usegalaxy.example.org}]``
+
       helpsite_url:
         type: str
         required: false

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -132,6 +132,7 @@ class ConfigSerializer(base.ModelSerializer):
             "logo_url": _use_config,
             "logo_src": _use_config,
             "logo_src_secondary": _use_config,
+            "subdomain_switcher": _use_config,
             "terms_url": _use_config,
             "wiki_url": _use_config,
             "screencasts_url": _use_config,

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -14,6 +14,7 @@ TEST_KEYS_FOR_ALL_USERS = [
     "logo_url",
     "terms_url",
     "allow_user_dataset_purge",
+    "subdomain_switcher",
 ]
 TEST_KEYS_FOR_ADMIN_ONLY = [
     "library_import_dir",
@@ -34,6 +35,13 @@ class TestConfigurationApi(ApiTestCase):
         config = self._get_configuration()
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
         assert_not_has_keys(config, *TEST_KEYS_FOR_ADMIN_ONLY)
+        assert config["subdomain_switcher"] == []
+
+    def test_anonymous_user_configuration(self):
+        with self._different_user(anon=True):
+            config = self._get_configuration()
+        assert_has_keys(config, "subdomain_switcher")
+        assert config["subdomain_switcher"] == []
 
     @requires_admin
     def test_admin_user_configuration(self):

--- a/test/integration/test_subdomain_switcher_configuration.py
+++ b/test/integration/test_subdomain_switcher_configuration.py
@@ -1,0 +1,23 @@
+from galaxy_test.driver import integration_util
+
+SITES = [
+    {"label": "Base site", "url": "https://usegalaxy.example.org"},
+    {"label": "Single Cell Omics", "url": "https://singlecell.usegalaxy.example.org/"},
+]
+
+
+class TestSubdomainSwitcherConfiguration(integration_util.IntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["subdomain_switcher"] = SITES
+
+    def test_configuration_is_exposed_to_registered_and_anonymous_users(self):
+        response = self.galaxy_interactor.get("configuration")
+        response.raise_for_status()
+        assert response.json()["subdomain_switcher"] == SITES
+
+        with self._different_user(anon=True):
+            response = self.galaxy_interactor.get("configuration")
+        response.raise_for_status()
+        assert response.json()["subdomain_switcher"] == SITES

--- a/test/unit/config/config_manage/test_config_manage.py
+++ b/test/unit/config/config_manage/test_config_manage.py
@@ -2,9 +2,14 @@ import os
 import shutil
 import tempfile
 
+import pytest
 import yaml
+from pykwalify.core import Core
+from pykwalify.errors import SchemaError
 
+from galaxy.config import GALAXY_CONFIG_SCHEMA_PATH
 from galaxy.config.config_manage import main
+from galaxy.config.schema import AppSchema
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -77,6 +82,37 @@ def test_validate_simple_config():
 def test_validate_embedded_config():
     with _config_directory("embedded") as config_dir:
         config_dir.manage_cli(["validate", "galaxy"])
+
+
+def test_validate_subdomain_switcher():
+    switcher = [
+        {"label": "Base site", "url": "https://usegalaxy.example.org"},
+        {"label": "Single Cell Omics", "url": "http://singlecell.usegalaxy.example.org/"},
+    ]
+
+    _validate_subdomain_switcher([])
+    _validate_subdomain_switcher(switcher)
+
+
+@pytest.mark.parametrize(
+    "site",
+    [
+        {"label": "", "url": "https://usegalaxy.example.org"},
+        {"label": "Base site", "url": "/relative/url"},
+        {"label": "Base site", "url": "ftp://usegalaxy.example.org"},
+        {"label": "Base site"},
+        {"url": "https://usegalaxy.example.org"},
+    ],
+)
+def test_reject_invalid_subdomain_switcher_entries(site):
+    with pytest.raises(SchemaError):
+        _validate_subdomain_switcher([site])
+
+
+def _validate_subdomain_switcher(value):
+    option_schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, "galaxy").app_schema["subdomain_switcher"].copy()
+    option_schema.pop("default")
+    Core(source_data=value, schema_data=option_schema).validate()
 
 
 class _TestConfigDirectory:

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -51,6 +51,23 @@ def test_base_config_if_running_not_from_source(monkeypatch):
     assert appconfig.managed_config_dir == os.path.join(appconfig.data_dir, "config")
 
 
+def test_subdomain_switcher_defaults_to_empty_list():
+    appconfig = config.GalaxyAppConfiguration(override_tempdir=False)
+
+    assert appconfig.subdomain_switcher == []
+
+
+def test_subdomain_switcher_preserves_configured_entries():
+    sites = [
+        {"label": "Base site", "url": "https://usegalaxy.example.org"},
+        {"label": "Single Cell Omics", "url": "https://singlecell.usegalaxy.example.org/"},
+    ]
+
+    appconfig = config.GalaxyAppConfiguration(override_tempdir=False, subdomain_switcher=sites)
+
+    assert appconfig.subdomain_switcher == sites
+
+
 def test_assign_email_from(monkeypatch):
     appconfig = config.GalaxyAppConfiguration(
         override_tempdir=False, galaxy_infrastructure_url="http://myhost:8080/galaxy/"


### PR DESCRIPTION
Adds an opt-in `subdomain_switcher` configuration option that renders a "Switch sites" dropdown in the masthead, so deployments running several Galaxy subdomains (e.g. a base site plus a Single Cell Omics site) can link between them from core rather than from deployment-specific webhook JavaScript.

### What it does

- New `subdomain_switcher` option in the config schema: a list of `{label, url}` entries, defaulting to `[]` (so the menu is absent unless configured).
- Exposed through `ConfigSerializer`, which is the all-users bucket, so the menu works for registered, anonymous, and single-user mastheads alike.
- The client renders entries in configured order and omits the one matching the current origin, preserving each destination's exact path/query/fragment.
- `MastheadDropdown` gained support for URL-backed items alongside the existing callback-backed ones.

### Why not a webhook

This replaces per-deployment webhook JavaScript with a config-driven mechanism, which keeps site ordering and exact root destinations under admin control and avoids each deployment reimplementing it.

### Notes for reviewers

The config value is admin-supplied but is not validated at runtime — Galaxy's pykwalify schema is only enforced by the offline `config_manage validate` CLI, never during startup. The client therefore treats the value as untrusted and filters it before render:

- only `http:`/`https:` URLs are accepted, so a `javascript:`/`data:`/`vbscript:` URL cannot reach an anchor `href` (`new URL()` parses these happily with `origin === "null"`, which otherwise passes an origin comparison);
- entries without a usable string label are dropped, rather than throwing while rendering the masthead on every page.

Both are covered by regression tests that were confirmed to fail without the corresponding guard.

Two follow-ups deliberately left out of scope:

- `subdomain_switcher` is not `per_host: true`, unlike every neighbouring branding option (`logo_url`, `logo_src`, `helpsite_url`, ...). Client-side origin filtering covers the common case, but per-host menus would need that flag.
- `config_manage validate` currently accepts invalid entries. That is pre-existing and not caused by this branch — the `except RuleError: pass` in `config_manage.py` swallows a schema rule error and aborts validation of the whole config — but it does mean the schema `pattern` constraints here are documentation rather than enforcement.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. Set `subdomain_switcher` in `galaxy.yml` to a list of `{label, url}` entries, at least one of which is not the current origin, and confirm the "Switch sites" menu appears in the masthead.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
