### PR TITLE
Use certifi for outbound HTTP clients

### DIFF
--- a/lib/galaxy/agents/gtn/search.py
+++ b/lib/galaxy/agents/gtn/search.py
@@ -5,13 +5,11 @@ Provides search over Galaxy Training Network tutorials and FAQs
 using SQLite FTS5 full-text search with BM25 ranking.
 """
 
-import http.client
 import logging
 import os
 import re
 import shutil
 import sqlite3
-import urllib.request
 from dataclasses import dataclass
 from datetime import (
     datetime,
@@ -23,6 +21,12 @@ from pathlib import Path
 from typing import (
     Any,
 )
+from urllib.parse import (
+    unquote,
+    urlparse,
+)
+
+from galaxy.util import requests
 
 GTN_DATABASE_URL = "https://depot.galaxyproject.org/chatgxy/gtn_search.db"
 GTN_FAQ_BASE_URL = "https://training.galaxyproject.org/training-material/faqs"
@@ -251,15 +255,23 @@ class GTNSearchDB:
     @staticmethod
     def _remote_last_modified(url: str) -> datetime | None:
         """HEAD ``url`` and return its parsed Last-Modified, or None on failure."""
+        parsed_url = urlparse(url)
+        if parsed_url.scheme == "file":
+            try:
+                return datetime.fromtimestamp(Path(unquote(parsed_url.path)).stat().st_mtime, tz=timezone.utc)
+            except OSError as e:
+                log.debug(f"GTN freshness check failed for {url}: {e}")
+                return None
         try:
-            req = urllib.request.Request(url, method="HEAD")
-            with urllib.request.urlopen(req, timeout=GTN_FRESHNESS_TIMEOUT_SECONDS) as resp:
-                header = resp.headers.get("Last-Modified")
-        except (OSError, ValueError, http.client.HTTPException) as e:
-            # http.client.HTTPException covers malformed responses
-            # (RemoteDisconnected, BadStatusLine) that urllib doesn't wrap
-            # into URLError -- without it the periodic queue would record a
-            # failed run instead of falling through to a full download.
+            with requests.Session() as session:
+                with session.head(
+                    url,
+                    allow_redirects=True,
+                    timeout=GTN_FRESHNESS_TIMEOUT_SECONDS,
+                ) as response:
+                    response.raise_for_status()
+                    header = response.headers.get("Last-Modified")
+        except (ValueError, requests.exceptions.RequestException) as e:
             log.debug(f"GTN freshness HEAD failed for {url}: {e}")
             return None
         return _parse_last_modified(header)
@@ -271,21 +283,35 @@ class GTNSearchDB:
         tmp_path.unlink(missing_ok=True)
         try:
             log.info(f"Downloading GTN database from {download_url} ...")
-            with urllib.request.urlopen(download_url, timeout=GTN_DOWNLOAD_TIMEOUT_SECONDS) as response:
-                last_modified_header = response.headers.get("Last-Modified")
-                with open(tmp_path, "wb") as out:
-                    shutil.copyfileobj(response, out)
+            parsed_url = urlparse(download_url)
+            remote_dt: datetime | None
+            if parsed_url.scheme == "file":
+                source_path = Path(unquote(parsed_url.path))
+                remote_dt = datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc)
+                with source_path.open("rb") as source, open(tmp_path, "wb") as out:
+                    shutil.copyfileobj(source, out)
+            else:
+                with requests.Session() as session:
+                    with session.get(
+                        download_url,
+                        stream=True,
+                        timeout=GTN_DOWNLOAD_TIMEOUT_SECONDS,
+                    ) as response:
+                        response.raise_for_status()
+                        remote_dt = _parse_last_modified(response.headers.get("Last-Modified"))
+                        response.raw.decode_content = True
+                        with open(tmp_path, "wb") as out:
+                            shutil.copyfileobj(response.raw, out)
             metadata = cls._validate_database_file(tmp_path)
             # Stamp the file with depot's Last-Modified so the next stale check
             # compares against the upstream mtime rather than "right now", which
             # would also drift with any local clock skew.
-            remote_dt = _parse_last_modified(last_modified_header)
             if remote_dt is not None:
                 remote_ts = remote_dt.timestamp()
                 os.utime(tmp_path, (remote_ts, remote_ts))
             tmp_path.replace(db_path)
             return metadata
-        except (OSError, sqlite3.Error) as e:
+        except (OSError, sqlite3.Error, requests.exceptions.RequestException) as e:
             tmp_path.unlink(missing_ok=True)
             raise FileNotFoundError(f"GTN database download failed for {db_path}: {e}") from e
 

--- a/lib/galaxy/agents/gtn/search.py
+++ b/lib/galaxy/agents/gtn/search.py
@@ -57,6 +57,18 @@ def _parse_last_modified(header: str | None) -> datetime | None:
     return parsed
 
 
+def _file_url_path(url: str) -> Path | None:
+    """Return the local path for a ``file://`` URL, or None for any other scheme."""
+    parsed_url = urlparse(url)
+    if parsed_url.scheme == "file":
+        return Path(unquote(parsed_url.path))
+    return None
+
+
+def _mtime_utc(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
 def _escape_like(value: str) -> str:
     """Escape SQLite LIKE metacharacters so tool names match literally."""
     return value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
@@ -255,10 +267,9 @@ class GTNSearchDB:
     @staticmethod
     def _remote_last_modified(url: str) -> datetime | None:
         """HEAD ``url`` and return its parsed Last-Modified, or None on failure."""
-        parsed_url = urlparse(url)
-        if parsed_url.scheme == "file":
+        if (source_path := _file_url_path(url)) is not None:
             try:
-                return datetime.fromtimestamp(Path(unquote(parsed_url.path)).stat().st_mtime, tz=timezone.utc)
+                return _mtime_utc(source_path)
             except OSError as e:
                 log.debug(f"GTN freshness check failed for {url}: {e}")
                 return None
@@ -283,11 +294,9 @@ class GTNSearchDB:
         tmp_path.unlink(missing_ok=True)
         try:
             log.info(f"Downloading GTN database from {download_url} ...")
-            parsed_url = urlparse(download_url)
             remote_dt: datetime | None
-            if parsed_url.scheme == "file":
-                source_path = Path(unquote(parsed_url.path))
-                remote_dt = datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc)
+            if (source_path := _file_url_path(download_url)) is not None:
+                remote_dt = _mtime_utc(source_path)
                 with source_path.open("rb") as source, open(tmp_path, "wb") as out:
                     shutil.copyfileobj(source, out)
             else:

--- a/lib/galaxy/datatypes/dataproviders/external.py
+++ b/lib/galaxy/datatypes/dataproviders/external.py
@@ -13,7 +13,10 @@ from urllib.parse import (
 )
 from urllib.request import urlopen
 
