### PR TITLE
[26.1] Fix null data manager config watcher

### DIFF
--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -158,7 +158,10 @@ from galaxy.structured_app import (
     StructuredApp,
 )
 from galaxy.tool_shed.cache import ToolShedRepositoryCache
-from galaxy.tool_shed.galaxy_install.client import InstallationTarget
+from galaxy.tool_shed.galaxy_install.client import (
+    INSTALLATION_RELOAD_TIMEOUT,
+    InstallationTarget,
+)
 from galaxy.tool_shed.galaxy_install.installed_repository_manager import (
     InstalledRepositoryManager,
 )
@@ -367,14 +370,13 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
     def wait_for_toolbox_reload(self, old_toolbox):
         timer = ExecutionTimer()
         log.debug("Waiting for toolbox reload")
-        # Wait till toolbox reload has been triggered (or more than 60 seconds have passed)
-        while timer.elapsed < 60:
+        while timer.elapsed < INSTALLATION_RELOAD_TIMEOUT:
             if self.toolbox.has_reloaded(old_toolbox):
                 log.debug("Finished waiting for toolbox reload %s", timer)
                 break
             time.sleep(0.1)
         else:
-            log.warning("Waiting for toolbox reload timed out after 60 seconds")
+            log.warning("Waiting for toolbox reload timed out after %s seconds", INSTALLATION_RELOAD_TIMEOUT)
 
     def _configure_tool_config_files(self):
         if self.config.shed_tool_config_file not in self.config.tool_configs:

--- a/lib/galaxy/config_watchers/__init__.py
+++ b/lib/galaxy/config_watchers/__init__.py
@@ -120,10 +120,9 @@ class ConfigWatchers:
     @property
     def data_manager_configs(self):
         data_manager_configs = []
-        if hasattr(self.app.config, "data_manager_config_file"):
-            data_manager_configs.append(self.app.config.data_manager_config_file)
-        if hasattr(self.app.config, "shed_data_manager_config_file"):
-            data_manager_configs.append(self.app.config.shed_data_manager_config_file)
+        for config_name in ("data_manager_config_file", "shed_data_manager_config_file"):
+            if config_path := getattr(self.app.config, config_name, None):
+                data_manager_configs.append(config_path)
         return data_manager_configs
 
     @property

--- a/lib/galaxy/tool_shed/galaxy_install/client.py
+++ b/lib/galaxy/tool_shed/galaxy_install/client.py
@@ -22,6 +22,8 @@ from galaxy.tool_util.toolbox.base import AbstractToolBox
 if TYPE_CHECKING:
     from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 
+INSTALLATION_RELOAD_TIMEOUT = 60
+
 
 class DataManagerInterface(Protocol):
     GUID_TYPE: str = "data_manager"

--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -1,7 +1,6 @@
 import errno
 import logging
 import os
-import time
 from typing import (
     Any,
     Optional,
@@ -9,6 +8,7 @@ from typing import (
 
 from galaxy.tool_shed.galaxy_install.client import (
     DataManagerInterface,
+    INSTALLATION_RELOAD_TIMEOUT,
     InstallationTarget,
 )
 from galaxy.util import (
@@ -20,6 +20,10 @@ from galaxy.util import (
 from galaxy.util.path import StrPath
 from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from galaxy.util.tool_shed.xml_util import parse_xml
+from galaxy.util.wait import (
+    TimeoutAssertionError,
+    wait_on,
+)
 from . import tool_panel_manager
 
 log = logging.getLogger(__name__)
@@ -36,6 +40,24 @@ class DataManagerHandler:
 
     def __init__(self, app: InstallationTarget):
         self.app = app
+
+    def _wait_for_data_managers_reload(
+        self, reload_count: int, timeout: int | float = INSTALLATION_RELOAD_TIMEOUT
+    ) -> None:
+        def data_managers_reloaded() -> Optional[bool]:
+            if self.app.data_managers._reload_count > reload_count:
+                return True
+            return None
+
+        try:
+            wait_on(
+                data_managers_reloaded,
+                "shed Data Manager configuration reload",
+                timeout,
+                delta=0.1,
+            )
+        except TimeoutAssertionError as exc:
+            raise TimeoutError(str(exc)) from exc
 
     @property
     def data_managers_path(self) -> Optional[str]:
@@ -180,8 +202,7 @@ class DataManagerHandler:
             if data_manager_config_has_changes:
                 reload_count = self.app.data_managers._reload_count
                 self._data_manager_config_elems_to_xml_file(config_elems, shed_data_manager_conf_filename)
-                while self.app.data_managers._reload_count <= reload_count:
-                    time.sleep(0.1)  # Wait for shed_data_manager watcher thread to pick up changes
+                self._wait_for_data_managers_reload(reload_count)
         return rval
 
     def remove_from_data_manager(self, repository):


### PR DESCRIPTION
Planemo may emit a null data_manager_config_file while still providing a valid shed Data Manager configuration. Galaxy attempted to register the null path first, raising TypeError before the shed configuration was watched. Tool Shed installation then waited indefinitely for a Data Manager reload that could never occur.

This filters unset Data Manager watcher paths while preserving configured order. It also bounds the post-write reload wait with the existing installation timeout and Galaxy wait helper so separate reload failures surface instead of hanging the installation request.

Relevant failure:

    TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType

Observed in IWC run: https://github.com/galaxyproject/iwc/actions/runs/32972432948/job/98191758984

## How to test the changes?
- [ ] I have included appropriate automated tests.
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows.

No new tests are included; the proposed watcher test required an artificial partially constructed application object, while the timeout wrapper only delegates to the existing tested wait helper.

Checks run:
- tox -e lint,format,mypy

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the MIT license.