### PR TITLE
Report a missing test-data path as None rather than the error body

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -539,12 +539,19 @@ class GalaxyInteractorApi:
         response = self._put(f"histories/{history_id}", json.dumps({"published": True}))
         response.raise_for_status()
 
-    def test_data_path(self, tool_id, filename, tool_version=None):
+    def test_data_path(self, tool_id, filename, tool_version=None) -> str | None:
+        """Path the server can read this test file from, or None if it has none.
+
+        A 404 here is an ordinary outcome - the server simply cannot resolve
+        that file - so it is reported as None rather than raised.
+        """
         version_fragment = f"&tool_version={tool_version}" if tool_version else ""
         response = self._get(f"tools/{tool_id}/test_data_path?filename={filename}{version_fragment}", admin=True)
         result = response.json()
-        if response.status_code in [200, 404]:
+        if response.status_code == 200:
             return result
+        if response.status_code == 404:
+            return None
         raise Exception(result["err_msg"])
 
     def test_data_download(self, tool_id, filename, mode="file", is_output=True, tool_version=None, path_only=False):
@@ -685,23 +692,21 @@ class GalaxyInteractorApi:
         location = self._ensure_valid_location_in(test_data)
         if fname and force_path_paste:
             file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)
-            file_name_exists = os.path.exists(file_name)
+            file_name_exists = file_name is not None and os.path.exists(file_name)
         if not file_name_exists and location is not None:
             return PathOrLocation(name=location, location=location, path=None)
-        else:
-            if force_path_paste:
-                if file_name is None:
-                    file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)
-                return PathOrLocation(name=fname, location=f"file://{file_name}", path=None)
-            else:
-                path = self.test_data_download(
-                    tool_id, fname, is_output=False, tool_version=tool_version, mode=mode, path_only=True
-                )
-                assert isinstance(path, str)
-                # Downloaded directories contain root directory
-                if path and mode == "directory":
-                    path = os.path.join(path, fname)
-                return PathOrLocation(name=fname, location=None, path=path)
+        if file_name is not None:
+            return PathOrLocation(name=fname, location=f"file://{file_name}", path=None)
+        # Either path paste was not requested, or the server has no path for
+        # this file - fetch it instead of pointing the server at nothing.
+        path = self.test_data_download(
+            tool_id, fname, is_output=False, tool_version=tool_version, mode=mode, path_only=True
+        )
+        assert isinstance(path, str)
+        # Downloaded directories contain root directory
+        if path and mode == "directory":
+            path = os.path.join(path, fname)
+        return PathOrLocation(name=fname, location=None, path=path)
 
     def _ensure_valid_location_in(self, test_data: dict) -> str | None:
         location: str | None = test_data.get("location")

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -540,17 +540,16 @@ class GalaxyInteractorApi:
         response.raise_for_status()
 
     def test_data_path(self, tool_id, filename, tool_version=None) -> str | None:
-        """Path the server can read this test file from, or None if it has none.
-
-        A 404 here is an ordinary outcome - the server simply cannot resolve
-        that file - so it is reported as None rather than raised.
-        """
+        """Path the server can read this test file from, or None if it has none."""
         version_fragment = f"&tool_version={tool_version}" if tool_version else ""
         response = self._get(f"tools/{tool_id}/test_data_path?filename={filename}{version_fragment}", admin=True)
         result = response.json()
         if response.status_code == 200:
             return result
         if response.status_code == 404:
+            # Callers already expect None here - see test_data_download, which
+            # checks `local_path is None` - and fall back to downloading the
+            # file or looking in the local test-data directories.
             return None
         raise Exception(result["err_msg"])
 

--- a/test/unit/tool_util/verify/test_interactor.py
+++ b/test/unit/tool_util/verify/test_interactor.py
@@ -4,6 +4,7 @@ import pytest
 
 from galaxy.tool_util.verify.interactor import (
     compare_expected_metadata_to_api_response,
+    GalaxyInteractorApi,
     get_metadata_to_test,
 )
 
@@ -40,3 +41,77 @@ def test_visible_mismatch_raises():
     with pytest.raises(Exception) as exc:
         compare_expected_metadata_to_api_response({"visible": False}, {"visible": True})
     assert "visible" in str(exc.value)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _interactor_with_response(response):