-from galaxy.util import DEFAULT_SOCKET_TIMEOUT
+from galaxy.util import (
+    DEFAULT_SOCKET_TIMEOUT,
+    requests,
+)
 from . import (
     base,
     line,
@@ -124,11 +127,36 @@ class URLDataProvider(base.DataProvider):
 
         if method == "GET":
             self.url += f"?{encoded_data}"
-            opened = urlopen(url, timeout=DEFAULT_SOCKET_TIMEOUT)
-        elif method == "POST":
-            opened = urlopen(url, encoded_data, timeout=DEFAULT_SOCKET_TIMEOUT)
-        else:
+        elif method != "POST":
             raise ValueError(f"Not a valid method: {method}")
+
+        self.response = None
+        self.session = None
+        if scheme == "ftp":
+            post_data = encoded_data.encode("utf-8") if method == "POST" else None
+            opened = urlopen(self.url, post_data, timeout=DEFAULT_SOCKET_TIMEOUT)
+        elif method == "GET":
+            self.session = requests.Session()
+            self.response = self.session.get(self.url, stream=True, timeout=DEFAULT_SOCKET_TIMEOUT)
+            try:
+                self.response.raise_for_status()
+            except requests.exceptions.HTTPError:
+                self.response.close()
+                self.session.close()
+                raise
+            self.response.raw.decode_content = True
+            opened = self.response.raw
+        else:
+            self.session = requests.Session()
+            self.response = self.session.post(url, data=self.data, stream=True, timeout=DEFAULT_SOCKET_TIMEOUT)
+            try:
+                self.response.raise_for_status()
+            except requests.exceptions.HTTPError:
+                self.response.close()
+                self.session.close()
+                raise
+            self.response.raw.decode_content = True
+            opened = self.response.raw
 
         super().__init__(opened, **kwargs)
         # NOTE: the request object is now accessible as self.source
@@ -137,7 +165,12 @@ class URLDataProvider(base.DataProvider):
         pass
 
     def __exit__(self, *args):
-        self.source.close()
+        if self.response is not None:
+            self.response.close()
+            assert self.session is not None
+            self.session.close()
+        else:
+            self.source.close()
 
 
 # ----------------------------------------------------------------------------- generic compression

--- a/lib/galaxy/files/sources/cbioportal.py
+++ b/lib/galaxy/files/sources/cbioportal.py
@@ -3,7 +3,7 @@ import json
 import posixpath
 import re
 import tarfile
-import urllib.request
+from contextlib import contextmanager
 from typing import (
     Annotated,
 )
@@ -26,7 +26,8 @@ from galaxy.files.sources._defaults import DEFAULT_SCHEME
 from galaxy.files.uris import validate_non_local
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
-    stream_to_open_named_file,
+    requests,
+    stream_to_path,
 )
 from galaxy.util.config_templates import TemplateExpansion
 from . import BaseFilesSource
@@ -211,7 +212,7 @@ class CBioPortalFilesSource(
         config: CBioPortalFileSourceConfiguration,
     ) -> None:
         archive_url = self._archive_url(config, study_id)
-        with self._urlopen(archive_url) as response:
+        with self._open_url(archive_url) as response:
             with tarfile.open(fileobj=response, mode="r|gz") as archive:
                 for member in archive:
                     if not member.isfile():
@@ -228,26 +229,30 @@ class CBioPortalFilesSource(
         raise ObjectNotFound(f"File [{filename}] was not found in cBioPortal study archive [{study_id}].")
 
     def _get_json(self, url: str):
-        with self._urlopen(url) as response:
+        with self._open_url(url) as response:
             return json.load(response)
 
     def _stream_url_to_file(self, url: str, native_path: str) -> None:
-        with self._urlopen(url) as response:
-            f = open(native_path, "wb")  # fd will be .close()ed in stream_to_open_named_file
-            stream_to_open_named_file(response, f.fileno(), native_path)
+        with self._open_url(url) as response:
+            stream_to_path(response, native_path)
 
-    def _urlopen(self, url: str):
+    @contextmanager
+    def _open_url(self, url: str):
         validate_non_local(url, self._allowlist or [])
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Accept": "application/json" if "/api/" in url else "application/octet-stream",
-                "User-Agent": "Galaxy cBioPortal file source",
-            },
-        )
-        response = urllib.request.urlopen(request, timeout=DEFAULT_SOCKET_TIMEOUT)
-        validate_non_local(response.geturl(), self._allowlist or [])
-        return response
+        with requests.Session() as session:
+            with session.get(
+                url,
+                headers={
+                    "Accept": "application/json" if "/api/" in url else "application/octet-stream",
+                    "User-Agent": "Galaxy cBioPortal file source",
+                },
+                stream=True,
+                timeout=DEFAULT_SOCKET_TIMEOUT,
+            ) as response:
+                response.raise_for_status()
+                validate_non_local(response.url, self._allowlist or [])
+                response.raw.decode_content = True
+                yield response.raw
 
     def _api_url(self, config: CBioPortalFileSourceConfiguration, *parts: str) -> str:
         return "/".join([config.api_url.rstrip("/"), *(part.strip("/") for part in parts)])

--- a/lib/galaxy/files/sources/dataverse.py
+++ b/lib/galaxy/files/sources/dataverse.py
@@ -1,12 +1,10 @@
 import json
 import re
-import urllib.request
 from typing import (
     Any,
     cast,
     get_args,
 )
-from urllib.error import HTTPError
 from urllib.parse import quote
 
 from typing_extensions import TypedDict
@@ -38,7 +36,7 @@ from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     get_charset_from_http_headers,
     requests,
-    stream_to_open_named_file,
+    stream_to_path,
 )
 from galaxy.util.hash_util import HashFunctionNames
 from galaxy.util.user_agent import get_default_headers
@@ -452,25 +450,34 @@ class DataverseRepositoryInteractor(RDMRepositoryInteractor):
             # pass the token as a header only when using the API
             headers.update(self._get_request_headers(context))
         try:
-            req = urllib.request.Request(download_file_content_url, headers=headers)
-            with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT) as page:
-                f = open(file_path, "wb")
-                return stream_to_open_named_file(
-                    page, f.fileno(), file_path, source_encoding=get_charset_from_http_headers(page.headers)
-                )
-        except HTTPError as e:
-            if e.code == 401:
+            with requests.Session() as session:
+                with session.get(
+                    download_file_content_url,
+                    headers=headers,
+                    stream=True,
+                    timeout=DEFAULT_SOCKET_TIMEOUT,
+                ) as page:
+                    page.raise_for_status()
+                    page.raw.decode_content = True
+                    return stream_to_path(
+                        page.raw,
+                        file_path,
+                        source_encoding=get_charset_from_http_headers(page.headers),
+                    )
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code == 401:
                 raise AuthenticationRequired(
                     f"Authentication required to download file from '{download_file_content_url}'. "
                     f"Please provide a valid API token in your user preferences."
                 )
-            if e.code == 403:
+            if status_code == 403:
                 # Permission denied: dataset may be unpublished or user lacks access rights
                 raise ObjectNotFound(
                     f"Access forbidden when downloading file from '{download_file_content_url}'. "
                     f"You may not have permission to access this file, or the dataset is not published."
                 )
