### PR TITLE
[26.1] Fix failing Selenium tests on release_26.1

### DIFF
--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -42,9 +42,8 @@ async function loadTools(offset: number, limit: number): Promise<{ items: Tool[]
     return { items, total: props.tools.length };
 }
 
-// Force ScrollList remount when tools change (e.g. after search),
-// ensuring loadTools is called again to await help data for new results.
-const toolsKey = computed(() => `${props.tools.length}-${props.tools[0]?.id}`);
+// Remount ScrollList when its result set changes so it reloads help data.
+const toolsKey = computed(() => JSON.stringify(props.tools.map((tool) => tool.id)));
 </script>
 
 <template>

--- a/client/src/stores/toolStore.test.ts
+++ b/client/src/stores/toolStore.test.ts
@@ -36,4 +36,20 @@ describe("toolStore", () => {
             helpFormat: "markdown",
         });
     });
+
+    it("settles a failed help request and retries it later", async () => {
+        const error = new Error("request failed");
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.mocked(axios.get)
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce({ data: { help: "Recovered help", help_format: "markdown" } });
+        const store = useToolStore();
+
+        await store.fetchHelpForId("test-tool");
+        expect(store.helpDataCached["test-tool"]).toEqual({ help: "", failed: true });
+
+        await store.fetchHelpForId("test-tool");
+        expect(axios.get).toHaveBeenCalledTimes(2);
+        expect(store.helpDataCached["test-tool"]).toMatchObject({ help: "Recovered help" });
+    });
 });

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -99,6 +99,7 @@ export type ToolHelpData = {
     help?: string;
     helpFormat?: string;
     summary?: string;
+    failed?: boolean;
 };
 
 type ToolHelpResponse = {
@@ -308,7 +309,8 @@ export const useToolStore = defineStore("toolStore", () => {
     }
 
     async function fetchHelpForId(toolId: string) {
-        if (helpDataCached.value[toolId]) {
+        const cached = helpDataCached.value[toolId];
+        if (cached && !cached.failed) {
             return;
         }
         const existing = fetchedHelpIds.value.get(toolId);
@@ -335,7 +337,9 @@ export const useToolStore = defineStore("toolStore", () => {
                 Vue.set(helpDataCached.value, toolId, toolHelpData);
             } catch (error) {
                 console.error("Error fetching help:", error);
-                fetchedHelpIds.value.delete(toolId); // Allow retrying on next request
+                // Settle current consumers but allow a later request to retry.
+                Vue.set(helpDataCached.value, toolId, { help: "", failed: true });
+                fetchedHelpIds.value.delete(toolId);
             }
         })();
         fetchedHelpIds.value.set(toolId, promise);

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1990,7 +1990,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         try:
             return rst_to_html(help_content.content)
         except Exception:
-            log.info("Exception while parsing help for tool with id '%s'", self.id)
+            log.warning("Exception while parsing help for tool with id '%s'", self.id, exc_info=True)
             return ""
 
     def render_help(self, static_path: str, host_url: str) -> str:

--- a/lib/galaxy/util/rst_to_html.py
+++ b/lib/galaxy/util/rst_to_html.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import threading
 
 try:
     import docutils.core
@@ -57,12 +58,17 @@ def get_publisher(error=False):
     return pub
 
 
+# Cached docutils publishers are stateful and not thread-safe.
+_publish_lock = threading.Lock()
+
+
 @functools.lru_cache(maxsize=None)
 def rst_to_html(s, error=False):
     if docutils is None:
         raise Exception("Attempted to use rst_to_html but docutils unavailable.")
 
-    publisher = get_publisher(error=error)
-    publisher.set_source(s, None)
-    publisher.set_destination(None, None)
-    return publisher.publish(enable_exit_status=False)
+    with _publish_lock:
+        publisher = get_publisher(error=error)
+        publisher.set_source(s, None)
+        publisher.set_destination(None, None)
+        return publisher.publish(enable_exit_status=False)

--- a/lib/galaxy_test/selenium/test_history_pages.py
+++ b/lib/galaxy_test/selenium/test_history_pages.py
@@ -530,9 +530,9 @@ class TestHistoryPages(SeleniumTestCase):
         items[-1].click()
         self.components.pages.history.revision_view.wait_for_visible()
 
-        # Oldest: "Compare to Previous" should be hidden, "Compare to Current" visible
-        self.components.pages.history.revision_compare_previous_button.assert_absent_or_hidden()
+        # Wait for the newly selected revision before asserting what disappeared.
         self.components.pages.history.revision_compare_current_button.wait_for_visible()
+        self.components.pages.history.revision_compare_previous_button.assert_absent_or_hidden()
 
         # Click "Compare to Current"
         self.components.pages.history.revision_compare_current_button.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_pages.py
+++ b/lib/galaxy_test/selenium/test_pages.py
@@ -190,9 +190,9 @@ class TestPages(SeleniumTestCase):
         items[-1].click()
         self.components.pages.history.revision_view.wait_for_visible()
 
-        # Oldest: "Compare to Previous" hidden, "Compare to Current" visible
-        self.components.pages.history.revision_compare_previous_button.assert_absent_or_hidden()
+        # Wait for the newly selected revision before asserting what disappeared.
         self.components.pages.history.revision_compare_current_button.wait_for_visible()
+        self.components.pages.history.revision_compare_previous_button.assert_absent_or_hidden()
 
         # Click "Compare to Current"
         self.components.pages.history.revision_compare_current_button.wait_for_and_click()

--- a/test/unit/util/test_rst_to_html.py
+++ b/test/unit/util/test_rst_to_html.py
@@ -1,0 +1,17 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from galaxy.util.rst_to_html import rst_to_html
+
+
+def test_rst_to_html_basic():
+    html = rst_to_html("**bold**")
+    assert "<strong>bold</strong>" in html
+
+
+def test_rst_to_html_concurrent_conversions():
+    documents = [f"Section {i}\n=========={'=' * len(str(i))}\n\nParagraph *{i}* with ``code``.\n" for i in range(50)]
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(rst_to_html, documents))
+    for i, html in enumerate(results):
+        assert f"Section {i}" in html
+        assert f"<em>{i}</em>" in html


### PR DESCRIPTION
Fixes the Selenium failures on `release_26.1`. Companion to #23405 (API tests); no overlap.

The "Selenium tests" workflow has been red on `release_26.1` for the last three pushes — 33184034332 (base SHA 94e49b14448), 33135225488, 33099904530. Artifacts upload only on `failure()`, so a shard with no artifact passed. Across those runs plus #23404 (branched from the base SHA):

| test | shard | 33099904530 | 33135225488 | 33184034332 | #23404 |
|---|---|---|---|---|---|
| `test_standalone_page_revision_diff` (test_pages.py) | 1 | FAIL | FAIL | pass | FAIL |
| `test_revision_diff_view` (test_history_pages.py) | 2 | pass | pass | FAIL | pass |
| `test_tool_discovery_help_toggle_shows_and_hides` | 0 | pass | pass | FAIL | FAIL |
| `test_published_histories_search_advanced` / `_tag_click` | 1 | pass | FAIL | pass | pass |
| `test_workflow_output_handling` (test_workflow_editor.py) | 2 | FAIL | pass | pass | pass |

Nothing is deterministic — that is the shape of the problem, not a reason to dismiss it. This PR fixes the three recurring ones.

### 1. `test_tool_discovery_help_toggle_shows_and_hides` — `rst_to_html` is not thread-safe

The card's description slot rendered as `<!----> <!---->` in the failure DOM: both branches false, i.e. `fetching` false and `help` falsy — the help *arrived*, empty. `/api/tools/__FILTER_FAILED_DATASETS__/build` returned 200, and the server log had:

```
Exception while parsing help for tool with id '__FILTER_FAILED_DATASETS__'
Exception while parsing help for tool with id 'Filter1'
Exception while parsing help for tool with id 'gff_filter_by_feature_count'
```

Those are exactly the cards rendered without a "Show tool help" link; `gtf_filter_by_attribute_values_list`, which rendered fine, has one. `get_publisher` is `lru_cache`d, so every thread shares one stateful docutils `Publisher`, and `rst_to_html` mutates it (`set_source`/`set_destination`) before `publish()`. The tools list fires ~32 concurrent `/build` requests, they corrupt each other's document state and raise, and `Tool.help_html` swallows the exception and returns `""`.

Cherry-pick of b53564c68d8, which guards publishing with a lock and logs the swallowed exception with a traceback. Conflict resolved on one line: `release_26.1` keeps `@functools.lru_cache(maxsize=None)` rather than dev's cosmetic `@functools.cache` (that came from the drop-Python-3.8 commit, which does not belong here).

### 2 & 3. The two revision-diff tests

Cherry-pick of df8979a8c8c, which fixes both. Selecting the oldest revision reuses the already-visible revision view, so `revision_view.wait_for_visible()` provides no synchronization and the compare-previous absence assert raced the async revision load. It now waits for the positive edge ("Compare to Current" only renders once the non-newest revision has loaded) before asserting what disappeared.

### Also included

Cherry-pick of 79388cdee47 ("Harden tools list help fetching"). **This is not what fixes the failing test** — with it applied and without the lock, `test_tool_discovery_help_toggle_shows_and_hides` still failed 4 of 6 local runs. It fixes two adjacent real bugs in the same path: a failed help fetch left the card in the skeleton state forever, and the old `length + first-id` ScrollList remount key collides across distinct result sets, leaving stale items whose help was never awaited. Unit-verified. Happy to drop it if you want this PR limited strictly to the CI fixes.

### Verification

- `test/unit/util/test_rst_to_html.py` (comes with the cherry-pick): **3/3 runs fail** with the lock reverted, **3/3 pass** with it.
- `test_tool_discovery_help_toggle_shows_and_hides`, locally, real browser: **4/6 failed before the lock**; **4/4 passed after**, with zero `Exception while parsing help` lines (6 in a failing run). Same failure mode locally as CI — timeout on the toggle becoming clickable.
- `test_revision_diff_view` and `test_standalone_page_revision_diff`: pass locally with the de-race. Their pre-fix failure is CI-timing-dependent and did **not** reproduce locally, so for those two the local runs confirm no regression rather than proving the fix; the upstream commit and the CI tracebacks are the evidence.
- `client/src/stores/toolStore.test.ts`: fails without the `toolStore` change (`expected undefined to deeply equal { help: '', failed: true }`), passes with it.
- `tox -e lint,format,mypy` green.

### Not addressed

`test_published_histories_search_advanced` / `_tag_click` and `test_workflow_output_handling` each failed once in four runs and have no corresponding fix on `dev`. I did not chase them; they may be independent flakes.
