### PR TITLE
Stop exposing flat nested inputs in workflow when expressions

### DIFF
--- a/doc/source/releases/26.2_announce.rst
+++ b/doc/source/releases/26.2_announce.rst
@@ -4,3 +4,12 @@
 ===========================================================
 26.2 Galaxy Release
 ===========================================================
+
+Workflow expression compatibility
+=================================
+
+Workflow ``when`` expressions no longer expose connected nested tool inputs
+through Galaxy's internal pipe-prefixed connection names (for example,
+``inputs["cond|param"]``). Use the nested tool-state form instead, such as
+``inputs.cond.param`` or ``inputs["cond"]["param"]``. Ordinary top-level inputs
+and extra expression inputs such as ``inputs.when`` remain unchanged.

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -3117,25 +3117,23 @@ class ToolModule(WorkflowModule):
                 extra_step_state = {}
                 for step_input in step.inputs:
                     step_input_name = step_input.name
-                    input_in_execution_state = step_input_name not in execution_state.inputs
-                    if input_in_execution_state:
-                        if step_input_name in all_inputs_by_name:
-                            if iteration_elements and step_input_name in iteration_elements:  # noqa: B023
-                                value = iteration_elements[step_input_name]  # noqa: B023
-                            else:
-                                value = progress.replacement_for_input(trans, step, all_inputs_by_name[step_input_name])
-                            # TODO: only do this for values... is everything with a default
-                            # this way a field parameter? I guess not?
-                            extra_step_state[step_input_name] = value
-                        # Might be needed someday...
-                        # elif step_input.default_value_set:
-                        #    extra_step_state[step_input_name] = step_input.default_value
+                    if step_input_name in execution_state.inputs:
+                        continue
+                    if step_input_name in all_inputs_by_name:
+                        if step_input_name and "|" in step_input_name:
+                            # Nested tool inputs have flat connection names but are already represented
+                            # by their nested shape in the execution state.
+                            continue
+                        if iteration_elements and step_input_name in iteration_elements:  # noqa: B023
+                            value = iteration_elements[step_input_name]  # noqa: B023
                         else:
-                            if iteration_elements and step_input_name in iteration_elements:  # noqa: B023
-                                value = iteration_elements[step_input_name]  # noqa: B023
-                            else:
-                                value = progress.replacement_for_connection(step_input.connections[0], is_data=True)
-                            extra_step_state[step_input_name] = value
+                            value = progress.replacement_for_input(trans, step, all_inputs_by_name[step_input_name])
+                    else:
+                        if iteration_elements and step_input_name in iteration_elements:  # noqa: B023
+                            value = iteration_elements[step_input_name]  # noqa: B023
+                        else:
+                            value = progress.replacement_for_connection(step_input.connections[0], is_data=True)
+                    extra_step_state[step_input_name] = value
 
                 if when_value is not False:
                     when_value = evaluate_value_from_expressions(

--- a/lib/galaxy_test/workflow/when_expression_nested_tool_inputs.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/when_expression_nested_tool_inputs.gxwf-tests.yml
@@ -1,0 +1,16 @@
+- doc: Nested dot and bracket access work when an optional input is omitted.
+  job: {}
+  outputs:
+    out:
+      asserts:
+        has_line:
+          line: okay
+- doc: Nested dot and bracket access work when an optional input is supplied.
+  job:
+    optional_text: supplied
+    expected: supplied
+  outputs:
+    out:
+      asserts:
+        has_line:
+          line: okay

--- a/lib/galaxy_test/workflow/when_expression_nested_tool_inputs.gxwf.yml
+++ b/lib/galaxy_test/workflow/when_expression_nested_tool_inputs.gxwf.yml
@@ -1,0 +1,31 @@
+class: GalaxyWorkflow
+doc: |
+  Ensure workflow when expressions expose connected tool parameters only in
+  their tool-state shape while preserving genuine extra expression inputs.
+inputs:
+  optional_text:
+    type: text
+    optional: true
+  gate:
+    type: boolean
+    default: true
+  expected:
+    type: text
+    default: fdefault
+outputs:
+  out:
+    outputSource: inputs_as_json/out_file1
+steps:
+  inputs_as_json:
+    tool_id: inputs_as_json
+    state:
+      test_case: 0
+      cond:
+        cond_test: first
+    in:
+      cond|more_text: optional_text
+      booltest: gate
+      when: gate
+      probe: gate
+      expected: expected
+    when: $(inputs.when && inputs.probe && inputs.booltest === inputs["booltest"] && inputs.cond.more_text === inputs["cond"]["more_text"] && inputs.cond.more_text === inputs.expected && !("cond|more_text" in inputs))


### PR DESCRIPTION
<!-- Suggested title: Stop exposing flat nested inputs in workflow when expressions -->

Galaxy builds the `inputs` object for workflow `when` expressions from tool execution state plus extra step connections. A parameter nested inside a tool conditional is available in its natural nested shape, `inputs.cond.param`, but Galaxy also exposes the same value under the workflow editor's internal flattened connection name, `inputs["cond|param"]`. That second spelling is an implementation detail escaping into a public expression API: it is undocumented, the editor cannot generate it, and it appears nowhere in the public Galaxy, IWC, GTN, or gxformat2 workflow corpora. This PR removes it, leaving one supported way to reach a nested input. That matters now because upcoming editor work needs to generate and read back these expressions, which is only tractable if each value has a single canonical path.

So, of these three spellings, the third stops resolving:

```javascript
inputs.cond.param
inputs["cond"]["param"]
inputs["cond|param"]
```

This PR stops copying recognized nested tool inputs into the expression context under their pipe-prefixed aliases. It preserves:

- nested dot and chained-bracket access;
- ordinary top-level inputs; and
- genuine extra expression inputs such as the conventional `inputs.when` boolean and arbitrary probe connections.

The new framework-workflow fixture exercises both supplied and omitted optional nested inputs. It also verifies, in the same expression, that dot and chained-bracket access agree, top-level and extra inputs remain available, and the flat nested alias is absent.

This is an intentional compatibility change for hand-authored private workflows that use `inputs["cond|param"]`. The supported replacement is `inputs.cond.param` or `inputs["cond"]["param"]`; the release note calls this out.

Closes #23333.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

The focused framework-workflow test can be run with:

```shell
pytest lib/galaxy_test/workflow/test_framework_workflows.py \
    -k when_expression_nested_tool_inputs -m workflow
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