-            if e.code == 404:
+            if status_code == 404:
                 raise ObjectNotFound(
                     f"File not found at '{download_file_content_url}'. "
                     f"Please make sure the dataset and file exist and are published."

--- a/lib/galaxy/files/sources/elabftw.py
+++ b/lib/galaxy/files/sources/elabftw.py
@@ -211,7 +211,7 @@ class eLabFTWFilesSource(BaseFilesSource[eLabFTWFileSourceTemplateConfiguration,
         """
         Create an ``aiohttp`` session.
         """
-        connector = aiohttp.TCPConnector(limit=MAX_CONCURRENT_REQUESTS)
+        connector = aiohttp.TCPConnector(limit=MAX_CONCURRENT_REQUESTS, ssl=requests.create_ssl_context())
         return aiohttp.ClientSession(
             connector=connector,
             raise_for_status=True,

--- a/lib/galaxy/files/sources/http.py
+++ b/lib/galaxy/files/sources/http.py
@@ -1,6 +1,8 @@
 import logging
 import re
 import urllib.request
+from contextlib import ExitStack
+from urllib.parse import urlparse
 
 from galaxy.files.models import (
     BaseFileSourceConfiguration,
@@ -11,7 +13,8 @@ from galaxy.files.uris import validate_non_local
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     get_charset_from_http_headers,
-    stream_to_open_named_file,
+    requests,
+    stream_to_path,
 )
 from galaxy.util.config_parsers import IpAllowedListEntryT
 from galaxy.util.config_templates import TemplateExpansion
@@ -63,23 +66,36 @@ class HTTPFilesSource(BaseFilesSource[HTTPFileSourceTemplateConfiguration, HTTPF
         self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[HTTPFileSourceConfiguration]
     ):
         config = context.config
-        req = urllib.request.Request(source_path, headers=config.http_headers)
-        try:
-            page = urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT)
-        except Exception as e:
-            if "control characters" in str(e):
-                raise ValueError(
-                    f"URL contains unencoded characters (e.g. spaces): {source_path}. "
-                    "The URL source should properly percent-encode the path."
-                ) from e
-            raise
+        scheme = urlparse(source_path).scheme.lower()
+        if scheme in ("http", "https") and re.search(r"[\x00-\x20\x7f]", source_path):
+            raise ValueError(
+                f"URL contains unencoded characters (e.g. spaces): {source_path}. "
+                "The URL source should properly percent-encode the path."
+            )
 
-        with page:
+        with ExitStack() as stack:
+            if scheme == "ftp":
+                req = urllib.request.Request(source_path, headers=config.http_headers)
+                page = stack.enter_context(urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT))
+            else:
+                session = stack.enter_context(requests.Session())
+                page = stack.enter_context(
+                    session.get(
+                        source_path,
+                        headers=config.http_headers,
+                        stream=True,
+                        timeout=DEFAULT_SOCKET_TIMEOUT,
+                    )
+                )
+                page.raise_for_status()
+                page.raw.decode_content = True
             # Verify url post-redirects is still allowlisted
-            validate_non_local(page.geturl(), self._allowlist or config.fetch_url_allowlist)
-            f = open(native_path, "wb")  # fd will be .close()ed in stream_to_open_named_file
-            return stream_to_open_named_file(
-                page, f.fileno(), native_path, source_encoding=get_charset_from_http_headers(page.headers)
+            final_url = page.geturl() if scheme == "ftp" else page.url
+            validate_non_local(final_url, self._allowlist or config.fetch_url_allowlist)
+            return stream_to_path(
+                page if scheme == "ftp" else page.raw,
+                native_path,
+                source_encoding=get_charset_from_http_headers(page.headers),
             )
 
     def _write_from(

--- a/lib/galaxy/files/sources/http.py
+++ b/lib/galaxy/files/sources/http.py
@@ -25,6 +25,10 @@ from . import (
 
 log = logging.getLogger(__name__)
 
+# ASCII control characters, space, and DEL must be percent-encoded in a URL;
+# same character set http.client refuses in a request line.
+_DISALLOWED_URL_CHARACTERS = re.compile(r"[\x00-\x20\x7f]")
+
 
 class HTTPFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
     # `url_regex` is not templated because it needs to be set at initialization with no RuntimeContext available.
@@ -67,7 +71,7 @@ class HTTPFilesSource(BaseFilesSource[HTTPFileSourceTemplateConfiguration, HTTPF
     ):
         config = context.config
         scheme = urlparse(source_path).scheme.lower()
-        if scheme in ("http", "https") and re.search(r"[\x00-\x20\x7f]", source_path):
+        if scheme in ("http", "https") and _DISALLOWED_URL_CHARACTERS.search(source_path):
             raise ValueError(
                 f"URL contains unencoded characters (e.g. spaces): {source_path}. "
                 "The URL source should properly percent-encode the path."

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -17,7 +17,7 @@ from galaxy.files import (
 )
 from galaxy.files.models import FilesSourceOptions
 from galaxy.util import (
-    stream_to_open_named_file,
+    stream_to_path,
     unicodify,
 )
 from galaxy.util.config_parsers import IpAllowedListEntryT
@@ -66,7 +66,8 @@ def ensure_file_sources(file_sources: Optional["ConfiguredFileSources"]) -> "Con
 def stream_to_file(stream, suffix="", prefix="", dir=None, text=False, **kwd):
     """Writes a stream to a temporary file, returns the temporary file's name"""
     fd, temp_name = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
-    return stream_to_open_named_file(stream, fd, temp_name, **kwd)
+    os.close(fd)
+    return stream_to_path(stream, temp_name, **kwd)
 
 
 def validate_uri_access(uri: str, is_admin: bool, ip_allowlist: list[IpAllowedListEntryT]) -> None:

--- a/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -7,15 +7,7 @@ import json
 import logging
 import os
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError
-from urllib.parse import (
-    urlencode,
-    urlparse,
-)
-from urllib.request import (
-    Request,
-    urlopen,
-)
+from urllib.parse import urlparse
 
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.util import repository_util
@@ -25,7 +17,7 @@ from galaxy.util import (
     asbool,
     build_url,
     DEFAULT_SOCKET_TIMEOUT,
-    smart_str,
+    requests,
     unicodify,
     url_get,
 )
@@ -485,16 +477,8 @@ class RepositoryDependencyInstallManager:
                     tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.app, tool_shed_url)
                     pathspec = ["repository", "get_required_repo_info_dict"]
                     url = build_url(tool_shed_url, pathspec=pathspec)
-                    # Fix for handling 307 redirect not being handled nicely by urlopen() when the Request() has data provided
-                    try:
-                        url = _urlopen(url).geturl()
-                    except HTTPError as e:
-                        if e.code == 502:
-                            pass
-                        else:
-                            raise
-                    payload = urlencode(dict(encoded_str=encoded_required_repository_str))
-                    response = _urlopen(url, payload).read()
+                    with _request(url, data={"encoded_str": encoded_required_repository_str}) as request_response:
+                        response = request_response.content
                     if response:
                         try:
                             required_repo_info_dict = json.loads(unicodify(response))
@@ -585,9 +569,14 @@ class RepositoryDependencyInstallManager:
         session.commit()
 
 
-def _urlopen(url, data=None):
+def _request(url, data=None):
     scheme = urlparse(url).scheme
-    assert scheme in ("http", "https", "ftp"), f"Invalid URL scheme: {scheme}"
-    if data is not None:
-        data = smart_str(data)
-    return urlopen(Request(url, data), timeout=DEFAULT_SOCKET_TIMEOUT)
+    assert scheme in ("http", "https"), f"Invalid URL scheme: {scheme}"
+    method = requests.post if data is not None else requests.get
+    response = method(url, data=data, timeout=DEFAULT_SOCKET_TIMEOUT)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        response.close()
+        raise
+    return response

--- a/lib/galaxy/tools/parameters/cancelable_request.py
+++ b/lib/galaxy/tools/parameters/cancelable_request.py
@@ -7,6 +7,8 @@ from typing import (
 
 import aiohttp
 
+from galaxy.util.requests import create_ssl_context
+
 log = logging.getLogger()
 
 REQUEST_METHOD = Literal["GET", "POST", "HEAD"]
@@ -32,7 +34,8 @@ async def async_request_with_timeout(
     method: REQUEST_METHOD = "GET",
     timeout: float = 1.0,
 ):
-    async with aiohttp.ClientSession() as session:
+    connector = aiohttp.TCPConnector(ssl=create_ssl_context())
+    async with aiohttp.ClientSession(connector=connector) as session:
         try:
             # Wait for the async request, with a user-defined timeout
             result = await asyncio.wait_for(

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1993,37 +1993,65 @@ def download_to_file(url, dest_file_path, timeout=30, chunk_size=2**20):
                 f.write(chunk)
 
 
-def stream_to_open_named_file(
-    stream, fd, filename, source_encoding=None, source_error="strict", target_encoding=None, target_error="strict"
+def _stream_to_writer(
+    stream, write, source_encoding=None, source_error="strict", target_encoding=None, target_error="strict"
 ):
-    """Writes a stream to the provided file descriptor, returns the file name. Closes file descriptor"""
-    # signature and behavor is somewhat odd, due to backwards compatibility, but this can/should be done better
     CHUNK_SIZE = 1048576
     try:
         codecs.lookup(target_encoding)
     except Exception:
         target_encoding = DEFAULT_ENCODING  # utf-8
     use_source_encoding = source_encoding is not None
+    while True:
+        chunk = stream.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        if use_source_encoding:
+            # If a source encoding is given we use it to convert to the target encoding
+            try:
+                if not isinstance(chunk, str):
+                    chunk = chunk.decode(source_encoding, source_error)
+                write(chunk.encode(target_encoding, target_error))
+            except UnicodeDecodeError:
+                use_source_encoding = False
+                write(chunk)
+        else:
+            # Compressed files must be encoded after they are uncompressed in the upload utility,
+            # while binary files should not be encoded at all.
+            if isinstance(chunk, str):
+                chunk = chunk.encode(target_encoding, target_error)
+            write(chunk)
+
+
+def stream_to_path(
+    stream, filename, source_encoding=None, source_error="strict", target_encoding=None, target_error="strict"
+):
+    """Write a stream to ``filename`` and return the filename."""
+    with open(filename, "wb") as output:
+        _stream_to_writer(stream, output.write, source_encoding, source_error, target_encoding, target_error)
+    return filename
+
+
+def stream_to_open_named_file(
+    stream, fd, filename, source_encoding=None, source_error="strict", target_encoding=None, target_error="strict"
+):
+    """Deprecated: use :func:`stream_to_path` instead.
+
+    Write a stream to an open file descriptor, close it, and return the filename.
+    """
+    # Known external callers retained for compatibility:
+    # - bgruening/galaxytools: tools/mave_tools/mavedb/data_source.py
+    # - galaxyecology/tools-ecology: tools/aquainfra_importer/data_source.py
+    # - galaxyecology/tools-ecology: tools/nfdi4earth_os4a_importer/data_source.py
     try:
-        while True:
-            chunk = stream.read(CHUNK_SIZE)
-            if not chunk:
-                break
-            if use_source_encoding:
-                # If a source encoding is given we use it to convert to the target encoding
-                try:
-                    if not isinstance(chunk, str):
-                        chunk = chunk.decode(source_encoding, source_error)
-                    os.write(fd, chunk.encode(target_encoding, target_error))
-                except UnicodeDecodeError:
-                    use_source_encoding = False
-                    os.write(fd, chunk)
-            else:
-                # Compressed files must be encoded after they are uncompressed in the upload utility,
-                # while binary files should not be encoded at all.
-                if isinstance(chunk, str):
-                    chunk = chunk.encode(target_encoding, target_error)
-                os.write(fd, chunk)
+        _stream_to_writer(
+            stream,
+            lambda chunk: os.write(fd, chunk),
+            source_encoding,
+            source_error,
+            target_encoding,
+            target_error,
+        )
     finally:
         os.close(fd)
     return filename

--- a/lib/galaxy/util/requests.py
+++ b/lib/galaxy/util/requests.py
@@ -1,3 +1,4 @@
+import ssl
 from collections.abc import Callable
 
 import requests
@@ -7,6 +8,7 @@ from requests import (  # noqa: F401
     Response as Response,
 )
 from requests.adapters import HTTPAdapter
+from requests.certs import where as requests_ca_bundle_path  # type: ignore[attr-defined]
 from requests.packages.urllib3.util.retry import Retry
 from typing_extensions import ParamSpec
 
@@ -14,6 +16,11 @@ from .user_agent import get_default_headers
 
 DEFAULT_RETRIES = 3
 DEFAULT_BACKOFF_FACTOR = 0.1
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context using the CA bundle trusted by ``requests``."""
+    return ssl.create_default_context(cafile=requests_ca_bundle_path())
 
 
 class Session(requests.Session):

--- a/test/unit/app/test_gtn_search.py
+++ b/test/unit/app/test_gtn_search.py
@@ -5,6 +5,7 @@ result types against tiny in-memory fixture databases built via
 GTNDatabaseBuilder.
 """
 
+import gzip
 import os
 import sqlite3
 from datetime import (
@@ -15,6 +16,7 @@ from datetime import (
 from pathlib import Path
 
 import pytest
+import responses
 
 from galaxy.agents.gtn import (
     FAQResult,
@@ -307,3 +309,38 @@ def test_download_stamps_local_mtime_to_remote_last_modified(tmp_path: Path):
     GTNSearchDB.refresh_database(local_path, remote_path.as_uri())
 
     assert int(local_path.stat().st_mtime) == int(pinned)
+
+
+@responses.activate
+def test_refresh_database_streams_http_download_and_stamps_timestamp(fixture_db: Path, tmp_path: Path):
+    url = "https://example.com/gtn_search.db"
+    last_modified = "Wed, 20 Aug 2025 12:00:00 GMT"
+    responses.add(
+        responses.GET,
+        url,
+        body=gzip.compress(fixture_db.read_bytes(), mtime=0),
+        headers={"Content-Encoding": "gzip", "Last-Modified": last_modified},
+    )
+    target = tmp_path / "downloaded.db"
+
+    metadata = GTNSearchDB.refresh_database(target, url)
+
+    assert metadata["tutorial_count"] == 2
+    assert target.read_bytes() == fixture_db.read_bytes()
+    assert datetime.fromtimestamp(target.stat().st_mtime, tz=timezone.utc) == datetime(
+        2025, 8, 20, 12, 0, tzinfo=timezone.utc
+    )
+
+
+@responses.activate
+def test_refresh_database_if_stale_uses_http_head(fixture_db: Path, tmp_path: Path):
+    url = "https://example.com/gtn_search.db"
+    target = tmp_path / "current.db"
+    target.write_bytes(fixture_db.read_bytes())
+    current = datetime(2025, 8, 21, 12, 0, tzinfo=timezone.utc).timestamp()
+    os.utime(target, (current, current))
+    responses.add(responses.HEAD, url, headers={"Last-Modified": "Wed, 20 Aug 2025 12:00:00 GMT"})
+
+    assert GTNSearchDB.refresh_database_if_stale(target, url) is None
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == "HEAD"

--- a/test/unit/data/datatypes/dataproviders/test_external_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_external_dataproviders.py
@@ -1,0 +1,72 @@
+import io
+from unittest import mock
+
+from galaxy.datatypes.dataproviders import external
+from galaxy.util import DEFAULT_SOCKET_TIMEOUT
+
+
+class DecodableBytesIO(io.BytesIO):
+    decode_content = False
+
+
+def test_url_data_provider_get_sends_query_and_closes_response():
+    url = "https://example.com/data"
+    raw = DecodableBytesIO(b"result")
+    response = mock.Mock(raw=raw)
+    session = mock.Mock()
+    session.get.return_value = response
+
+    with mock.patch("galaxy.datatypes.dataproviders.external.requests.Session", return_value=session):
+        provider = external.URLDataProvider(url, data={"gene": "BRCA1"})
+    assert provider.read() == b"result"
+    assert provider.url == f"{url}?gene=BRCA1"
+    provider.__exit__()
+
+    session.get.assert_called_once_with(
+        f"{url}?gene=BRCA1",
+        stream=True,
+        timeout=DEFAULT_SOCKET_TIMEOUT,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert raw.decode_content is True
+    response.close.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_url_data_provider_post_sends_form_and_closes_response():
+    url = "https://example.com/data"
+    raw = DecodableBytesIO(b"result")
+    response = mock.Mock(raw=raw)
+    session = mock.Mock()
+    session.post.return_value = response
+
+    with mock.patch("galaxy.datatypes.dataproviders.external.requests.Session", return_value=session):
+        provider = external.URLDataProvider(url, method="POST", data={"gene": "BRCA1"})
+    assert provider.read() == b"result"
+    provider.__exit__()
+
+    session.post.assert_called_once_with(
+        url,
+        data={"gene": "BRCA1"},
+        stream=True,
+        timeout=DEFAULT_SOCKET_TIMEOUT,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert raw.decode_content is True
+    response.close.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_url_data_provider_keeps_ftp_fallback():
+    opened = io.BytesIO(b"ftp result")
+    with mock.patch.object(external, "urlopen", return_value=opened) as urlopen:
+        provider = external.URLDataProvider("ftp://example.com/data", data={"gene": "BRCA1"})
+        assert provider.read() == b"ftp result"
+        provider.__exit__()
+
+    urlopen.assert_called_once_with(
+        "ftp://example.com/data?gene=BRCA1",
+        None,
+        timeout=DEFAULT_SOCKET_TIMEOUT,
+    )
+    assert opened.closed

--- a/test/unit/files/test_cbioportal_download.py
+++ b/test/unit/files/test_cbioportal_download.py
@@ -1,0 +1,31 @@
+import gzip
+from typing import cast
+from unittest import mock
+
+import responses
+from requests import Response
+
+from galaxy.files.sources.cbioportal import CBioPortalFilesSource
+
+
+@responses.activate
+def test_cbioportal_streams_download_and_closes_response(tmp_path):
+    url = "https://example.com/study.tar.gz"
+    responses.add(
+        responses.GET,
+        url,
+        body=gzip.compress(b"archive contents", mtime=0),
+        headers={"Content-Encoding": "gzip"},
+    )
+    source = object.__new__(CBioPortalFilesSource)
+    target = tmp_path / "study.tar.gz"
+
+    with (
+        mock.patch.object(CBioPortalFilesSource, "_allowlist", new_callable=mock.PropertyMock, return_value=[]),
+        mock.patch("galaxy.files.sources.cbioportal.validate_non_local", side_effect=lambda value, allowlist: value),
+    ):
+        source._stream_url_to_file(url, str(target))
+
+    assert target.read_bytes() == b"archive contents"
+    response = cast(Response, responses.calls[0].response)
+    assert response.raw.closed

--- a/test/unit/files/test_dataverse_download.py
+++ b/test/unit/files/test_dataverse_download.py
@@ -1,0 +1,55 @@
+import gzip
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+import responses
+from requests import Response
+
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    ObjectNotFound,
+)
+from galaxy.files.sources.dataverse import (
+    DataverseRDMFilesSource,
+    DataverseRepositoryInteractor,
+)
+
+
+def _source():
+    return DataverseRepositoryInteractor("https://example.com", object.__new__(DataverseRDMFilesSource))
+
+
+@responses.activate
+def test_dataverse_streams_download_and_closes_response(tmp_path):
+    url = "https://example.com/download/1"
+    responses.add(
+        responses.GET,
+        url,
+        body=gzip.compress(b"dataset contents", mtime=0),
+        headers={"Content-Encoding": "gzip"},
+    )
+    target = tmp_path / "dataset.txt"
+
+    _source()._download_file(str(target), url, SimpleNamespace())
+
+    assert target.read_bytes() == b"dataset contents"
+    response = cast(Response, responses.calls[0].response)
+    assert response.raw.closed
+
+
+@pytest.mark.parametrize(
+    ("status", "exception", "message"),
+    (
+        (401, AuthenticationRequired, "Authentication required"),
+        (403, ObjectNotFound, "Access forbidden"),
+        (404, ObjectNotFound, "File not found"),
+    ),
+)
+@responses.activate
+def test_dataverse_maps_download_errors(tmp_path, status, exception, message):
+    url = "https://example.com/download/1"
+    responses.add(responses.GET, url, status=status)
+
+    with pytest.raises(exception, match=message):
+        _source()._download_file(str(tmp_path / "dataset.txt"), url, SimpleNamespace())

--- a/test/unit/files/test_drs.py
+++ b/test/unit/files/test_drs.py
@@ -1,12 +1,6 @@
-import io
 import json
 import os
-import urllib
-from typing import (
-    Any,
-    cast,
-)
-from unittest import mock
+from typing import cast
 
 import pytest
 import responses
@@ -127,7 +121,7 @@ def test_file_source_drs_http():
     def access_handler(request):
         assert request.headers["Authorization"] == "Bearer IBearTokens"
         access_data = {
-            "url": "https://my.respository.org/myfile.txt",
+            "url": "https://my.repository.org/myfile.txt",
             "headers": ["Authorization: Basic Z2E0Z2g6ZHJz"],
         }
         return (200, {}, json.dumps(access_data))
@@ -148,23 +142,23 @@ def test_file_source_drs_http():
 
     test_url = "drs://drs.example.org/314159"
 
-    def check_specific_header(request, **kwargs):
-        assert request.full_url == "https://my.respository.org/myfile.txt"
+    def check_specific_header(request):
         assert request.headers["Authorization"] == "Basic Z2E0Z2g6ZHJz"
-        response: Any = io.StringIO("hello drs world")
-        response.headers = {}
-        response.geturl = lambda: test_url
-        return response
+        return 200, {}, "hello drs world"
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_specific_header):
-        user_context = user_context_fixture()
-        file_sources = configured_file_sources(FILE_SOURCES_CONF)
-        file_source_pair = file_sources.get_file_source_path(test_url)
+    responses.add_callback(
+        responses.GET,
+        "https://my.repository.org/myfile.txt",
+        callback=check_specific_header,
+    )
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path(test_url)
 
-        assert file_source_pair.path == test_url
-        assert file_source_pair.file_source.id == "test1"
+    assert file_source_pair.path == test_url
+    assert file_source_pair.file_source.id == "test1"
 
-        assert_realizes_as(file_sources, test_url, "hello drs world", user_context=user_context)
+    assert_realizes_as(file_sources, test_url, "hello drs world", user_context=user_context)
 
 
 @responses.activate
@@ -260,21 +254,16 @@ def test_file_source_drs_attach_oidc_token():
 
     test_url = "drs://drs.oidc-example.org/999"
 
-    def check_download(request, **kwargs):
-        response: Any = io.StringIO("hello oidc world")
-        response.headers = {}
-        response.geturl = lambda: test_url
-        return response
+    responses.add(responses.GET, "https://my.repository.org/oidcfile.txt", body="hello oidc world")
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_download):
-        user_context = DictFileSourcesUserContext(
-            username="alice",
-            email="alice@galaxyproject.org",
-            preferences={},
-            role_names=set(),
-            group_names=set(),
-            is_admin=False,
-            oidc_access_tokens={"oidc": oidc_token},
-        )
-        file_sources = configured_file_sources(DRS_OIDC_FILE_SOURCES_CONF)
-        assert_realizes_as(file_sources, test_url, "hello oidc world", user_context=user_context)
+    user_context = DictFileSourcesUserContext(
+        username="alice",
+        email="alice@galaxyproject.org",
+        preferences={},
+        role_names=set(),
+        group_names=set(),
+        is_admin=False,
+        oidc_access_tokens={"oidc": oidc_token},
+    )
+    file_sources = configured_file_sources(DRS_OIDC_FILE_SOURCES_CONF)
+    assert_realizes_as(file_sources, test_url, "hello oidc world", user_context=user_context)

--- a/test/unit/files/test_elabftw_ssl.py
+++ b/test/unit/files/test_elabftw_ssl.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+from galaxy.files.sources import elabftw
+
+
+def test_async_session_uses_certifi_ssl_context():
+    ssl_context = mock.Mock()
+    connector = mock.Mock()
+    session = mock.Mock()
+    source = object.__new__(elabftw.eLabFTWFilesSource)
+    config = cast(elabftw.eLabFTWFileSourceConfiguration, SimpleNamespace(api_key="secret"))
+
+    with (
+        mock.patch("galaxy.files.sources.elabftw.requests.create_ssl_context", return_value=ssl_context),
+        mock.patch("galaxy.files.sources.elabftw.aiohttp.TCPConnector", return_value=connector) as tcp_connector,
+        mock.patch("galaxy.files.sources.elabftw.aiohttp.ClientSession", return_value=session) as client_session,
+    ):
+        assert source._create_session_async(config) is session
+
+    tcp_connector.assert_called_once_with(limit=elabftw.MAX_CONCURRENT_REQUESTS, ssl=ssl_context)
+    client_session.assert_called_once_with(
+        connector=connector,
+        raise_for_status=True,
+        headers={"Authorization": "secret", "Accept": "application/json"},
+    )

--- a/test/unit/files/test_http.py
+++ b/test/unit/files/test_http.py
@@ -1,3 +1,4 @@
+import gzip
 import io
 import os
 import urllib
@@ -5,6 +6,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+import responses
 
 from galaxy import exceptions
 from ._util import (
@@ -19,25 +21,23 @@ FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "http_file_sources_conf.yml")
 FILE_SOURCES_CONF_WITHOUT_STOCK = os.path.join(SCRIPT_DIRECTORY, "http_without_stock_file_sources_conf.yml")
 
 
+@responses.activate
 def test_file_source_http_specific():
     test_url = "https://www.usegalaxy.org/myfile.txt"
 
-    def check_specific_header(request, **kwargs):
+    def check_specific_header(request):
         assert request.headers["Authorization"] == "Bearer IBearTokens"
-        response: Any = io.StringIO("hello specific world")
-        response.headers = {}
-        response.geturl = lambda: test_url
-        return response
+        return 200, {}, "hello specific world"
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_specific_header):
-        user_context = user_context_fixture()
-        file_sources = configured_file_sources(FILE_SOURCES_CONF)
-        file_source_pair = file_sources.get_file_source_path(test_url)
+    responses.add_callback(responses.GET, test_url, callback=check_specific_header)
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path(test_url)
 
-        assert file_source_pair.path == test_url
-        assert file_source_pair.file_source.id == "test1"
+    assert file_source_pair.path == test_url
+    assert file_source_pair.file_source.id == "test1"
 
-        assert_realizes_as(file_sources, test_url, "hello specific world", user_context=user_context)
+    assert_realizes_as(file_sources, test_url, "hello specific world", user_context=user_context)
 
 
 def test_plugins_to_dict_serializes_only_best_matching_http_source():
@@ -52,46 +52,59 @@ def test_plugins_to_dict_serializes_only_best_matching_http_source():
     assert [plugin["id"] for plugin in plugins] == ["test1"]
 
 
+@responses.activate
 def test_file_source_another_http_specific():
     test_url = "http://www.galaxyproject.org/anotherfile.txt"
 
-    def check_another_header(request, **kwargs):
+    def check_another_header(request):
         assert request.headers["Another_header"] == "found"
-        response: Any = io.StringIO("hello another world")
-        response.geturl = lambda: test_url
-        response.headers = {}
-        return response
+        return 200, {}, "hello another world"
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_another_header):
-        user_context = user_context_fixture()
-        file_sources = configured_file_sources(FILE_SOURCES_CONF)
-        file_source_pair = file_sources.get_file_source_path(test_url)
+    responses.add_callback(responses.GET, test_url, callback=check_another_header)
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path(test_url)
 
-        assert file_source_pair.path == test_url
-        assert file_source_pair.file_source.id == "test2"
+    assert file_source_pair.path == test_url
+    assert file_source_pair.file_source.id == "test2"
 
-        assert_realizes_as(file_sources, test_url, "hello another world", user_context=user_context)
+    assert_realizes_as(file_sources, test_url, "hello another world", user_context=user_context)
 
 
+@responses.activate
 def test_file_source_http_generic():
     test_url = "https://www.elsewhere.org/myfile.txt"
 
-    def check_generic_headers(request, **kwargs):
-        assert not request.headers
-        response: Any = io.StringIO("hello generic world")
-        response.headers = {}
-        response.geturl = lambda: test_url
-        return response
+    def check_generic_headers(request):
+        assert "Authorization" not in request.headers
+        assert "Another_header" not in request.headers
+        return 200, {}, "hello generic world"
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_generic_headers):
-        user_context = user_context_fixture()
-        file_sources = configured_file_sources(FILE_SOURCES_CONF)
-        file_source_pair = file_sources.get_file_source_path(test_url)
+    responses.add_callback(responses.GET, test_url, callback=check_generic_headers)
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path(test_url)
 
-        assert file_source_pair.path == test_url
-        assert file_source_pair.file_source.id == "test3"
+    assert file_source_pair.path == test_url
+    assert file_source_pair.file_source.id == "test3"
 
-        assert_realizes_as(file_sources, test_url, "hello generic world", user_context=user_context)
+    assert_realizes_as(file_sources, test_url, "hello generic world", user_context=user_context)
+
+
+@responses.activate
+def test_file_source_http_decodes_content_encoding():
+    test_url = "https://www.elsewhere.org/compressed.txt"
+    content = b"content compressed for transfer"
+    responses.add(
+        responses.GET,
+        test_url,
+        body=gzip.compress(content, mtime=0),
+        headers={"Content-Encoding": "gzip"},
+    )
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+
+    assert_realizes_as(file_sources, test_url, content.decode(), user_context=user_context)
 
 
 def test_file_source_ftp_url():
@@ -127,30 +140,53 @@ def test_file_source_http_without_stock_generic():
         file_sources.get_file_source_path(test_url)
 
 
+@responses.activate
 def test_file_source_http_without_stock_specific():
     test_url = "https://www.usegalaxy.org/myfile2.txt"
 
-    def check_specific_header(request, **kwargs):
+    def check_specific_header(request):
         assert request.headers["Authorization"] == "Bearer IBearTokens"
-        response: Any = io.StringIO("hello specific world 2")
-        response.headers = {}
-        response.geturl = lambda: test_url
-        return response
+        return 200, {}, "hello specific world 2"
 
-    with mock.patch.object(urllib.request, "urlopen", new=check_specific_header):
-        user_context = user_context_fixture()
-        file_sources = configured_file_sources(FILE_SOURCES_CONF_WITHOUT_STOCK)
-        file_source_pair = file_sources.get_file_source_path(test_url)
+    responses.add_callback(responses.GET, test_url, callback=check_specific_header)
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF_WITHOUT_STOCK)
+    file_source_pair = file_sources.get_file_source_path(test_url)
 
-        assert file_source_pair.path == test_url
-        assert file_source_pair.file_source.id == "test1"
+    assert file_source_pair.path == test_url
+    assert file_source_pair.file_source.id == "test1"
 
-        assert_realizes_as(file_sources, test_url, "hello specific world 2", user_context=user_context)
+    assert_realizes_as(file_sources, test_url, "hello specific world 2", user_context=user_context)
 
 
 def test_file_source_http_with_spaces_in_url_error():
     """Test that URLs with unencoded spaces give a helpful error (issue #21221)."""
     test_url = "https://example.com/Markers File.csv"
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+
+    with pytest.raises(ValueError, match="URL contains unencoded characters"):
+        file_source_pair = file_sources.get_file_source_path(test_url)
+        file_source_pair.file_source.realize_to(file_source_pair.path, "/tmp/test", user_context=user_context)
+
+
+@responses.activate
+def test_file_source_http_validates_redirect_target():
+    test_url = "https://example.com/start"
+    private_url = "http://127.0.0.1/private"
+    responses.add(responses.GET, test_url, status=302, headers={"Location": private_url})
+    responses.add(responses.GET, private_url, body="private data")
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+
+    with pytest.raises(exceptions.ConfigDoesNotAllowException):
+        file_source_pair = file_sources.get_file_source_path(test_url)
+        file_source_pair.file_source.realize_to(file_source_pair.path, "/tmp/test", user_context=user_context)
+
+
+@pytest.mark.parametrize("character", ("\n", "\t", "\x7f"))
+def test_file_source_http_with_control_character_error(character):
+    test_url = f"https://example.com/file{character}name.txt"
     user_context = user_context_fixture()
     file_sources = configured_file_sources(FILE_SOURCES_CONF)
 

--- a/test/unit/tool_shed/test_repository_dependency_http.py
+++ b/test/unit/tool_shed/test_repository_dependency_http.py
@@ -1,0 +1,48 @@
+import threading
+from http.server import (
+    BaseHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
+
+from galaxy.tool_shed.galaxy_install.repository_dependencies.repository_dependency_manager import _request
+
+
+class RedirectingRequestHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, bytes]] = []
+
+    def do_POST(self):
+        content_length = int(self.headers["Content-Length"])
+        body = self.rfile.read(content_length)
+        self.requests.append((self.path, body))
+        if self.path == "/initial":
+            self.send_response(307)
+            self.send_header("Location", "/redirected")
+            self.end_headers()
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"response")
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_request_posts_form_through_307_redirect_and_closes():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectingRequestHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    RedirectingRequestHandler.requests = []
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/initial"
+        with _request(url, data={"encoded_str": "encoded-value"}) as response:
+            assert response.content == b"response"
+
+        assert RedirectingRequestHandler.requests == [
+            ("/initial", b"encoded_str=encoded-value"),
+            ("/redirected", b"encoded_str=encoded-value"),
+        ]
+        assert response.raw.closed
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()

--- a/test/unit/tools/parameters/test_cancelable_request.py
+++ b/test/unit/tools/parameters/test_cancelable_request.py
@@ -1,0 +1,34 @@
+import asyncio
+from unittest import mock
+
+from galaxy.tools.parameters import cancelable_request
+
+
+class AsyncSessionContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+def test_async_request_uses_certifi_ssl_context():
+    ssl_context = mock.Mock()
+    connector = mock.Mock()
+    session = AsyncSessionContext()
+
+    with (
+        mock.patch.object(cancelable_request, "create_ssl_context", return_value=ssl_context),
+        mock.patch(
+            "galaxy.tools.parameters.cancelable_request.aiohttp.TCPConnector", return_value=connector
+        ) as tcp_connector,
+        mock.patch(
+            "galaxy.tools.parameters.cancelable_request.aiohttp.ClientSession", return_value=session
+        ) as client_session,
+        mock.patch.object(cancelable_request, "fetch_url", new=mock.AsyncMock(return_value={"ok": True})),
+    ):
+        result = asyncio.run(cancelable_request.async_request_with_timeout("https://example.com"))
+
+    assert result == {"ok": True}
+    tcp_connector.assert_called_once_with(ssl=ssl_context)
+    client_session.assert_called_once_with(connector=connector)

--- a/test/unit/tools/test_data_source_download.py
+++ b/test/unit/tools/test_data_source_download.py
@@ -1,0 +1,59 @@
+import gzip
+import io
+from typing import cast
+from unittest import mock
+
+import responses
+from requests import Response
+from tools.data_source import data_source
+
+
+class FTPResponse(io.BytesIO):
+    headers: dict[str, str]
+
+
+@responses.activate
+def test_open_remote_source_get_streams_and_closes():
+    url = "https://example.com/data"
+    responses.add(
+        responses.GET,
+        url,
+        body=gzip.compress(b"result", mtime=0),
+        headers={"Content-Encoding": "gzip"},
+    )
+
+    with data_source._open_remote_source(url, "get", {}, {"X-Test": "yes"}) as (source, headers):
+        assert source.read() == b"result"
+        assert headers is not None
+
+    assert responses.calls[0].request.headers["X-Test"] == "yes"
+    response = cast(Response, responses.calls[0].response)
+    assert response.raw.closed
+
+
+@responses.activate
+def test_open_remote_source_post_sends_form_and_closes():
+    url = "https://example.com/data"
+
+    def check_form(request):
+        assert request.body == "gene=BRCA1"
+        return 200, {}, b"result"
+
+    responses.add_callback(responses.POST, url, callback=check_form)
+    with data_source._open_remote_source(url, "post", {"gene": "BRCA1"}, {}) as (source, _):
+        assert source.read() == b"result"
+
+    response = cast(Response, responses.calls[0].response)
+    assert response.raw.closed
+
+
+def test_open_remote_source_keeps_ftp_fallback():
+    response = FTPResponse(b"ftp result")
+    response.headers = {}
+    with mock.patch.object(data_source, "urlopen", return_value=response) as urlopen:
+        with data_source._open_remote_source("ftp://example.com/data", "get", {}, {}) as (source, _):
+            assert source.read() == b"ftp result"
+
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "ftp://example.com/data"
+    assert response.closed

--- a/test/unit/util/test_requests.py
+++ b/test/unit/util/test_requests.py
@@ -1,5 +1,7 @@
 import socket
+import ssl
 import threading
+from unittest import mock
 
 import pytest
 import responses
@@ -10,6 +12,17 @@ from galaxy.util.requests import DEFAULT_RETRIES
 from galaxy.util.user_agent import get_default_headers
 
 EXPECTED_USER_AGENT = get_default_headers()["user-agent"]
+
+
+def test_create_ssl_context_uses_requests_ca_bundle():
+    ssl_context = mock.Mock()
+    with (
+        mock.patch.object(galaxy_requests, "requests_ca_bundle_path", return_value="/certifi/cacert.pem"),
+        mock.patch.object(ssl, "create_default_context", return_value=ssl_context) as create_default_context,
+    ):
+        assert galaxy_requests.create_ssl_context() is ssl_context
+
+    create_default_context.assert_called_once_with(cafile="/certifi/cacert.pem")
 
 
 # --- User-Agent header injection ---

--- a/test/unit/util/test_requests.py
+++ b/test/unit/util/test_requests.py
@@ -1,8 +1,8 @@
 import socket
 import ssl
 import threading
-from unittest import mock
 
+import certifi
 import pytest
 import responses
 from requests.adapters import HTTPAdapter
@@ -14,15 +14,13 @@ from galaxy.util.user_agent import get_default_headers
 EXPECTED_USER_AGENT = get_default_headers()["user-agent"]
 
 
-def test_create_ssl_context_uses_requests_ca_bundle():
-    ssl_context = mock.Mock()
-    with (
-        mock.patch.object(galaxy_requests, "requests_ca_bundle_path", return_value="/certifi/cacert.pem"),
-        mock.patch.object(ssl, "create_default_context", return_value=ssl_context) as create_default_context,
-    ):
-        assert galaxy_requests.create_ssl_context() is ssl_context
-
-    create_default_context.assert_called_once_with(cafile="/certifi/cacert.pem")
+def test_create_ssl_context_uses_certifi_ca_bundle():
+    context = galaxy_requests.create_ssl_context()
+    certifi_context = ssl.create_default_context(cafile=certifi.where())
+    assert context.get_ca_certs()
+    assert context.get_ca_certs() == certifi_context.get_ca_certs()
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname
 
 
 # --- User-Agent header injection ---

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -98,13 +98,11 @@ def test_parse_xml_enoent():
 
 
 def test_clean_multiline_string():
-    x = util.clean_multiline_string(
-        """
+    x = util.clean_multiline_string("""
         a
         b
         c
-"""
-    )
+""")
     assert x == "a\nb\nc\n"
 
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -2,7 +2,10 @@ import errno
 import os
 import tempfile
 from enum import Enum
-from io import StringIO
+from io import (
+    BytesIO,
+    StringIO,
+)
 from pathlib import Path
 
 import pytest
@@ -24,6 +27,21 @@ SECTION_XML = """<?xml version="1.0" ?>
 def test_strip_control_characters():
     s = "\x00bla"
     assert util.strip_control_characters(s) == "bla"
+
+
+def test_stream_to_path(tmp_path):
+    destination = tmp_path / "streamed"
+
+    assert util.stream_to_path(BytesIO(b"streamed content"), destination) == destination
+    assert destination.read_bytes() == b"streamed content"
+
+
+def test_stream_to_open_named_file_compatibility(tmp_path):
+    destination = tmp_path / "streamed"
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT)
+
+    assert util.stream_to_open_named_file(BytesIO(b"streamed content"), fd, destination) == destination
+    assert destination.read_bytes() == b"streamed content"
 
 
 def test_parse_xml_string():

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -42,6 +42,8 @@ def test_stream_to_open_named_file_compatibility(tmp_path):
 
     assert util.stream_to_open_named_file(BytesIO(b"streamed content"), fd, destination) == destination
     assert destination.read_bytes() == b"streamed content"
+    with pytest.raises(OSError):
+        os.fstat(fd)
 
 
 def test_parse_xml_string():
@@ -96,11 +98,13 @@ def test_parse_xml_enoent():
 
 
 def test_clean_multiline_string():
-    x = util.clean_multiline_string("""
+    x = util.clean_multiline_string(
+        """
         a
         b
         c
-""")
+"""
+    )
     assert x == "a\nb\nc\n"
 
 

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -4,6 +4,7 @@
 import json
 import os
 import sys
+from contextlib import contextmanager
 from urllib.parse import (
     urlencode,
     urlparse,
@@ -18,13 +19,42 @@ from galaxy.datatypes.registry import Registry
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     get_charset_from_http_headers,
-    stream_to_open_named_file,
+    requests,
+    stream_to_path,
 )
 from galaxy.util.user_agent import get_default_headers
 
 GALAXY_PARAM_PREFIX = "GALAXY"
 GALAXY_ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 GALAXY_DATATYPES_CONF_FILE = os.path.join(GALAXY_ROOT_DIR, "datatypes_conf.xml")
+
+
+@contextmanager
+def _open_remote_source(url, method, incoming_request_params, headers):
+    scheme = urlparse(url).scheme
+    if method not in ("get", "post"):
+        raise ValueError(f"Unknown URL_method specified: {method}")
+
+    if scheme == "ftp":
+        data = urlencode(incoming_request_params).encode("utf-8") if method == "post" else None
+        request = Request(url, data=data, headers=headers)
+        with urlopen(request, timeout=DEFAULT_SOCKET_TIMEOUT) as response:
+            yield response, response.headers
+        return
+
+    data = incoming_request_params if method == "post" else None
+    with requests.Session() as session:
+        request_method = session.get if method == "get" else session.post
+        with request_method(
+            url,
+            data=data,
+            headers=headers,
+            stream=True,
+            timeout=DEFAULT_SOCKET_TIMEOUT,
+        ) as response:
+            response.raise_for_status()
+            response.raw.decode_content = True
+            yield response.raw, response.headers
 
 
 def __main__():
@@ -54,35 +84,34 @@ def __main__():
             open(cur_filename, "w").write("")
             sys.exit("The remote data source application has not sent back a URL parameter in the request.")
 
-        # The following calls to urlopen() will use the above default timeout
         headers = get_default_headers()
         try:
-            if URL_method == "get":
-                req = Request(cur_URL, headers=headers)
-            elif URL_method == "post":
-                data = urlencode(params["param_dict"]["incoming_request_params"]).encode("utf-8")
-                req = Request(cur_URL, data=data, headers=headers)
-            else:
-                raise Exception("Unknown URL_method specified: %s" % URL_method)
-            page = urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT)
+            remote_source = _open_remote_source(
+                cur_URL,
+                URL_method,
+                params["param_dict"].get("incoming_request_params", {}),
+                headers,
+            )
+            page, response_headers = remote_source.__enter__()
         except Exception as e:
             sys.exit("The remote data source application may be off line, please try again later. Error: %s" % str(e))
-        if max_file_size:
-            file_size = int(page.info().get("Content-Length", 0))
-            if file_size > max_file_size:
-                sys.exit(
-                    "The size of the data (%d bytes) you have requested exceeds the maximum allowed (%d bytes) on this server."
-                    % (file_size, max_file_size)
-                )
         try:
-            cur_filename = stream_to_open_named_file(
+            if max_file_size:
+                file_size = int(response_headers.get("Content-Length", 0))
+                if file_size > max_file_size:
+                    sys.exit(
+                        f"The size of the data ({file_size} bytes) you have requested exceeds the maximum allowed "
+                        f"({max_file_size} bytes) on this server."
+                    )
+            cur_filename = stream_to_path(
                 page,
-                os.open(cur_filename, os.O_WRONLY | os.O_TRUNC | os.O_CREAT),
                 cur_filename,
-                source_encoding=get_charset_from_http_headers(page.headers),
+                source_encoding=get_charset_from_http_headers(response_headers),
             )
         except Exception as e:
             sys.exit(f"Unable to fetch {cur_URL}:\n{e}")
+        finally:
+            remote_source.__exit__(None, None, None)
 
         # here import checks that upload tool performs
         try:


### PR DESCRIPTION
## Why

Several active runtime download paths still used standard-library HTTP openers, which use platform-dependent CA configuration instead of the certifi bundle used by Galaxy's requests dependency. The affected aiohttp clients likewise relied on their default SSL context. This could make outbound TLS behavior inconsistent across Galaxy code paths and installations.

## What changed

- route the selected runtime HTTP(S) downloads through `galaxy.util.requests`
- configure the eLabFTW and cancelable-request aiohttp connectors with a certifi-backed SSL context
- retain urllib only for advertised FTP support and direct filesystem access for GTN local files
- preserve streaming, HTTP content decoding, timeouts, redirects, post-redirect allowlist checks, error mappings, and atomic GTN replacement
- add `stream_to_path()` so callers do not need to manage raw file descriptors
- retain `stream_to_open_named_file()` as a documented compatibility shim because external Galaxy tools import it

## Testing

- focused util, file-source, GTN, data-provider, Tool Shed, and tool-side downloader unit coverage
- 123 affected tests passed locally

