### PR TITLE
[26.1] Preserve tool lint errors after parser failures

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -54,6 +54,7 @@ from typing import (
     Callable,
     List,
     Optional,
+    Set,
     Type,
     TYPE_CHECKING,
     TypeVar,
@@ -62,10 +63,12 @@ from typing import (
 
 import galaxy.tool_util.linters
 from galaxy.tool_util.parser import get_tool_source
+from galaxy.tool_util.parser.util import ParseException
 from galaxy.tool_util.parser.yaml import YamlToolSource
 from galaxy.util import (
     Element,
     submodules,
+    unicodify,
 )
 
 if TYPE_CHECKING:
@@ -207,6 +210,7 @@ class LintContext:
         object_name: Optional[str] = None,
     ):
         self.skip_types = skip_types or []
+        self._reported_failures: Set[str] = set()
         if isinstance(level, str):
             self.level = LintLevel[level.upper()]
         else:
@@ -247,7 +251,12 @@ class LintContext:
             self.message_list = []
 
         # call linter
-        lint_func(lint_target, self)
+        try:
+            lint_func(lint_target, self)
+        except ParseException as e:
+            # Attribute the error to parsing, not whichever linter happened to
+            # encounter the unparseable part of the tool source first.
+            self._report_failure(f"Tool could not be parsed: {unicodify(e)}", "ToolParse")
 
         if self.level < LintLevel.SILENT:
             for message in self.error_messages:
@@ -291,6 +300,14 @@ class LintContext:
 
     def info(self, message: str, linter: Optional[str] = None, *args, **kwargs) -> None:
         self.__handle_message("info", message, linter, *args, **kwargs)
+
+    def _report_failure(self, message: str, linter: str) -> None:
+        # Several linters parse the same tool source, so an unparseable tool would
+        # otherwise report the same failure once per linter.
+        if message in self._reported_failures:
+            return
+        self._reported_failures.add(message)
+        self.error(message, linter=linter)
 
     def error(self, message: str, linter: Optional[str] = None, *args, **kwargs) -> None:
         self.__handle_message("error", message, linter, *args, **kwargs)

--- a/lib/galaxy/tool_util/parser/util.py
+++ b/lib/galaxy/tool_util/parser/util.py
@@ -108,7 +108,11 @@ def text_input_is_optional(input_source: "InputSource") -> Tuple[bool, bool]:
     return optional, optionality_inferred
 
 
-class ParameterParseException(Exception):
+class ParseException(Exception):
+    """A tool source could not be parsed into a usable tool."""
+
+
+class ParameterParseException(ParseException):
     message: str
 
     def __init__(self, message):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -29,6 +29,7 @@ from galaxy.tool_util.linters import (
 )
 from galaxy.tool_util.loader_directory import load_tool_sources_from_path
 from galaxy.tool_util.parser.interface import ToolSource
+from galaxy.tool_util.parser.util import ParameterParseException
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.tool_util.unittest_utils import functional_test_tool_path
 from galaxy.util import (
@@ -2597,6 +2598,34 @@ def test_linting_yml_tool(lint_ctx):
     assert len(lint_ctx.valid_messages) == 4
     assert not lint_ctx.warn_messages
     assert not lint_ctx.error_messages
+
+
+def test_parser_failure_does_not_abort_or_repeat():
+    lint_ctx = LintContext("silent")
+
+    def fail_to_parse(tool_source, lint_ctx):
+        raise ParameterParseException("invalid parameter")
+
+    def complete_lint(tool_source, lint_ctx):
+        lint_ctx.valid("Linting continued.")
+
+    lint_ctx.lint("FirstParser", fail_to_parse, None)
+    lint_ctx.lint("SecondParser", fail_to_parse, None)
+    lint_ctx.lint("Complete", complete_lint, None)
+
+    assert lint_ctx.error_messages == ["Tool could not be parsed: invalid parameter"]
+    assert lint_ctx.error_messages[0].linter == "ToolParse"
+    assert lint_ctx.valid_messages == ["Linting continued."]
+
+
+def test_unexpected_linter_failure_is_not_swallowed():
+    lint_ctx = LintContext("silent")
+
+    def fail_unexpectedly(tool_source, lint_ctx):
+        raise RuntimeError("unexpected failure")
+
+    with pytest.raises(RuntimeError, match="unexpected failure"):
+        lint_ctx.lint("Broken", fail_unexpectedly, None)
 
 
 def test_linting_cwl_tool(lint_ctx):


### PR DESCRIPTION
A parser exception raised by one tool linter currently aborts the complete lint run. This adds a common `ParseException` base, catches only that exception hierarchy at the lint boundary, and records the parser failure as a structured `ToolParse` lint error. Repeated encounters with the same parse failure are deduplicated so other linters can continue without spamming the result.

Unexpected exceptions are deliberately left uncaught so programming errors remain visible.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Automated verification performed locally:

- `.tox/unit/bin/pytest -q test/unit/tool_util/test_tool_linters.py test/unit/tool_util/test_parsing.py` (190 passed)
- `tox -e lint,format,mypy`

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).