### PR TITLE
[26.1] Fix workflow run-form dropdowns hiding and offering wrong datasets

### DIFF
--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -169,5 +169,21 @@ export const NON_TERMINAL_DATASET_STATES = ["new", "upload", "queued", "running"
 // Error dataset states (dataset failed processing)
 export const ERROR_DATASET_STATES = ["error", "failed_metadata"];
 
+// States a dataset may be in and still be offered as a tool/workflow input.
+// Mirrors ``Dataset.valid_input_states`` (all states bar error, discarded and
+// failed_metadata), which the server applies when it builds the first page of
+// a data parameter's options.
+export const VALID_INPUT_DATASET_STATES = [
+    "new",
+    "upload",
+    "queued",
+    "running",
+    "setting_metadata",
+    "ok",
+    "empty",
+    "paused",
+    "deferred",
+];
+
 // Terminal dataset states (dataset processing is complete)
 export const TERMINAL_DATASET_STATES = ["ok", "empty", "deferred", "discarded", "paused"].concat(ERROR_DATASET_STATES);

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -29,7 +29,7 @@ import { type EventData, useEventStore } from "@/stores/eventStore";
 import { orList } from "@/utils/strings";
 
 import type { DataOption, ExtendedCollectionType } from "./types";
-import { containsDataOption, isDataOption } from "./types";
+import { containsDataOption, DEFAULT_OPTIONS_PAGE_SIZE, isDataOption } from "./types";
 import { BATCH, SOURCE, VARIANTS } from "./variants";
 
 import FormSelection from "../FormSelection.vue";
@@ -111,8 +111,8 @@ const $emit = defineEmits(["input", "alert", "focus", "load-more", "search-chang
 
 /** Active backend search query for this parameter. Updated when the user types
  * in the dropdown's search box (debounced upstream by ``FormSelect``). Sent in
- * both ``search-change`` (replace-merge) and subsequent ``load-more``
- * (append-merge) payloads so the server keeps filtering as the user paginates. */
+ * both the ``search-change`` and the subsequent ``load-more`` payloads so the
+ * server keeps filtering as the user paginates. */
 const searchQuery = ref("");
 
 // Determines wether values should be processed as linked or unlinked
@@ -303,8 +303,7 @@ const hasMoreInCurrentSource = computed(() => {
 });
 
 /**
- * Total count of options for the current source — used to label the sentinel
- * and to compute the next page offset.
+ * Count of options loaded for the current source — used to label the sentinel.
  */
 const currentSourceLoadedCount = computed(() => {
     if (!currentSource.value) {
@@ -325,11 +324,16 @@ function onLoadMore() {
         return;
     }
     const src = currentSource.value;
-    const limit = props.optionsMeta?.[src]?.limit ?? 50;
+    const meta = props.optionsMeta?.[src];
+    const limit = meta?.limit ?? DEFAULT_OPTIONS_PAGE_SIZE;
+    // Advance the server's cursor rather than measuring ``options`` — the
+    // loaded list is a union of every page fetched so far (including pages
+    // fetched under a different search), so its length is not an offset into
+    // the currently filtered result set.
     $emit("load-more", {
         name: props.name,
         src,
-        offset: currentSourceLoadedCount.value,
+        offset: (meta?.offset ?? 0) + limit,
         limit,
         search: searchQuery.value || undefined,
     });
@@ -344,7 +348,7 @@ function onSearchChange(query: string) {
     }
     searchQuery.value = query;
     const src = currentSource.value;
-    const limit = props.optionsMeta?.[src]?.limit ?? 50;
+    const limit = props.optionsMeta?.[src]?.limit ?? DEFAULT_OPTIONS_PAGE_SIZE;
     $emit("search-change", {
         name: props.name,
         src,

--- a/client/src/components/Form/Elements/FormData/types.ts
+++ b/client/src/components/Form/Elements/FormData/types.ts
@@ -4,6 +4,13 @@
  */
 import type { FieldDict, SampleSheetColumnDefinition } from "@/api";
 
+/**
+ * Options fetched per page. Mirrors ``DEFAULT_OPTIONS_PAGE_SIZE`` in
+ * ``galaxy.tools.parameters.pagination``, which sizes the first page the
+ * server renders into a data parameter.
+ */
+export const DEFAULT_OPTIONS_PAGE_SIZE = 50;
+
 interface DatasetHash {
     hash_function: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
     hash_value: string;

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -10,6 +10,7 @@ import type { WriteStoreToPayload } from "@/api/exports";
 import type { WorkflowInvocationRequestInputs } from "@/api/invocations";
 import type { ToolIdentifier } from "@/api/tools";
 import type { DataOption } from "@/components/Form/Elements/FormData/types";
+import { DEFAULT_OPTIONS_PAGE_SIZE } from "@/components/Form/Elements/FormData/types";
 import type { FormParameterTypes } from "@/components/Form/parameterTypes";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import { useConfig } from "@/composables/config";
@@ -334,13 +335,15 @@ async function fetchStepOptions(
     }
     const type = src === "hdca" ? "dataset_collection" : "dataset";
     const extensions = (input.acceptable_extensions || []) as string[];
-    const limit = payload.limit || 50;
+    const limit = payload.limit || DEFAULT_OPTIONS_PAGE_SIZE;
     const offset = payload.offset || 0;
     try {
         const rows = await searchHistoryContents(props.model.historyId, {
             extensions,
             type,
             tag: input.tag,
+            // ``data_collection`` parameters offer hidden collections too.
+            visibleOnly: input.type !== "data_collection",
             search: payload.search,
             offset,
             limit,
@@ -391,7 +394,7 @@ function onLoadMore({
 }
 
 function onSearchChange({ name, src, query, limit }: { name: string; src: string; query: string; limit?: number }) {
-    fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query });
+    fetchStepOptions(name, src, { offset: 0, limit: limit || DEFAULT_OPTIONS_PAGE_SIZE, search: query });
 }
 
 function onStorageUpdate(objectStoreId: string, intermediate: boolean) {

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -340,6 +340,7 @@ async function fetchStepOptions(
         const rows = await searchHistoryContents(props.model.historyId, {
             extensions,
             type,
+            tag: input.tag,
             search: payload.search,
             offset,
             limit,

--- a/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
@@ -19,6 +19,7 @@
 <script>
 import { debounce } from "lodash";
 
+import { DEFAULT_OPTIONS_PAGE_SIZE } from "@/components/Form/Elements/FormData/types";
 import WorkflowIcons from "@/components/Workflow/icons";
 
 import { searchHistoryContents } from "./services";
@@ -103,7 +104,6 @@ export default {
     },
     methods: {
         onChange(data) {
-            console.log("emitting default change", data);
             this.$emit("onChange", this.model.index, data);
         },
         onValidation(validation) {
@@ -133,13 +133,15 @@ export default {
             }
             const type = src === "hdca" ? "dataset_collection" : "dataset";
             const extensions = input.acceptable_extensions || [];
-            const limit = payload.limit || 50;
+            const limit = payload.limit || DEFAULT_OPTIONS_PAGE_SIZE;
             const offset = payload.offset || 0;
             try {
                 const rows = await searchHistoryContents(this.historyId, {
                     extensions,
                     type,
                     tag: input.tag,
+                    // ``data_collection`` parameters offer hidden collections too.
+                    visibleOnly: input.type !== "data_collection",
                     search: payload.search,
                     offset,
                     limit,
@@ -175,7 +177,7 @@ export default {
             this._fetchStepOptions(name, src, { offset, limit, search });
         },
         onSearchChange({ name, src, query, limit }) {
-            this._fetchStepOptions(name, src, { offset: 0, limit: limit || 50, search: query });
+            this._fetchStepOptions(name, src, { offset: 0, limit: limit || DEFAULT_OPTIONS_PAGE_SIZE, search: query });
         },
     },
 };

--- a/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunInputStep.vue
@@ -139,6 +139,7 @@ export default {
                 const rows = await searchHistoryContents(this.historyId, {
                     extensions,
                     type,
+                    tag: input.tag,
                     search: payload.search,
                     offset,
                     limit,

--- a/client/src/components/Workflow/Run/services.js
+++ b/client/src/components/Workflow/Run/services.js
@@ -3,6 +3,8 @@
  */
 import axios from "axios";
 
+import { VALID_INPUT_DATASET_STATES } from "@/api/datasets";
+import { DEFAULT_OPTIONS_PAGE_SIZE } from "@/components/Form/Elements/FormData/types";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -36,17 +38,30 @@ export async function getRunData(workflowId, version = null, instance = false) {
  * @param {Array<string>} [opts.extensions] - sorted accept-set; empty/missing → no extension filter.
  * @param {String} [opts.type] - "dataset" | "dataset_collection".
  * @param {String} [opts.tag] - exact dataset/collection tag required by the workflow input.
+ * @param {Boolean} [opts.visibleOnly] - restrict to visible items; false for
+ *   ``data_collection`` parameters, which offer hidden collections too.
  * @param {String} [opts.search] - name substring or numeric hid match.
  * @param {Number} [opts.offset]
  * @param {Number} [opts.limit]
  */
-export async function searchHistoryContents(historyId, { extensions, type, tag, search, offset = 0, limit = 50 } = {}) {
+export async function searchHistoryContents(
+    historyId,
+    { extensions, type, tag, search, visibleOnly = true, offset = 0, limit = DEFAULT_OPTIONS_PAGE_SIZE } = {},
+) {
     const q = [];
     const qv = [];
-    q.push("visible-eq");
-    qv.push("True");
+    if (visibleOnly) {
+        q.push("visible-eq");
+        qv.push("True");
+    }
     q.push("deleted-eq");
     qv.push("False");
+    if (type !== "dataset_collection") {
+        // The server only offers datasets in an input-eligible state on the
+        // first page; without this the later pages would offer more than it did.
+        q.push("state-in");
+        qv.push(VALID_INPUT_DATASET_STATES.join(","));
+    }
     if (type) {
         q.push("history_content_type-eq");
         qv.push(type);

--- a/client/src/components/Workflow/Run/services.js
+++ b/client/src/components/Workflow/Run/services.js
@@ -35,11 +35,12 @@ export async function getRunData(workflowId, version = null, instance = false) {
  * @param {Object} opts
  * @param {Array<string>} [opts.extensions] - sorted accept-set; empty/missing → no extension filter.
  * @param {String} [opts.type] - "dataset" | "dataset_collection".
+ * @param {String} [opts.tag] - exact dataset/collection tag required by the workflow input.
  * @param {String} [opts.search] - name substring or numeric hid match.
  * @param {Number} [opts.offset]
  * @param {Number} [opts.limit]
  */
-export async function searchHistoryContents(historyId, { extensions, type, search, offset = 0, limit = 50 } = {}) {
+export async function searchHistoryContents(historyId, { extensions, type, tag, search, offset = 0, limit = 50 } = {}) {
     const q = [];
     const qv = [];
     q.push("visible-eq");
@@ -53,6 +54,10 @@ export async function searchHistoryContents(historyId, { extensions, type, searc
     if (extensions && extensions.length) {
         q.push("extension-in");
         qv.push(extensions.join(","));
+    }
+    if (tag) {
+        q.push("tag-eq");
+        qv.push(tag);
     }
     if (search) {
         const trimmed = String(search).trim();

--- a/client/src/components/Workflow/Run/services.test.js
+++ b/client/src/components/Workflow/Run/services.test.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { VALID_INPUT_DATASET_STATES } from "@/api/datasets";
+
 import { searchHistoryContents } from "./services";
 
 vi.mock("axios", () => ({
@@ -13,10 +15,25 @@ vi.mock("@/onload/loadConfig", () => ({
     getAppRoot: () => "/",
 }));
 
-describe("workflow run services", () => {
+/** ``q`` and ``qv`` are parallel arrays the backend zips positionally, so they
+ * have to be asserted zipped — asserting each independently passes even when
+ * every key is paired with the wrong value. */
+function requestFilters() {
+    const url = new URL(axios.get.mock.calls[0][0], "http://localhost");
+    const keys = url.searchParams.getAll("q");
+    const values = url.searchParams.getAll("qv");
+    expect(keys).toHaveLength(values.length);
+    return Object.fromEntries(keys.map((key, index) => [key, values[index]]));
+}
+
+function requestParams() {
+    return new URL(axios.get.mock.calls[0][0], "http://localhost").searchParams;
+}
+
+describe("searchHistoryContents", () => {
     beforeEach(() => {
-        vi.mocked(axios.get).mockReset();
-        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+        axios.get.mockReset();
+        axios.get.mockResolvedValue({ data: [] });
     });
 
     it("preserves a workflow input tag when paging history contents", async () => {
@@ -27,9 +44,49 @@ describe("workflow run services", () => {
             limit: 50,
         });
 
-        const requestUrl = new URL(vi.mocked(axios.get).mock.calls[0][0], "http://localhost");
-        expect(requestUrl.searchParams.getAll("q")).toContain("tag-eq");
-        expect(requestUrl.searchParams.getAll("qv")).toContain("genomescope_model");
-        expect(requestUrl.searchParams.get("offset")).toBe("50");
+        expect(requestFilters()).toMatchObject({
+            "tag-eq": "genomescope_model",
+            "history_content_type-eq": "dataset",
+        });
+        expect(requestParams().get("offset")).toBe("50");
+    });
+
+    it("omits the tag filter entirely when no tag is required", async () => {
+        await searchHistoryContents("history-id", { type: "dataset" });
+
+        expect(requestFilters()).not.toHaveProperty("tag-eq");
+    });
+
+    it("restricts datasets to input-eligible states", async () => {
+        await searchHistoryContents("history-id", { type: "dataset" });
+
+        expect(requestFilters()["state-in"]).toBe(VALID_INPUT_DATASET_STATES.join(","));
+    });
+
+    it("does not apply a dataset-state filter to collections", async () => {
+        await searchHistoryContents("history-id", { type: "dataset_collection" });
+
+        expect(requestFilters()).not.toHaveProperty("state-in");
+    });
+
+    it("drops the visibility filter when hidden items are offered", async () => {
+        await searchHistoryContents("history-id", { type: "dataset_collection", visibleOnly: false });
+
+        expect(requestFilters()).not.toHaveProperty("visible-eq");
+    });
+
+    it("matches a numeric query against the hid and a text query against the name", async () => {
+        await searchHistoryContents("history-id", { type: "dataset", search: "42" });
+        expect(requestFilters()).toMatchObject({ "hid-eq": "42" });
+
+        axios.get.mockClear();
+        await searchHistoryContents("history-id", { type: "dataset", search: "sample" });
+        expect(requestFilters()).toMatchObject({ "name-contains": "sample" });
+    });
+
+    it("comma-joins the accepted extensions", async () => {
+        await searchHistoryContents("history-id", { type: "dataset", extensions: ["bam", "txt"] });
+
+        expect(requestFilters()).toMatchObject({ "extension-in": "bam,txt" });
     });
 });

--- a/client/src/components/Workflow/Run/services.test.js
+++ b/client/src/components/Workflow/Run/services.test.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { searchHistoryContents } from "./services";
+
+vi.mock("axios", () => ({
+    default: {
+        get: vi.fn(),
+    },
+}));
+
+vi.mock("@/onload/loadConfig", () => ({
+    getAppRoot: () => "/",
+}));
+
+describe("workflow run services", () => {
+    beforeEach(() => {
+        vi.mocked(axios.get).mockReset();
+        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+    });
+
+    it("preserves a workflow input tag when paging history contents", async () => {
+        await searchHistoryContents("history-id", {
+            type: "dataset",
+            tag: "genomescope_model",
+            offset: 50,
+            limit: 50,
+        });
+
+        const requestUrl = new URL(vi.mocked(axios.get).mock.calls[0][0], "http://localhost");
+        expect(requestUrl.searchParams.getAll("q")).toContain("tag-eq");
+        expect(requestUrl.searchParams.getAll("qv")).toContain("genomescope_model");
+        expect(requestUrl.searchParams.get("offset")).toBe("50");
+    });
+});

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -8,13 +8,9 @@ import logging
 import re
 from typing import Optional
 
-from sqlalchemy import (
-    func,
-    sql,
-)
-
 from galaxy import model
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.model.tag_filter import build_tag_filter
 from galaxy.model.tags import GalaxyTagHandler
 from .base import (
     ModelValidator,
@@ -87,19 +83,7 @@ class TaggableFilterMixin:
                 # Unfortunately we were a little inconsistent with our naming scheme
                 class_name = "HistoryDatasetCollection"
             target_model = getattr(model, f"{class_name}TagAssociation")
-            id_column = f"{target_model.table.name.rsplit('_tag_association')[0]}_id"
-            column = target_model.table.c.user_tname + ":" + target_model.table.c.user_value
-            lower_val = val.lower()  # Ignore case
-            if op == "eq":
-                if ":" not in lower_val:
-                    # We require an exact match and the tag to look for has no user_value,
-                    # so we can't just concatenate user_tname, ':' and user_vale
-                    cond = func.lower(target_model.table.c.user_tname) == lower_val
-                else:
-                    cond = func.lower(column) == lower_val
-            else:
-                cond = func.lower(column).contains(lower_val, autoescape=True)
-            return sql.expression.and_(model_class.table.c.id == getattr(target_model.table.c, id_column), cond)
+            return build_tag_filter(model_class, target_model, op, val)
 
         return _create_tag_filter
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -166,6 +166,7 @@ from galaxy.model.item_attrs import (
     UsesAnnotations,
 )
 from galaxy.model.orm.util import add_object_to_object_session
+from galaxy.model.tag_filter import build_tag_filter
 from galaxy.objectstore import USER_OBJECTS_SCHEME
 from galaxy.objectstore.templates import (
     ObjectStoreConfiguration,
@@ -4100,12 +4101,13 @@ class History(Base, HasTags, UsesAnnotations, HasName, Serializable, UsesCreateA
         *,
         extensions: Optional[set[str]] = None,
         valid_states: Optional[tuple[str, ...]] = None,
+        tag: Optional[str] = None,
         search: Optional[str] = None,
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list["HistoryDatasetAssociation"], int]:
-        """Active, visible HDAs filtered by extension, dataset state, and an
-        optional ``search`` term, paginated.
+        """Active, visible HDAs filtered by extension, dataset state, tag,
+        and an optional ``search`` term, paginated.
 
         Returns ``(rows, total)`` where ``total`` is the count under the same WHERE
         clause. Used by data-tool-parameter ``to_dict`` to avoid loading the entire
@@ -4121,6 +4123,10 @@ class History(Base, HasTags, UsesAnnotations, HasName, Serializable, UsesCreateA
             filters.append(HistoryDatasetAssociation.extension.in_(extensions))
         if valid_states is not None:
             filters.append(HistoryDatasetAssociation.dataset.has(Dataset.state.in_(valid_states)))
+        if tag:
+            filters.append(
+                build_tag_filter(HistoryDatasetAssociation, HistoryDatasetAssociationTagAssociation, "eq", tag)
+            )
         if search:
             name_match = HistoryDatasetAssociation.name.ilike(f"%{search}%")
             if search.isdigit():
@@ -4205,17 +4211,18 @@ class History(Base, HasTags, UsesAnnotations, HasName, Serializable, UsesCreateA
         self,
         *,
         visible_only: bool = True,
+        tag: Optional[str] = None,
         search: Optional[str] = None,
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list["HistoryDatasetCollectionAssociation"], int]:
-        """Active HDCAs paginated. Pass ``visible_only=False`` to include
-        hidden collections (matches the legacy ``active_dataset_collections``
-        semantics used by some tool-form paths). ``search`` matches
-        case-insensitively against the collection name and (when numeric)
-        against the hid. Extension filtering for collections is exposed via
-        the history-contents filter parser (see
-        :py:meth:`_hdca_extensions_only_in_clause`).
+        """Active HDCAs filtered by tag and an optional ``search`` term,
+        paginated. Pass ``visible_only=False`` to include hidden collections
+        (matches the legacy ``active_dataset_collections`` semantics used by
+        some tool-form paths). ``search`` matches case-insensitively against
+        the collection name and (when numeric) against the hid. Extension
+        filtering for collections is exposed via the history-contents filter
+        parser (see :py:meth:`_hdca_extensions_only_in_clause`).
         """
         filters = [
             HistoryDatasetCollectionAssociation.history_id == self.id,
@@ -4223,6 +4230,10 @@ class History(Base, HasTags, UsesAnnotations, HasName, Serializable, UsesCreateA
         ]
         if visible_only:
             filters.append(HistoryDatasetCollectionAssociation.visible.is_(True))
+        if tag:
+            filters.append(
+                build_tag_filter(HistoryDatasetCollectionAssociation, HistoryDatasetCollectionTagAssociation, "eq", tag)
+            )
         if search:
             name_match = HistoryDatasetCollectionAssociation.name.ilike(f"%{search}%")
             if search.isdigit():

--- a/lib/galaxy/model/tag_filter.py
+++ b/lib/galaxy/model/tag_filter.py
@@ -1,0 +1,56 @@
+"""Shared tag-filter predicate, used by both the model layer's paginated
+option queries and :mod:`galaxy.managers.taggable`.
+"""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    func,
+    select,
+)
+from sqlalchemy.sql.elements import ColumnElement
+
+if TYPE_CHECKING:
+    from sqlalchemy import Table
+
+    from galaxy.model import (
+        ItemTagAssociation,
+        RepresentById,
+    )
+
+
+def build_tag_filter(
+    model_class: "type[RepresentById]",
+    tag_association_class: "type[ItemTagAssociation]",
+    op: str,
+    value: str,
+) -> "ColumnElement[bool]":
+    """Build the shared ORM predicate for filtering a tagged model.
+
+    A correlated ``EXISTS`` rather than a join predicate: one item can carry
+    several tag rows that satisfy ``condition`` at once — ``eq`` on a bare name
+    matches both ``gsm`` and ``gsm:v1`` — and a join emits that item once per
+    matching row. Callers apply ``LIMIT`` and ``COUNT`` over this predicate, so
+    duplicates would silently shorten pages and inflate totals.
+    """
+    # ``ItemTagAssociation`` is a mixin without ``table``; the concrete
+    # subclasses acquire it from the declarative base.
+    tag_table: Table = tag_association_class.table  # type: ignore[attr-defined]
+    id_column = f"{tag_table.name.rsplit('_tag_association', 1)[0]}_id"
+    tag_with_value = tag_association_class.user_tname + ":" + tag_association_class.user_value
+    lower_value = value.lower()
+    if op == "eq" and ":" not in lower_value:
+        # An exact match on a tag with no user_value: concatenating
+        # ``user_tname``, ':' and a NULL ``user_value`` would yield NULL.
+        condition = func.lower(tag_association_class.user_tname) == lower_value
+    elif op == "eq":
+        condition = func.lower(tag_with_value) == lower_value
+    else:
+        condition = func.lower(tag_with_value).contains(lower_value, autoescape=True)
+    return (
+        select(1)
+        .select_from(tag_association_class)
+        .where(getattr(tag_association_class, id_column) == model_class.id, condition)
+        .correlate_except(tag_association_class)
+        .exists()
+    )

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1888,6 +1888,7 @@ def _paginated_visible_datasets(
     *,
     extensions: Optional[set[str]],
     valid_states: Optional[tuple[str, ...]],
+    tag: Optional[str] = None,
     search: Optional[str] = None,
     offset: int = 0,
     limit: int = 50,
@@ -1908,6 +1909,7 @@ def _paginated_visible_datasets(
         history.id,
         frozenset(extensions) if extensions is not None else None,
         tuple(valid_states) if valid_states is not None else None,
+        tag or None,
         search or None,
         offset,
         limit,
@@ -1915,7 +1917,7 @@ def _paginated_visible_datasets(
     return trans.get_or_set_cache_value(
         key,
         lambda: history.paginated_active_visible_datasets(
-            extensions=extensions, valid_states=valid_states, search=search, offset=offset, limit=limit
+            extensions=extensions, valid_states=valid_states, tag=tag, search=search, offset=offset, limit=limit
         ),
     )
 
@@ -1925,23 +1927,25 @@ def _paginated_dataset_collections(
     history: "History",
     *,
     visible_only: bool,
+    tag: Optional[str] = None,
     search: Optional[str] = None,
     offset: int = 0,
     limit: int = 50,
 ) -> tuple[list[HistoryDatasetCollectionAssociation], int]:
     """``history.paginated_active_dataset_collections`` memoized on the request
     context's short-term cache (see :func:`_paginated_visible_datasets`)."""
-    key = ("data_param_hdca_page", history.id, bool(visible_only), search or None, offset, limit)
+    key = ("data_param_hdca_page", history.id, bool(visible_only), tag or None, search or None, offset, limit)
     return trans.get_or_set_cache_value(
         key,
         lambda: history.paginated_active_dataset_collections(
-            visible_only=visible_only, search=search, offset=offset, limit=limit
+            visible_only=visible_only, tag=tag, search=search, offset=offset, limit=limit
         ),
     )
 
 
 class BaseDataToolParameter(ToolParameter):
     multiple: bool
+    tag: Optional[str]
 
     # Sentinel distinguishing "cache not yet populated" from "cache populated
     # with None" (which is a legitimate return for parameters with no formats).
@@ -2068,6 +2072,7 @@ class BaseDataToolParameter(ToolParameter):
                         history,
                         extensions=self._acceptable_extensions(),
                         valid_states=dataset_matcher_factory.valid_input_states,
+                        tag=self.tag,
                         offset=db_offset,
                         limit=chunk_size,
                     )
@@ -2089,6 +2094,7 @@ class BaseDataToolParameter(ToolParameter):
                         trans,
                         history,
                         visible_only=True,
+                        tag=self.tag,
                         offset=db_offset,
                         limit=chunk_size,
                     )
@@ -2655,6 +2661,7 @@ class DataToolParameter(BaseDataToolParameter):
                 history,
                 extensions=acceptable_extensions,
                 valid_states=valid_states,
+                tag=self.tag,
                 search=hda_search,
                 offset=offset,
                 limit=limit,
@@ -2761,7 +2768,7 @@ class DataToolParameter(BaseDataToolParameter):
 
         def hdca_query(*, offset, limit):
             return _paginated_dataset_collections(
-                trans, history, visible_only=True, search=hdca_search, offset=offset, limit=limit
+                trans, history, visible_only=True, tag=self.tag, search=hdca_search, offset=offset, limit=limit
             )
 
         def hdca_filter(hdca):
@@ -2991,7 +2998,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
 
         def hdca_query(*, offset, limit):
             return _paginated_dataset_collections(
-                trans, history, visible_only=False, search=hdca_search, offset=offset, limit=limit
+                trans, history, visible_only=False, tag=self.tag, search=hdca_search, offset=offset, limit=limit
             )
 
         def hdca_filter(hdca):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -65,6 +65,7 @@ from galaxy.tool_util_models.tool_source import DrillDownOptionsDict
 from galaxy.tools.parameters.options import ParameterOption
 from galaxy.tools.parameters.pagination import (
     DataOptionsBuilder,
+    DEFAULT_OPTIONS_PAGE_SIZE,
     make_dce_entry,
     make_hda_entry,
     make_hdca_entry,
@@ -1891,7 +1892,7 @@ def _paginated_visible_datasets(
     tag: Optional[str] = None,
     search: Optional[str] = None,
     offset: int = 0,
-    limit: int = 50,
+    limit: int = DEFAULT_OPTIONS_PAGE_SIZE,
 ) -> tuple[list[HistoryDatasetAssociation], int]:
     """``history.paginated_active_visible_datasets`` memoized on the request.
 
@@ -1930,7 +1931,7 @@ def _paginated_dataset_collections(
     tag: Optional[str] = None,
     search: Optional[str] = None,
     offset: int = 0,
-    limit: int = 50,
+    limit: int = DEFAULT_OPTIONS_PAGE_SIZE,
 ) -> tuple[list[HistoryDatasetCollectionAssociation], int]:
     """``history.paginated_active_dataset_collections`` memoized on the request
     context's short-term cache (see :func:`_paginated_visible_datasets`)."""

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -1,4 +1,5 @@
 import json
+from functools import partial
 from typing import Literal
 from uuid import uuid4
 
@@ -6,6 +7,7 @@ import yaml
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
+from galaxy.tools.parameters.pagination import DEFAULT_OPTIONS_PAGE_SIZE
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_LIST_PAIRED_MAPPED_OVER_PAIRED,
@@ -131,7 +133,9 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
             history_id,
             [{"src": "pasted", "paste_content": "y", "name": legacy_sentinel}],
         )
-        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.dataset_populator.fetch_hdas(
+            history_id, [{"src": "pasted", "paste_content": "x"}] * (DEFAULT_OPTIONS_PAGE_SIZE + 10)
+        )
         self.home()
         # A single cat1 step with no workflow-level inputs — the step's
         # ``input1`` is unconnected, so it renders as a dropdown the user
@@ -146,7 +150,9 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
         self.sleep_for(self.wait_types.UX_RENDER)
         baseline_options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-        assert len(baseline_options) == 50, f"Expected default page to contain 50 options, got {len(baseline_options)}"
+        assert (
+            len(baseline_options) == DEFAULT_OPTIONS_PAGE_SIZE
+        ), f"Expected the default page to contain {DEFAULT_OPTIONS_PAGE_SIZE} options, got {len(baseline_options)}"
         baseline_labels = [opt.text for opt in baseline_options]
         assert all(legacy_sentinel not in label for label in baseline_labels), baseline_labels
         search_input = select_field.find_element(By.CSS_SELECTOR, "input.multiselect__input")
@@ -172,22 +178,27 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         input tree kept rendering the first 50 options.
         """
         history_id = self.current_history_id()
-        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.dataset_populator.fetch_hdas(
+            history_id, [{"src": "pasted", "paste_content": "x"}] * (DEFAULT_OPTIONS_PAGE_SIZE + 10)
+        )
         self.home()
         self.workflow_run_open_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.workflow_run_ensure_expanded()
         select_field = self.components.workflow_run.input_data_div(label="input1").wait_for_visible()
         select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
         self.sleep_for(self.wait_types.UX_RENDER)
-        assert len(select_field.find_elements(By.CSS_SELECTOR, "[role='option']")) == 50
+        assert len(select_field.find_elements(By.CSS_SELECTOR, "[role='option']")) == DEFAULT_OPTIONS_PAGE_SIZE
 
-        @retry_assertion_during_transitions
+        # The default ~1s budget has to cover an IntersectionObserver firing,
+        # an HTTP round-trip and a re-render; widen it so loaded CI is not a
+        # false red.
+        @partial(retry_assertion_during_transitions, attempts=30, sleep=0.2)
         def assert_more_options_loaded():
-            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
-            if sentinels:
-                self.scroll_into_view(sentinels[0])
+            self.scroll_into_view(select_field.find_element(By.CSS_SELECTOR, ".form-data-load-more-sentinel"))
             options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-            assert len(options) > 50, f"Expected the dropdown to append a second page, got {len(options)} options"
+            assert (
+                len(options) > DEFAULT_OPTIONS_PAGE_SIZE
+            ), f"Expected the dropdown to append a second page, got {len(options)} options"
 
         assert_more_options_loaded()
 
@@ -195,7 +206,9 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
     def test_workflow_run_pagination_simplified_form(self):
         """Scrolling a simplified workflow-run dropdown appends its second page."""
         history_id = self.current_history_id()
-        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.dataset_populator.fetch_hdas(
+            history_id, [{"src": "pasted", "paste_content": "x"}] * (DEFAULT_OPTIONS_PAGE_SIZE + 10)
+        )
         # Sentinel for positive lower-bound (see legacy-form test).
         simplified_sentinel = "unique-simplified-sentinel"
         self.dataset_populator.fetch_hdas(
@@ -224,21 +237,24 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         select_field.find_element(By.CSS_SELECTOR, ".multiselect__select").click()
         self.sleep_for(self.wait_types.UX_RENDER)
         options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-        assert len(options) == 50, f"Expected the first page to contain 50 options, got {len(options)}"
+        assert (
+            len(options) == DEFAULT_OPTIONS_PAGE_SIZE
+        ), f"Expected the first page to contain {DEFAULT_OPTIONS_PAGE_SIZE} options, got {len(options)}"
         # Positive lower-bound: the sentinel HDA is newest (hid=61) so it must
         # appear in the first page of options. Without this the ``<= 50`` upper
         # bound passes vacuously on an empty dropdown.
         labels = [opt.text for opt in options]
         assert any(simplified_sentinel in label for label in labels), labels
 
-        @retry_assertion_during_transitions
+        # The default ~1s budget has to cover an IntersectionObserver firing,
+        # an HTTP round-trip and a re-render; widen it so loaded CI is not a
+        # false red.
+        @partial(retry_assertion_during_transitions, attempts=30, sleep=0.2)
         def assert_more_options_loaded():
-            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
-            if sentinels:
-                self.scroll_into_view(sentinels[0])
+            self.scroll_into_view(select_field.find_element(By.CSS_SELECTOR, ".form-data-load-more-sentinel"))
             loaded_options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
             assert (
-                len(loaded_options) > 50
+                len(loaded_options) > DEFAULT_OPTIONS_PAGE_SIZE
             ), f"Expected the simplified dropdown to append a second page, got {len(loaded_options)} options"
 
         assert_more_options_loaded()
@@ -820,7 +836,9 @@ steps: {}
         # tag predicate must be applied before pagination; filtering the first
         # generic page in FormData would otherwise leave this required input
         # empty even though a matching dataset exists in the history.
-        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.dataset_populator.fetch_hdas(
+            history_id, [{"src": "pasted", "paste_content": "x"}] * (DEFAULT_OPTIONS_PAGE_SIZE + 10)
+        )
         workflow_id, workflow_name = self._create_workflow_with_unique_name(WORKFLOW_WITH_DATA_TAG_FILTER, "ga")
         self.workflow_run_with_name(workflow_name)
         self.workflow_run_submit()

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -816,8 +816,11 @@ steps: {}
         history_id = self.current_history_id()
         dataset = self.dataset_populator.new_dataset(history_id, wait=True)
         self.dataset_populator.tag_dataset(history_id, dataset["id"], tags=["genomescope_model"])
-        # Add another possible input that should not be selected
-        self.dataset_populator.new_dataset(history_id, wait=True)
+        # Push the tagged dataset beyond the first 50 datatype matches. The
+        # tag predicate must be applied before pagination; filtering the first
+        # generic page in FormData would otherwise leave this required input
+        # empty even though a matching dataset exists in the history.
+        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
         workflow_id, workflow_name = self._create_workflow_with_unique_name(WORKFLOW_WITH_DATA_TAG_FILTER, "ga")
         self.workflow_run_with_name(workflow_name)
         self.workflow_run_submit()

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -194,11 +194,17 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         # false red.
         @partial(retry_assertion_during_transitions, attempts=30, sleep=0.2)
         def assert_more_options_loaded():
-            self.scroll_into_view(select_field.find_element(By.CSS_SELECTOR, ".form-data-load-more-sentinel"))
+            # The sentinel renders only while the server reports has_more, so it
+            # unmounts once the last page lands. Scroll it if it is still there,
+            # and report its absence in the message rather than requiring it.
+            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
+            if sentinels:
+                self.scroll_into_view(sentinels[0])
             options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-            assert (
-                len(options) > DEFAULT_OPTIONS_PAGE_SIZE
-            ), f"Expected the dropdown to append a second page, got {len(options)} options"
+            assert len(options) > DEFAULT_OPTIONS_PAGE_SIZE, (
+                f"Expected the dropdown to append a second page, got {len(options)} options "
+                f"(load-more sentinel present: {bool(sentinels)})"
+            )
 
         assert_more_options_loaded()
 
@@ -251,11 +257,17 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         # false red.
         @partial(retry_assertion_during_transitions, attempts=30, sleep=0.2)
         def assert_more_options_loaded():
-            self.scroll_into_view(select_field.find_element(By.CSS_SELECTOR, ".form-data-load-more-sentinel"))
+            # The sentinel renders only while the server reports has_more, so it
+            # unmounts once the last page lands. Scroll it if it is still there,
+            # and report its absence in the message rather than requiring it.
+            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
+            if sentinels:
+                self.scroll_into_view(sentinels[0])
             loaded_options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
-            assert (
-                len(loaded_options) > DEFAULT_OPTIONS_PAGE_SIZE
-            ), f"Expected the simplified dropdown to append a second page, got {len(loaded_options)} options"
+            assert len(loaded_options) > DEFAULT_OPTIONS_PAGE_SIZE, (
+                f"Expected the simplified dropdown to append a second page, got {len(loaded_options)} options "
+                f"(load-more sentinel present: {bool(sentinels)})"
+            )
 
         assert_more_options_loaded()
 

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -8,6 +8,7 @@ import pytest
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.tools.parameters.basic import ParameterValueError
+from galaxy.tools.parameters.pagination import DEFAULT_OPTIONS_PAGE_SIZE
 from .util import BaseParameterTestCase
 
 
@@ -194,14 +195,16 @@ class TestDataToolParameter(BaseParameterTestCase):
         # Stub the paginated query helper used by ``DataToolParameter.to_dict``.
         # The fakes mock ``find_conversion_destination`` at the HDA level rather
         # than at the datatypes-registry level, so we deliberately ignore the
-        # SQL ``extensions``/``valid_states`` filters here and return all
-        # visible HDAs — the matcher path then exercises the per-HDA mocked
+        # SQL ``extensions``/``valid_states``/``tag`` filters here and return
+        # all visible HDAs — the matcher path then exercises the per-HDA mocked
         # conversion logic. We sort by ``hid`` descending to mirror the real
         # query's ordering (newest-first), which ``get_initial_value`` relies
         # on to pick the most recent matching HDA.
         visible_desc = sorted(visible, key=lambda h: h.hid, reverse=True)
 
-        def _paginated(*, extensions=None, valid_states=None, search=None, offset=0, limit=50):
+        def _paginated(
+            *, extensions=None, valid_states=None, tag=None, search=None, offset=0, limit=DEFAULT_OPTIONS_PAGE_SIZE
+        ):
             return visible_desc[offset : offset + limit], len(visible_desc)
 
         self.test_history.paginated_active_visible_datasets = _paginated  # type: ignore[method-assign]

--- a/test/unit/data/model/test_history_option_pagination.py
+++ b/test/unit/data/model/test_history_option_pagination.py
@@ -1,0 +1,136 @@
+import pytest
+
+from galaxy import model
+
+# The pagination filters must be applied in SQL, before the page is cut. Seeding
+# more items than this proves it: a filter applied to an already-limited page
+# would leave the tagged item out of the result entirely.
+PAGE_LIMIT = 50
+SEEDED_ITEMS = PAGE_LIMIT + 11
+
+
+@pytest.fixture(scope="module")
+def init_model(engine):
+    model.mapper_registry.metadata.create_all(engine)
+
+
+def test_paginated_active_visible_datasets_filters_tag_before_limit(session, make_history):
+    history = make_history()
+    tagged_hda = _add_hda(session, history, hid=1, name="tagged", tag="genomescope_model")
+    for hid in range(2, SEEDED_ITEMS + 1):
+        _add_hda(session, history, hid=hid, name=f"untagged-{hid}")
+    session.commit()
+
+    rows, total = history.paginated_active_visible_datasets(
+        extensions={"txt"},
+        valid_states=(model.Dataset.states.OK,),
+        tag="genomescope_model",
+        limit=PAGE_LIMIT,
+    )
+
+    assert total == 1
+    assert rows == [tagged_hda]
+
+
+def test_paginated_active_dataset_collections_filters_tag_before_limit(session, make_history):
+    history = make_history()
+    tagged_hdca = _add_hdca(session, history, hid=1, name="tagged", tag="genomescope_params")
+    for hid in range(2, SEEDED_ITEMS + 1):
+        _add_hdca(session, history, hid=hid, name=f"untagged-{hid}")
+    session.commit()
+
+    rows, total = history.paginated_active_dataset_collections(
+        tag="genomescope_params",
+        limit=PAGE_LIMIT,
+    )
+
+    assert total == 1
+    assert rows == [tagged_hdca]
+
+
+def test_paginated_active_visible_datasets_multi_tag_match_does_not_shorten_page(session, make_history):
+    history = make_history()
+    # ``gsm`` matches both of the newer dataset's tag rows.
+    newest = _add_hda(session, history, hid=2, name="double-tagged", tag="gsm")
+    _append_tag(newest, model.HistoryDatasetAssociationTagAssociation, "gsm", "v1")
+    older = _add_hda(session, history, hid=1, name="single-tagged", tag="gsm")
+    session.commit()
+
+    rows, total = history.paginated_active_visible_datasets(tag="gsm", limit=2)
+
+    assert total == 2
+    assert rows == [newest, older]
+
+
+def test_paginated_active_dataset_collections_multi_tag_match_does_not_shorten_page(session, make_history):
+    history = make_history()
+    newest = _add_hdca(session, history, hid=2, name="double-tagged", tag="gsp")
+    _append_tag(newest, model.HistoryDatasetCollectionTagAssociation, "gsp", "v1")
+    older = _add_hdca(session, history, hid=1, name="single-tagged", tag="gsp")
+    session.commit()
+
+    rows, total = history.paginated_active_dataset_collections(tag="gsp", limit=2)
+
+    assert total == 2
+    assert rows == [newest, older]
+
+
+def test_paginated_active_visible_datasets_tag_eq_matches_name_with_any_value(session, make_history):
+    history = make_history()
+    valueless = _add_hda(session, history, hid=1, name="valueless", tag="gsm")
+    valued = _add_hda(session, history, hid=2, name="valued", tag="gsm", tag_value="v1")
+    _add_hda(session, history, hid=3, name="other", tag="unrelated")
+    session.commit()
+
+    rows, total = history.paginated_active_visible_datasets(tag="gsm", limit=PAGE_LIMIT)
+
+    assert total == 2
+    assert rows == [valued, valueless]
+
+
+def test_paginated_active_visible_datasets_tag_eq_with_value_matches_that_value_only(session, make_history):
+    history = make_history()
+    _add_hda(session, history, hid=1, name="valueless", tag="gsm")
+    valued = _add_hda(session, history, hid=2, name="valued", tag="gsm", tag_value="v1")
+    session.commit()
+
+    rows, total = history.paginated_active_visible_datasets(tag="gsm:v1", limit=PAGE_LIMIT)
+
+    assert total == 1
+    assert rows == [valued]
+
+
+def _append_tag(item, tag_association_class, name, value):
+    item.tags.append(tag_association_class(user_tname=name, user_value=value, value=value))
+
+
+def _add_hda(session, history, *, hid, name, tag=None, tag_value=None):
+    dataset = model.Dataset(state=model.Dataset.states.OK)
+    hda = model.HistoryDatasetAssociation(
+        dataset=dataset,
+        history=history,
+        hid=hid,
+        name=name,
+        extension="txt",
+        visible=True,
+        deleted=False,
+    )
+    if tag:
+        _append_tag(hda, model.HistoryDatasetAssociationTagAssociation, tag, tag_value)
+    session.add(hda)
+    return hda
+
+
+def _add_hdca(session, history, *, hid, name, tag=None, tag_value=None):
+    hdca = model.HistoryDatasetCollectionAssociation(
+        collection=model.DatasetCollection(collection_type="list"),
+        history=history,
+        hid=hid,
+        name=name,
+        visible=True,
+        deleted=False,
+    )
+    if tag:
+        _append_tag(hdca, model.HistoryDatasetCollectionTagAssociation, tag, tag_value)
+    session.add(hdca)
+    return hdca


### PR DESCRIPTION
Follow-up to #23384, which paginated the workflow run form's data dropdowns. Reviewing that work surfaced four bugs where the paginated option list can hide a dataset the user needs, or offer one the form will reject.

## Tagged inputs: items could drop off a page entirely

`build_tag_filter` expressed the tag join as a `WHERE` predicate against the tag-association table. An item can satisfy that predicate through more than one tag row — an exact match on a bare name matches both `gsm` and `gsm:v1`, an ordinary tagging pattern — so the item came back once per matching row.

The page limit applies in SQL; deduplication happens afterwards in Python. So the duplicates ate into the page. With two matching datasets and `limit=2`:

```
raw SQL rows (pre-dedup): [(1,'single-tagged'), (2,'double-tagged'), (2,'double-tagged')]
rows : ['double-tagged']   len 1     <- 'single-tagged' gone
total: 3                             <- COUNT has no DISTINCT; actual is 2
```

The short page then reads as `has_more: false` on the client, so page 2 is never requested and the missing dataset is unreachable. Rebuilt as a correlated `EXISTS`, which yields one row per item by construction and fixes the page and the count together. The predicate is shared with `TaggableFilterMixin`, whose queries paginate too, so history-contents tag filtering gets the same fix.

## Search results were skipped

Typing a query and then scrolling asked the server for the wrong page, so a block of matches was never fetched. The next offset came from how many options the client had loaded, which is the right cursor only if those options are exactly the current search's results. Since a search merges its matches into the already-loaded list rather than replacing it, the count runs ahead of the server's position in the filtered results, and the gap grows with each further search. The cursor now comes from `options_meta`.

## Later pages offered datasets the form would reject

The server puts only datasets in an input-eligible state on the first page (`Dataset.valid_input_states`), but the client's paging request carried no state filter, so scrolling surfaced errored and discarded datasets. Selecting one failed at submit.

## Hidden collections vanished after the first page

`data_collection` parameters are served with `visible_only=False`; the client always asked for visible items only.

## Tests

- Regression tests for the tag fan-out on both the HDA and HDCA paths, plus the previously untested `eq`-with-value and value-less branches of `build_tag_filter`. Verified they fail against the old join form (`assert 3 == 2`).
- The history-contents query is now asserted as zipped `q`/`qv` pairs. The backend pairs them positionally, so the previous per-list assertions passed even when every key carried the wrong value — confirmed by deliberately mis-pairing them.
- #23384 added a `tag` keyword that broke the pagination stub in `test_data_parameters.py`, failing 9 tests. It went unnoticed because that commit never reached CI. Fixed; that file is back to 20/20.
- Longer retry budget on the load-more selenium assertions, whose ~1s default has to cover an IntersectionObserver, a request and a re-render, and a missing sentinel now fails by name instead of silently skipping the scroll.

## Checked locally

`ruff`/`black`/`isort` clean; `cd lib && mypy . ../test` back to the 13 pre-existing unrelated errors. 361 Python unit tests pass across `test/unit/data/model/` and `test_data_parameters.py`. Client eslint/prettier/`vue-tsc` clean; vitest went 21 → 27 passing against an unchanged baseline of failures. The selenium changes are syntax- and import-checked only.
