### PR TITLE
Fix Extract Genomic DNA custom-sequence branch under Python 3

### DIFF
--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -29,11 +29,6 @@ from galaxy.datatypes.util import gff_util
 from galaxy.tools.util.galaxyops import parse_cols_arg
 
 
-def stop_err(msg):
-    sys.stderr.write(msg)
-    sys.exit(1)
-
-
 def reverse_complement(s):
     complement_dna = {
         "A": "T",
@@ -139,12 +134,12 @@ def __main__():
             if returncode != 0:
                 raise Exception(stderr)
         except Exception as e:
-            stop_err("Error running faToTwoBit. " + str(e))
+            sys.exit("Error running faToTwoBit. " + str(e))
     else:
         seq_path = check_seq_file(dbkey, GALAXY_DATA_INDEX_DIR)
         if not os.path.exists(seq_path):
             # If this occurs, we need to fix the metadata validator.
-            stop_err("No sequences are available for '%s', request them by reporting this error." % dbkey)
+            sys.exit("No sequences are available for '%s', request them by reporting this error." % dbkey)
 
     #
     # Fetch sequences.

--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -31,7 +31,7 @@ from galaxy.tools.util.galaxyops import parse_cols_arg
 
 def stop_err(msg):
     sys.stderr.write(msg)
-    sys.exit()
+    sys.exit(1)
 
 
 def reverse_complement(s):
@@ -122,16 +122,18 @@ def __main__():
 
             # Get stderr, allowing for case where it's very large.
             tmp_stderr = open(tmp_name, "rb")
-            stderr = ""
+            chunks = []
             buffsize = 1048576
             try:
                 while True:
-                    stderr += tmp_stderr.read(buffsize)
-                    if not stderr or len(stderr) % buffsize != 0:
+                    chunk = tmp_stderr.read(buffsize)
+                    if not chunk:
                         break
+                    chunks.append(chunk)
             except OverflowError:
                 pass
             tmp_stderr.close()
+            stderr = b"".join(chunks).decode(errors="replace")
 
             # Error checking.
             if returncode != 0:


### PR DESCRIPTION
Two bugs in `tools/extract/extract_genomic_dna.py`, both on the branch taken when the reference is supplied **from the history** (`index_source=history`) rather than from a cached genome.

### 1. `TypeError` on every run of this branch

stderr from `faToTwoBit` is read from a file opened in binary mode but accumulated into a `str`:

```python
tmp_stderr = open(tmp_name, "rb")
stderr = ""
...
    stderr += tmp_stderr.read(buffsize)      # str + bytes
```

This raises on the *first* iteration — including when `faToTwoBit` succeeded, because reading an empty file still returns `b""`. So the branch fails unconditionally. `TypeError` isn't caught by the inner `except OverflowError`, so it reaches the outer handler and is reported as:

```
Error running faToTwoBit. can only concatenate str (not "bytes") to str
```

which replaces whatever `faToTwoBit` actually said.

### 2. The tool exits 0 while failing

```python
def stop_err(msg):
    sys.stderr.write(msg)
    sys.exit()          # exits 0
```

So the tool reports success, writes an error to stderr, and produces no output file. Galaxy only flags it through stderr-content detection.

### Fix

Accumulate the chunks as `bytes` and decode once at the end — this keeps the existing "allow for very large stderr" intent and the `OverflowError` guard — and use `sys.exit(1)`.

Worth flagging: the `stop_err` change affects the other callers in this file too, e.g. the `No sequences are available for '%s'` path, which also exited 0 previously. That is the intended behaviour but it will surface failures that were silent before.

### Verification

Run against the real tool with `faToTwoBit` stubbed both ways:

**faToTwoBit fails**

```
before:  exit 0   Error running faToTwoBit. can only concatenate str (not "bytes") to str
after:   exit 1   Error running faToTwoBit. faToTwoBit: cannot open input file
```

**faToTwoBit succeeds**

```
before:  exit 0   same TypeError, no output file written
after:   exit 0   >mm9_chr1_10_40_+ f1
                  GTACGTACGTACGTACGTACGTACGTACGT
```

Correct coordinates and sequence for the supplied reference. `ruff check` and `black --check` are clean.

### Why this wasn't caught

Tests 6 and 7 in `extract_genomic_dna.xml` do cover this branch, but the tool is not listed in `lib/galaxy/config/sample/tool_conf.xml.sample`, which is the panel `run_tests.sh --main_tools` loads, nor in `test/functional/tools/samples_tool_conf.xml`. So its tests never run in CI. Found instead by an external harness that drives each tool's own XML tests directly, where this tool failed 7/7 — 5 on the cached branch for an unrelated reference-data reason, and these 2 on the history branch.