### PR TITLE
[26.1] Gate user tool build endpoints

### DIFF
--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -84,6 +84,12 @@ class DynamicToolManager(ModelManager[DynamicTool]):
         if not any(role.type == model.Role.types.USER_TOOL_EXECUTE and not role.deleted for role in user.all_roles()):
             raise exceptions.InsufficientPermissionsException("User is not allowed to run unprivileged tools")
 
+    def ensure_beta_tool_formats_enabled(self) -> None:
+        if not self.app.config.enable_beta_tool_formats:
+            raise exceptions.ConfigDoesNotAllowException(
+                "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
+            )
+
     def get_tool_by_id_or_uuid(self, id_or_uuid: Union[int, str]) -> Union[DynamicTool, None]:
         if isinstance(id_or_uuid, int):
             return self.get_tool_by_id(id_or_uuid)
@@ -121,10 +127,7 @@ class DynamicToolManager(ModelManager[DynamicTool]):
         return self.session().scalars(stmt).one_or_none()
 
     def create_tool(self, tool_payload: DynamicToolPayload):
-        if not getattr(self.app.config, "enable_beta_tool_formats", False):
-            raise exceptions.ConfigDoesNotAllowException(
-                "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
-            )
+        self.ensure_beta_tool_formats_enabled()
 
         uuid = model.get_uuid()
         tool_directory: Optional[str] = None
@@ -185,10 +188,7 @@ class DynamicToolManager(ModelManager[DynamicTool]):
     def create_unprivileged_tool(
         self, user: model.User, tool_payload: DynamicUnprivilegedToolCreatePayload
     ) -> DynamicTool:
-        if not getattr(self.app.config, "enable_beta_tool_formats", False):
-            raise exceptions.ConfigDoesNotAllowException(
-                "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
-            )
+        self.ensure_beta_tool_formats_enabled()
         self.ensure_can_use_unprivileged_tool(user)
         lint_errors = lint_user_tool_source(tool_payload.representation)
         if lint_errors:

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -163,8 +163,11 @@ class UnprivilegedToolsApi:
         self,
         payload: DynamicUnprivilegedToolCreatePayload,
         history_id: DecodedDatabaseIdField,
+        user: User = DependsOnUser,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ):
+        self.dynamic_tools_manager.ensure_beta_tool_formats_enabled()
+        self.dynamic_tools_manager.ensure_can_use_unprivileged_tool(user)
         history = trans.app.history_manager.get_owned(history_id, trans.user)
         tool = tool_payload_to_tool(trans.app, payload.representation.model_dump(by_alias=True))
         if tool:
@@ -172,6 +175,7 @@ class UnprivilegedToolsApi:
 
     @router.post("/api/unprivileged_tools/runtime_model")
     def runtime_model(self, payload: DynamicUnprivilegedToolCreatePayload, user: User = DependsOnUser):
+        self.dynamic_tools_manager.ensure_beta_tool_formats_enabled()
         self.dynamic_tools_manager.ensure_can_use_unprivileged_tool(user)
         represention = payload.representation.model_dump(by_alias=True)
         tool_source = YamlToolSource(root_dict=represention)

--- a/lib/galaxy_test/api/test_unprivileged_tools.py
+++ b/lib/galaxy_test/api/test_unprivileged_tools.py
@@ -1,5 +1,4 @@
 # Test tools API.
-from unittest.mock import patch
 from uuid import uuid4
 
 from galaxy.tool_util_models import UserToolSource
@@ -97,24 +96,6 @@ class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):
             UserToolSource(**TOOL_WITH_SHELL_COMMAND), assert_ok=False
         )
         assert response["err_msg"] == "User is not allowed to run unprivileged tools"
-
-    def test_build_endpoints_require_beta_tool_formats(self):
-        driver = self.driver_or_skip_test_if_remote()
-        assert driver.app
-        config_error = "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
-        with (
-            self.dataset_populator.test_history() as history_id,
-            self.dataset_populator.user_tool_execute_permissions(),
-            patch.object(driver.app.config, "enable_beta_tool_formats", False),
-        ):
-            build_response = self.dataset_populator.build_unprivileged_tool(
-                UserToolSource(**TOOL_WITH_SHELL_COMMAND), history_id=history_id, assert_ok=False
-            )
-            runtime_model_response = self.dataset_populator.build_runtime_model_for_tool(
-                UserToolSource(**TOOL_WITH_SHELL_COMMAND), assert_ok=False
-            )
-        assert build_response["err_msg"] == config_error
-        assert runtime_model_response["err_msg"] == config_error
 
     def test_run(self):
         with (

--- a/lib/galaxy_test/api/test_unprivileged_tools.py
+++ b/lib/galaxy_test/api/test_unprivileged_tools.py
@@ -1,4 +1,5 @@
 # Test tools API.
+from unittest.mock import patch
 from uuid import uuid4
 
 from galaxy.tool_util_models import UserToolSource
@@ -76,6 +77,44 @@ class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):
             assert response
             assert response["openapi"] == "3.1.0"
             assert response["components"]["schemas"]["inputs"]