+    interactor = GalaxyInteractorApi.__new__(GalaxyInteractorApi)
+    interactor._get = lambda *args, **kwds: response  # type: ignore[method-assign]
+    return interactor
+
+
+def test_test_data_path_returns_path_on_200():
+    interactor = _interactor_with_response(_FakeResponse(200, "/srv/test-data/1.bed"))
+    assert interactor.test_data_path("some_tool", "1.bed") == "/srv/test-data/1.bed"
+
+
+def test_test_data_path_returns_none_on_404():
+    """A 404 means the server has no path for this file, not that it errored.
+
+    It used to return the error body, so callers got a dict where a path was
+    expected and os.path.exists() raised TypeError.
+    """
+    interactor = _interactor_with_response(_FakeResponse(404, {"err_msg": "not found", "err_code": 0}))
+    assert interactor.test_data_path("some_tool", "1.bed") is None
+
+
+def test_test_data_path_raises_on_other_errors():
+    interactor = _interactor_with_response(_FakeResponse(500, {"err_msg": "boom"}))
+    with pytest.raises(Exception) as exc:
+        interactor.test_data_path("some_tool", "1.bed")
+    assert "boom" in str(exc.value)
+
+
+def _interactor_for_path_lookup(server_path, downloaded="/tmp/downloaded/1.bed"):
+    """Interactor whose server-side lookup yields server_path, counting calls."""
+    interactor = GalaxyInteractorApi.__new__(GalaxyInteractorApi)
+    calls: list[str] = []
+
+    def _test_data_path(tool_id, filename, tool_version=None):
+        calls.append(filename)
+        return server_path
+
+    interactor.test_data_path = _test_data_path  # type: ignore[method-assign]
+    interactor.test_data_download = lambda *args, **kwds: downloaded  # type: ignore[method-assign]
+    return interactor, calls
+
+
+def test_get_path_or_location_falls_back_when_server_has_no_path():
+    """force_path_paste plus a 404 must download, not build a file://None URI."""
+    interactor, _ = _interactor_for_path_lookup(server_path=None)
+    result = interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
+    assert result.path == "/tmp/downloaded/1.bed"
+    assert result.location is None
+
+
+def test_get_path_or_location_asks_the_server_once():
+    """The path lookup used to be repeated for the same input."""
+    interactor, calls = _interactor_for_path_lookup(server_path=None)
+    interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
+    assert calls == ["1.bed"]
+
+
+def test_get_path_or_location_uses_server_path_when_available():
+    interactor, calls = _interactor_for_path_lookup(server_path="/srv/test-data/1.bed")
+    result = interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
+    assert result.location == "file:///srv/test-data/1.bed"
+    assert result.path is None
+    assert calls == ["1.bed"]

--- a/test/unit/tool_util/verify/test_interactor.py
+++ b/test/unit/tool_util/verify/test_interactor.py
@@ -52,14 +52,18 @@ class _FakeResponse:
         return self._payload
 
 
-def _interactor_with_response(response):
-    interactor = GalaxyInteractorApi.__new__(GalaxyInteractorApi)
-    interactor._get = lambda *args, **kwds: response  # type: ignore[method-assign]
-    return interactor
+class _ResponseInteractor(GalaxyInteractorApi):
+    """Interactor whose HTTP layer always yields one canned response."""
+
+    def __init__(self, response):
+        self._response = response
+
+    def _get(self, *args, **kwds):
+        return self._response
 
 
 def test_test_data_path_returns_path_on_200():
-    interactor = _interactor_with_response(_FakeResponse(200, "/srv/test-data/1.bed"))
+    interactor = _ResponseInteractor(_FakeResponse(200, "/srv/test-data/1.bed"))
     assert interactor.test_data_path("some_tool", "1.bed") == "/srv/test-data/1.bed"
 
 
@@ -69,34 +73,36 @@ def test_test_data_path_returns_none_on_404():
     It used to return the error body, so callers got a dict where a path was
     expected and os.path.exists() raised TypeError.
     """
-    interactor = _interactor_with_response(_FakeResponse(404, {"err_msg": "not found", "err_code": 0}))
+    interactor = _ResponseInteractor(_FakeResponse(404, {"err_msg": "not found", "err_code": 0}))
     assert interactor.test_data_path("some_tool", "1.bed") is None
 
 
 def test_test_data_path_raises_on_other_errors():
-    interactor = _interactor_with_response(_FakeResponse(500, {"err_msg": "boom"}))
+    interactor = _ResponseInteractor(_FakeResponse(500, {"err_msg": "boom"}))
     with pytest.raises(Exception) as exc:
         interactor.test_data_path("some_tool", "1.bed")
     assert "boom" in str(exc.value)
 
 
-def _interactor_for_path_lookup(server_path, downloaded="/tmp/downloaded/1.bed"):
-    """Interactor whose server-side lookup yields server_path, counting calls."""
-    interactor = GalaxyInteractorApi.__new__(GalaxyInteractorApi)
-    calls: list[str] = []
+class _PathLookupInteractor(GalaxyInteractorApi):
+    """Interactor with a stubbed server-side path lookup, recording its calls."""
 
-    def _test_data_path(tool_id, filename, tool_version=None):
-        calls.append(filename)
-        return server_path
+    def __init__(self, server_path, downloaded="/tmp/downloaded/1.bed"):
+        self._server_path = server_path
+        self._downloaded = downloaded
+        self.calls: list[str] = []
 
-    interactor.test_data_path = _test_data_path  # type: ignore[method-assign]
-    interactor.test_data_download = lambda *args, **kwds: downloaded  # type: ignore[method-assign]
-    return interactor, calls
+    def test_data_path(self, tool_id, filename, tool_version=None):
+        self.calls.append(filename)
+        return self._server_path
+
+    def test_data_download(self, *args, **kwds):
+        return self._downloaded
 
 
 def test_get_path_or_location_falls_back_when_server_has_no_path():
     """force_path_paste plus a 404 must download, not build a file://None URI."""
