### PR TITLE
[26.1] Fix failing API tests on release_26.1

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -770,6 +770,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     tool_filters: list[str]
     tool_label_filters: list[str]
     tool_path: str
+    tool_search_index_dir: str
     tool_section_filters: list[str]
     toolbox_filter_base_modules: list[str]
     track_jobs_in_database: bool

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -256,7 +256,16 @@ class ToolPanelViewSearch:
                 if indexed_tool.is_latest_version:
                     continue
                 latest_version = indexed_tool.latest_version
-                if latest_version and latest_version.hidden:
+                # `Tool.latest_version` resolves the newest revision through the
+                # tool cache under the lineage id `<versionless id>/<version>`.
+                # That key only exists for tools whose id carries their version,
+                # i.e. toolshed guids. A tool whose revisions share one bare id
+                # (`filters/grep.xml` and `filters/grep_1.0.1.xml` both declare
+                # `Grep1`) resolves to None, and the tool cache hands back
+                # whichever revision was parsed last. Both revisions are indexed
+                # under that one id, so an unresolvable latest version means the
+                # entry is still current, not that the tool went away.
+                if latest_version is None or latest_version.hidden:
                     continue
             tool_ids_to_remove.add(indexed_tool_id)
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6762,8 +6762,7 @@ steps:
     def test_workflow_with_deleted_dataset_step_parameter(self):
         """Verify workflow fails gracefully when a step parameter references a deleted dataset.
 
-        Uses a pause step so we can delete the dataset after the invocation is
-        queued but before the cat step executes, avoiding a race condition.
+        The pause ensures deletion happens after the initial parameter validation.
         """
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow("""
@@ -6797,15 +6796,10 @@ steps:
                 },
                 inputs_by="name",
             )
-            # Wait for the scheduler to hit the pause step (invocation state "new" → "ready")
-            # before deleting, otherwise the scheduler may detect the deleted dataset
-            # on step 2 during scheduling and fail the invocation before we can resume.
-            self._wait_for_invocation_state(workflow_id, invocation_id, "ready")
-            # Invocation is paused — delete the dataset before resuming.
+            # Ensure the parameter override is initially valid before deleting its dataset.
+            assert self._wait_for_invocation_state(workflow_id, invocation_id, "ready")
+            # The scheduler revalidates the override while the invocation is paused.
             self.dataset_populator.delete_dataset(history_id=history_id, content_id=to_delete_id, purge=False)
-            # Resume the pause step. The cat step will now run and
-            # ToolModule.execute() → compute_runtime_state will find the deleted dataset.
-            self.__review_paused_steps(workflow_id, invocation_id, order_index=1, action=True)
             self.workflow_populator.wait_for_invocation_and_jobs(
                 history_id=history_id,
                 workflow_id=workflow_id,

--- a/test/unit/app/tools/test_toolbox_search.py
+++ b/test/unit/app/tools/test_toolbox_search.py
@@ -1,0 +1,54 @@
+import os
+
+from galaxy.app_unittest_utils.toolbox_support import BaseToolBoxTestCase
+from galaxy.config import (
+    GALAXY_APP_NAME,
+    GALAXY_CONFIG_SCHEMA_PATH,
+)
+from galaxy.config.schema import AppSchema
+from galaxy.tools.search import ToolBoxSearch
+
+SEARCH_OPTIONS = (
+    "tool_description_boost",
+    "tool_enable_ngram_search",
+    "tool_help_bm25f_k1",
+    "tool_help_boost",
+    "tool_id_boost",
+    "tool_label_boost",
+    "tool_name_boost",
+    "tool_name_exact_multiplier",
+    "tool_ngram_factor",
+    "tool_ngram_maxsize",
+    "tool_ngram_minsize",
+    "tool_section_boost",
+    "tool_stub_boost",
+)
+
+
+class TestToolBoxSearch(BaseToolBoxTestCase):
+    def test_versioned_tool_survives_reindex(self):
+        # tool_conf.xml.sample lists the newest revision of a multi-version tool
+        # first (filters/grep.xml before filters/grep_1.0.1.xml), so the tool
+        # cache ends up pointing the shared id at the *older* revision.
+        self._init_tool(filename="tool_v02.xml", version="0.2")
+        self._init_tool(filename="tool_v01.xml", version="0.1")
+        self._add_config("""<toolbox><tool file="tool_v02.xml" /><tool file="tool_v01.xml" /></toolbox>""")
+        search = self._build_search()
+
+        search.build_index(self.app.tool_cache, self.toolbox)
+        assert "test_tool" in search.search("Test Tool", "default", self.app.config)
+
+        # Galaxy indexes twice on startup: the postfork
+        # `rebuild_toolbox_search_index` control task and, for the test driver,
+        # an explicit `reindex_tool_search()`.
+        self.app.tool_cache.reset_status()
+        search.build_index(self.app.tool_cache, self.toolbox)
+        assert "test_tool" in search.search("Test Tool", "default", self.app.config)
+
+    def _build_search(self) -> ToolBoxSearch:
+        schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
+        for option in SEARCH_OPTIONS:
+            setattr(self.app.config, option, schema.defaults[option])
+        index_dir = os.path.join(self.test_directory, "tool_search_index")
+        self.app.config.tool_search_index_dir = index_dir
+        return ToolBoxSearch(self.toolbox, index_dir=index_dir)

--- a/test/unit/app/tools/test_toolbox_search.py
+++ b/test/unit/app/tools/test_toolbox_search.py
@@ -25,25 +25,35 @@ SEARCH_OPTIONS = (
 )
 
 
+TOOL_ID = "toolbox_search_versioned_tool"
+
+
 class TestToolBoxSearch(BaseToolBoxTestCase):
     def test_versioned_tool_survives_reindex(self):
         # tool_conf.xml.sample lists the newest revision of a multi-version tool
         # first (filters/grep.xml before filters/grep_1.0.1.xml), so the tool
         # cache ends up pointing the shared id at the *older* revision.
-        self._init_tool(filename="tool_v02.xml", version="0.2")
-        self._init_tool(filename="tool_v01.xml", version="0.1")
+        self._init_tool(filename="tool_v02.xml", version="0.2", tool_id=TOOL_ID)
+        self._init_tool(filename="tool_v01.xml", version="0.1", tool_id=TOOL_ID)
         self._add_config("""<toolbox><tool file="tool_v02.xml" /><tool file="tool_v01.xml" /></toolbox>""")
-        search = self._build_search()
 
+        # ``ToolLineage.lineages_by_id`` is a class attribute that outlives each
+        # test, so an id shared with another test would carry that test's
+        # versions in here and change which revision counts as the latest.
+        tool = self.toolbox.get_tool(TOOL_ID)
+        assert tool.tool_versions == ["0.1", "0.2"]
+        assert tool.is_latest_version
+
+        search = self._build_search()
         search.build_index(self.app.tool_cache, self.toolbox)
-        assert "test_tool" in search.search("Test Tool", "default", self.app.config)
+        assert TOOL_ID in search.search("Test Tool", "default", self.app.config)
 
         # Galaxy indexes twice on startup: the postfork
         # `rebuild_toolbox_search_index` control task and, for the test driver,
         # an explicit `reindex_tool_search()`.
         self.app.tool_cache.reset_status()
         search.build_index(self.app.tool_cache, self.toolbox)
-        assert "test_tool" in search.search("Test Tool", "default", self.app.config)
+        assert TOOL_ID in search.search("Test Tool", "default", self.app.config)
 
     def _build_search(self) -> ToolBoxSearch:
         schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)


### PR DESCRIPTION
Fixes the two API-test failures on `release_26.1`. They are unrelated to each other.

Evidence: [run 33184034013 / job 98892275502](https://github.com/galaxyproject/galaxy/actions/runs/33184034013) on `release_26.1` at 94e49b14448, reproduced identically twice on #23404 (which branches from that SHA). Both failures are on the base SHA; #23404 itself is unrelated.

### 1. `test_tools.py::TestToolsApi::test_search_grep` — patched here, not backported

`Grep1` was missing from `/api/tools` search results even though the tool loads fine.

Galaxy indexes the toolbox twice on startup: the postfork `rebuild_toolbox_search_index` control task and, under the test driver, an explicit `reindex_tool_search()`. Both are visible in the failing job's log — the queue-worker pass takes 33s for the `default` panel, and the driver's pass runs after it:

```
15:14:00 [tN:Thread-4]    Starting to build toolbox index of panel default.
15:14:34 [tN:Thread-4]    Toolbox index of panel default finished (33510.915 ms)
15:14:50 [tN:MainThread]  Starting to build toolbox index of panel default.
```

The second pass asks `_get_tools_to_remove` which indexed ids are stale. That check resolves a tool's newest revision through `Tool.latest_version`, which looks the tool cache up under the lineage id `<versionless id>/<version>`. Only toolshed guids are cached under such a key. `Grep1` is declared by *two* files in `tool_conf.xml.sample` — `filters/grep.xml` (1.0.4) and `filters/grep_1.0.1.xml` (1.0.1) — so the cache maps the bare id to whichever file was parsed last (the older one), which answers `is_latest_version` with `False` and `latest_version` with `None`. `Grep1` was dropped from the index and never re-added, because `_get_tool_list` only considers ids the tool cache reports as new.

An unresolvable latest version now means "this entry is still current" rather than "remove it": both revisions share the one indexed id, so there is nothing to replace it with.

This is **not** a backport. `dev` has the same `_get_tools_to_remove` logic; the tool-search rewrite there is part of the cached-toolbox series, which does not belong on a release branch. `dev` is green because it loses the race less often, not because it is fixed — the latent bug is the same, and this is a real production bug: any second index build (a tool conf change in production triggers one) drops multi-revision tools from search.

Because the failure needs the two index builds to interleave the way CI does, it does not reproduce locally — `test_search_grep` passes on unmodified `release_26.1` both alone and with all of `test_tools.py`. The proof is therefore a unit test, `test/unit/app/tools/test_toolbox_search.py`, which drives `ToolBoxSearch.build_index` twice over a toolbox with two revisions of one bare tool id. It fails on unmodified `release_26.1` (`AssertionError: assert 'test_tool' in []`) and passes with the fix.

`lib/galaxy/config/__init__.py` gains a `tool_search_index_dir: str` annotation so the new test type-checks; the option was already in the schema, just missing from the stub block.

### 2. `test_workflows.py::TestWorkflowsApi::test_workflow_with_deleted_dataset_step_parameter` — backported

Got 400 `Attempting to modify the state of a completed workflow invocation` where 200 was expected. Straight `cherry-pick -x` of 8e9d1b8dce2 from `dev`; applied cleanly. The scheduler re-validates the cat step's runtime parameter override every scheduling iteration, so the invocation fails on its own once the dataset is deleted; resuming the pause step raced that. The resume is dropped and the test just waits for the failure — assertions unchanged.

### Verification

- `test/unit/app/tools/test_toolbox_search.py` fails without the fix, passes with it.
- `test/unit/app/tools/test_toolbox.py` unchanged and passing.
- Both API tests pass locally with the fixes applied. The workflow one is a race and passed locally before the fix too, so its local run is not evidence — the cherry-picked commit is upstream-verified (6 of 10 failing runs on `dev` before it landed).
- `tox -e lint,format,mypy` green.