+
+    def test_build_requires_execute_role(self):
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.build_unprivileged_tool(
+                UserToolSource(**TOOL_WITH_SHELL_COMMAND), history_id=history_id, assert_ok=False
+            )
+        assert response["err_msg"] == "User is not allowed to run unprivileged tools"
+
+    def test_build_requires_authenticated_user(self):
+        with self.dataset_populator.test_history() as history_id, self._different_user(anon=True):
+            response = self.dataset_populator.build_unprivileged_tool(
+                UserToolSource(**TOOL_WITH_SHELL_COMMAND), history_id=history_id, assert_ok=False
+            )
+        assert response["err_msg"] == "Action requires user authentication."
+
+    def test_build_runtime_model_requires_execute_role(self):
+        response = self.dataset_populator.build_runtime_model_for_tool(
+            UserToolSource(**TOOL_WITH_SHELL_COMMAND), assert_ok=False
+        )
+        assert response["err_msg"] == "User is not allowed to run unprivileged tools"
+
+    def test_build_endpoints_require_beta_tool_formats(self):
+        driver = self.driver_or_skip_test_if_remote()
+        assert driver.app
+        config_error = "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+            patch.object(driver.app.config, "enable_beta_tool_formats", False),
+        ):
+            build_response = self.dataset_populator.build_unprivileged_tool(
+                UserToolSource(**TOOL_WITH_SHELL_COMMAND), history_id=history_id, assert_ok=False
+            )
+            runtime_model_response = self.dataset_populator.build_runtime_model_for_tool(
+                UserToolSource(**TOOL_WITH_SHELL_COMMAND), assert_ok=False
+            )
+        assert build_response["err_msg"] == config_error
+        assert runtime_model_response["err_msg"] == config_error
 
     def test_run(self):
         with (

--- a/test/unit/app/managers/test_DynamicToolManager.py
+++ b/test/unit/app/managers/test_DynamicToolManager.py
@@ -1,3 +1,4 @@
+from galaxy import exceptions
 from galaxy.app_unittest_utils.toolbox_support import BaseToolBoxTestCase
 from galaxy.managers.tools import DynamicToolManager
 from galaxy.tool_util_models.dynamic_tool_models import DynamicToolCreatePayload
@@ -32,4 +33,17 @@ class TestDynamicToolManager(BaseToolBoxTestCase):
             representation={"class": "GalaxyTool", "name": "Test Tool", "shell_command": "echo 42"}
         )
         with self.assertRaises(ValueError):
+            self.dynamic_tool_manager.create_tool(payload)
+
+    def test_create_tool_requires_beta_tool_formats(self):
+        self.app.config.enable_beta_tool_formats = False
+        payload = DynamicToolCreatePayload(
+            representation={
+                "class": "GalaxyTool",
+                "name": "Test Tool",
+                "version": "0.1",
+                "shell_command": "echo 42",
+            }
+        )
+        with self.assertRaises(exceptions.ConfigDoesNotAllowException):
             self.dynamic_tool_manager.create_tool(payload)


### PR DESCRIPTION
## Summary

- require authentication and the Custom Tool Execution role for user-defined-tool build requests
- enforce `enable_beta_tool_formats` for build and runtime-model requests
- share the beta-format configuration check with create paths
- add regressions for anonymous callers, missing execute permission, disabled beta formats, and successful authorized calls

## Testing

- `.venv/bin/python -m pytest -q test/unit/app/managers/test_DynamicToolManager.py` (3 passed)
- `.venv/bin/python -m pytest -q --import-mode=importlib lib/galaxy_test/api/test_unprivileged_tools.py` (16 passed)
- Ruff, Black, and isort on changed Python files
- `make update-client-api-schema` (no generated diff; injected dependencies do not alter the OpenAPI contract)
- targeted mypy on the two production modules reported only existing errors in transitive, unchanged files