### PR TITLE
Document that retry_job_output_collection also covers output datasets

### DIFF
--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2793,11 +2793,18 @@ galaxy:
   #outputs_to_working_directory: false
 
   # If your network filesystem's caching prevents the Galaxy server from
-  # seeing the job's stdout and stderr files when it completes, you can
-  # retry reading these files.  The job runner will retry the number of
-  # times specified below, waiting 1 second between tries.  For NFS, you
-  # may want to try the -noac mount option (Linux) or -actimeo=0
-  # (Solaris).
+  # seeing a job's output when it completes, you can retry reading it.
+  # This covers both the job's stdout and stderr files and its output
+  # datasets, waiting 1 second between tries.  0 means no retries: stdout
+  # and stderr are still read once, but the cache-busting stat of each
+  # output dataset is skipped entirely, so raise this if you see datasets
+  # marked ok with empty or truncated content.
+  # This is most likely on a deployment where a job's output is written by
+  # a host other than the one running Galaxy, since nothing guarantees
+  # Galaxy's client has a coherent view of the file the moment the job
+  # reports done.  For NFS, you may also want to try the -noac mount
+  # option (Linux) or -actimeo=0 (Solaris), or a low -actimeo to shrink
+  # the staleness window without disabling caching.
   #retry_job_output_collection: 0
 
   # Determines which process will evaluate the tool command line. If set

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3807,11 +3807,17 @@ mapping:
         default: 0
         required: false
         desc: |
-          If your network filesystem's caching prevents the Galaxy server from seeing
-          the job's stdout and stderr files when it completes, you can retry reading
-          these files.  The job runner will retry the number of times specified below,
-          waiting 1 second between tries.  For NFS, you may want to try the -noac mount
-          option (Linux) or -actimeo=0 (Solaris).
+          If your network filesystem's caching prevents the Galaxy server from seeing a
+          job's output when it completes, you can retry reading it.  This covers both the
+          job's stdout and stderr files and its output datasets, waiting 1 second between
+          tries.  0 means no retries: stdout and stderr are still read once, but the
+          cache-busting stat of each output dataset is skipped entirely, so raise this if
+          you see datasets marked ok with empty or truncated content.
+          This is most likely on a deployment where a job's output is written by a host
+          other than the one running Galaxy, since nothing guarantees Galaxy's client has
+          a coherent view of the file the moment the job reports done.  For NFS, you may
+          also want to try the -noac mount option (Linux) or -actimeo=0 (Solaris), or a
+          low -actimeo to shrink the staleness window without disabling caching.
 
       tool_evaluation_strategy:
         type: str


### PR DESCRIPTION
Docs only — no behaviour change, default stays `0`.

The description mentioned only a job's stdout and stderr files, but the same
option also guards the cache-busting stat of each output dataset in
`_finish_dataset()`. This adds that, notes that `0` means the stdout/stderr read
still happens once while the per-dataset stat is skipped entirely, and points out
that the failure shows up where a job's output is written by a host other than
the one running Galaxy. Sample updated in step with the schema.

Per @mvdbeek's suggestion in #23393.