-    interactor, _ = _interactor_for_path_lookup(server_path=None)
+    interactor = _PathLookupInteractor(server_path=None)
     result = interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
     assert result.path == "/tmp/downloaded/1.bed"
     assert result.location is None
@@ -104,14 +110,14 @@ def test_get_path_or_location_falls_back_when_server_has_no_path():
 
 def test_get_path_or_location_asks_the_server_once():
     """The path lookup used to be repeated for the same input."""
-    interactor, calls = _interactor_for_path_lookup(server_path=None)
+    interactor = _PathLookupInteractor(server_path=None)
     interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
-    assert calls == ["1.bed"]
+    assert interactor.calls == ["1.bed"]
 
 
 def test_get_path_or_location_uses_server_path_when_available():
-    interactor, calls = _interactor_for_path_lookup(server_path="/srv/test-data/1.bed")
+    interactor = _PathLookupInteractor(server_path="/srv/test-data/1.bed")
     result = interactor._get_path_or_location("1.bed", {}, "some_tool", force_path_paste=True)
     assert result.location == "file:///srv/test-data/1.bed"
     assert result.path is None
-    assert calls == ["1.bed"]
+    assert interactor.calls == ["1.bed"]


### PR DESCRIPTION
## Problem

`test_data_path()` claims to return a path, and its own callers already treat
that as `Optional[str]` — `test_data_download()` assigns the result and checks
it on the very next line
([`interactor.py#L583-L585`](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/verify/interactor.py#L583-L585)):

```python
local_path = self.test_data_path(tool_id, filename, tool_version=tool_version)

if result is None and (local_path is None or not os.path.exists(local_path)):
    local_path = self._find_in_test_data_directories(filename)
```

But the function never returned `None`. It returned `response.json()` for 404
as well as 200, so a file the server cannot resolve came back as an error dict
where a path string was expected. `_get_path_or_location()` then handed that to
`os.path.exists()`:

```
TypeError: stat: path should be string, bytes, os.PathLike or integer, not dict
```

which propagated out as a non-zero exit for the whole `galaxy-tool-test`
process, after results had already been written.

Note the old code was `if response.status_code in [200, 404]: return result` —
404 already returned rather than raised. This changes *what* comes back on
404, not whether 404 is fatal. A file that no strategy can resolve still fails
the test at
[`interactor.py#L600-L606`](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/verify/interactor.py#L600-L606)
with `Test input file (...) cannot be found.` — which is the point, since that
message is actionable and the `TypeError` was not.

## Also tidied

While `_get_path_or_location()` is being taught to handle `None`:

- it asked the server for the same path **twice**, and under the new contract
  the second lookup would 404 again and build a literal `file://None`
  location;
- the retained branch reads as a straight sequence now that the download
  fallback is shared, rather than nesting it inside an `else`.

## Relationship to #23401

These are independent fixes to the same function, but they interact, and
**this one is the safer of the two to merge first**.

#23401 makes `--force_path_paste` actually take effect for non-composite
inputs. Today that branch never reaches
`_get_path_or_location()`'s `if fname and force_path_paste:` block, so it
never calls `test_data_path()` and is never exposed to the 404 above. Once
#23401 lands, it does — so any installation using `--force_path_paste`
against a server that cannot resolve a test file would go from quietly
downloading it to the `TypeError`, taking the process down.

Merging this first removes that exposure. Happy to combine them into one PR
instead if reviewers would rather see them together.

## Tests

Seven tests in `test/unit/tool_util/verify/test_interactor.py`: 200 / 404 /
other-error on the function itself, plus `_get_path_or_location()` falling
back to a download rather than building `file://None`, asking the server
exactly once, and still path-pasting when the server does have the file.

Confirmed that three of them fail without the change.
