### PR TITLE
Forward force_path_paste for non-composite test inputs

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -668,6 +668,7 @@ class GalaxyInteractorApi:
                 test_data,
                 tool_id,
                 tool_version=tool_version,
+                force_path_paste=force_path_paste,
                 mode="file" if tool_input["class"].lower() == "file" else "directory",
             )
             if path_or_location.path:

--- a/test/unit/tool_util/verify/test_interactor.py
+++ b/test/unit/tool_util/verify/test_interactor.py
@@ -1,11 +1,17 @@
 """Tests for adapting test output properties onto dataset API response keys."""
 
+from typing import (
+    Any,
+    Literal,
+)
+
 import pytest
 
 from galaxy.tool_util.verify.interactor import (
     compare_expected_metadata_to_api_response,
     GalaxyInteractorApi,
     get_metadata_to_test,
+    PathOrLocation,
 )
 
 
@@ -121,3 +127,56 @@ def test_get_path_or_location_uses_server_path_when_available():
     assert result.location == "file:///srv/test-data/1.bed"
     assert result.path is None
     assert interactor.calls == ["1.bed"]
+
+
+class _RecordingInteractor(GalaxyInteractorApi):
+    """Interactor recording how each _get_path_or_location call was made."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def _get_path_or_location(
+        self,
+        fname: str,
+        test_data: dict[str, Any],
+        tool_id: str,
+        tool_version: str | None = None,
+        force_path_paste: bool = False,
+        mode: Literal["file", "directory"] = "file",
+    ) -> PathOrLocation:
+        self.calls.append({"force_path_paste": force_path_paste, "mode": mode})
+        return PathOrLocation(name=fname, location=None, path=f"/tmp/{fname}")
+
+
+def _test_data(fname, **kwds):
+    data = {
+        "fname": fname,
+        "ftype": "bed",
+        "dbkey": "?",
+        "composite_data": None,
+    }
+    data.update(kwds)
+    return data
+
+
+@pytest.mark.parametrize("force_path_paste", [True, False])
+def test_remote_to_input_forwards_force_path_paste(force_path_paste):
+    """--force_path_paste must reach _get_path_or_location for ordinary inputs.
+
+    It was only forwarded on the composite_data branch, so the flag was
+    silently ignored for the far commoner single-file input.
+    """
+    interactor = _RecordingInteractor()
+    interactor.remote_to_input(_test_data("1.bed"), "some_tool", force_path_paste=force_path_paste)
+    assert len(interactor.calls) == 1
+    assert interactor.calls[0]["force_path_paste"] is force_path_paste
+
+
+@pytest.mark.parametrize("force_path_paste", [True, False])
+def test_remote_to_input_forwards_force_path_paste_for_composite_data(force_path_paste):
+    interactor = _RecordingInteractor()
+    interactor.remote_to_input(
+        _test_data("1.bed", composite_data=["a.txt", "b.txt"]), "some_tool", force_path_paste=force_path_paste
+    )
+    assert len(interactor.calls) == 2
+    assert all(call["force_path_paste"] is force_path_paste for call in interactor.calls)


### PR DESCRIPTION
## Problem

`remote_to_input()` passes `force_path_paste` to `_get_path_or_location()` on
its `composite_data` branch, but not on the branch immediately below it:

```python
if composite_data := test_data["composite_data"]:
    tool_input["composite_data"] = [
        self._get_path_or_location(
            ...
            force_path_paste=force_path_paste,   # forwarded here
        ).path
        for fname_ in composite_data
    ]
else:
    path_or_location = self._get_path_or_location(
        fname,
        test_data,
        tool_id,
        tool_version=tool_version,               # ...but not here
        mode="file" if tool_input["class"].lower() == "file" else "directory",
    )
```

So `galaxy-tool-test --force_path_paste` has been silently ignored for ordinary
single-file inputs — the far commoner case — and those inputs fall through to
the client-upload path regardless of the flag.

## Fix

Add the missing keyword argument.

## Tests

There was no coverage of `force_path_paste` anywhere, so this adds two
parametrised tests in `test/unit/tool_util/verify/test_interactor.py`, one per
branch, since the bug is precisely that the two branches disagree. They record
what `_get_path_or_location` is called with rather than standing up an
interactor, as none of `GalaxyInteractorApi.__init__`'s connection setup is
relevant to argument forwarding.

Verified on Python 3.10 that the non-composite pair fails without the fix and
passes with it, while the composite pair passes either way.