### PR TITLE
[26.1] Make _finish_dataset's output-collection retry loop attempt at least once

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1956,12 +1956,14 @@ class MinimalJobWrapper(HasResourceParameters):
         purged = dataset.dataset.purged
         if not purged and dataset.dataset.external_filename is None:
             trynum = 0
-            while trynum < self.app.config.retry_job_output_collection:
+            # +1 so retry_job_output_collection=0 still makes one attempt, matching the
+            # sibling retry loop in runners/__init__.py's _collect_job_output.
+            while trynum < self.app.config.retry_job_output_collection + 1:
                 try:
                     # Attempt to short circuit NFS attribute caching
                     os.stat(dataset.dataset.get_file_name())
                     os.chown(dataset.dataset.get_file_name(), os.getuid(), -1)
-                    trynum = self.app.config.retry_job_output_collection
+                    break
                 except (OSError, ObjectNotFound) as e:
                     trynum += 1
                     log.warning("Error accessing dataset with ID %i, will retry: %s", dataset.dataset.id, unicodify(e))


### PR DESCRIPTION
## Problem

`_finish_dataset()` has a loop meant to work around network filesystem
attribute caching when the handler reads a job's output right after the
job finishes:

```python
while trynum < self.app.config.retry_job_output_collection:
    try:
        # Attempt to short circuit NFS attribute caching
        os.stat(dataset.dataset.get_file_name())
        os.chown(dataset.dataset.get_file_name(), os.getuid(), -1)
        trynum = self.app.config.retry_job_output_collection
    except (OSError, ObjectNotFound) as e:
        ...
```

`retry_job_output_collection` defaults to `0`, so
`trynum < retry_job_output_collection` (`0 < 0`) is false immediately --
the loop body, including the cache-busting `stat`/`chown`, never runs at
all. This has been dead code at stock config since it was written.

The sibling retry loop in `runners/__init__.py`'s `_collect_job_output`
avoids this with a `+ 1` in its bound, so a configured count of `0` still
makes one attempt. This loop didn't follow that convention.

## Fix

Add the same `+ 1` to the bound. The old success path exited the loop by
setting `trynum` equal to the bound (`retry_job_output_collection`); with
the bound now `retry_job_output_collection + 1`, that assignment no longer
satisfies the loop condition and would spin forever, so the success path
now just `break`s, same as the sibling loop.

This is a narrow, behavior-restoring fix: it doesn't change what counts as
a retryable failure, doesn't add configuration, and doesn't touch the
`stat`/`chown` ordering.

## Context

Split out of #23378 per review -- that PR bundled this loop-bound fix with
a second, more involved change (treating a zero-length stat as retryable)
that needs more work (gating it per-destination, sleeping only when a
retry will follow, failing loudly on exhaustion, and finding a staleness
signal that doesn't also trip on legitimately empty outputs). This PR is
just the first, independently-correct part.