### PR TITLE
Skip push-triggered CI on galaxyproject outside dev and release_* branches

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -1,6 +1,9 @@
 name: API tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -27,6 +27,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -1,9 +1,6 @@
 name: API tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/cff-validator.yaml
+++ b/.github/workflows/cff-validator.yaml
@@ -12,6 +12,11 @@ permissions: {}
 
 jobs:
   validate-citation-cff:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cff-validator.yaml
+++ b/.github/workflows/cff-validator.yaml
@@ -2,6 +2,9 @@ name: Validate CITATION.cff
 
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - "CITATION.cff"
   pull_request:

--- a/.github/workflows/cff-validator.yaml
+++ b/.github/workflows/cff-validator.yaml
@@ -2,9 +2,6 @@ name: Validate CITATION.cff
 
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - "CITATION.cff"
   pull_request:

--- a/.github/workflows/client-api-test.yaml
+++ b/.github/workflows/client-api-test.yaml
@@ -1,9 +1,6 @@
 name: Client API Testing
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - 'client/packages/api-client/**'
       - 'client/pnpm-workspace.yaml'

--- a/.github/workflows/client-api-test.yaml
+++ b/.github/workflows/client-api-test.yaml
@@ -20,6 +20,11 @@ concurrency:
 permissions: {}
 jobs:
   client-api-test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/.github/workflows/client-api-test.yaml
+++ b/.github/workflows/client-api-test.yaml
@@ -1,6 +1,9 @@
 name: Client API Testing
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - 'client/packages/api-client/**'
       - 'client/pnpm-workspace.yaml'

--- a/.github/workflows/client-unit.yaml
+++ b/.github/workflows/client-unit.yaml
@@ -1,9 +1,6 @@
 name: Client Unit Testing
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - 'client/**'
       - '.github/workflows/client-unit.yaml'

--- a/.github/workflows/client-unit.yaml
+++ b/.github/workflows/client-unit.yaml
@@ -1,6 +1,9 @@
 name: Client Unit Testing
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - 'client/**'
       - '.github/workflows/client-unit.yaml'

--- a/.github/workflows/client-unit.yaml
+++ b/.github/workflows/client-unit.yaml
@@ -14,6 +14,11 @@ concurrency:
 permissions: {}
 jobs:
   client-unit-test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -21,6 +21,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -1,6 +1,9 @@
 name: Converter tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -1,9 +1,6 @@
 name: Converter tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -1,9 +1,6 @@
 name: CWL conformance
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -1,6 +1,9 @@
 name: CWL conformance
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -1,9 +1,6 @@
 name: Database indexes
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -1,6 +1,9 @@
 name: Database indexes
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -21,6 +21,11 @@ defaults:
 permissions: {}
 jobs:
   check:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Check database indexes
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,11 @@ concurrency:
 permissions: {}
 jobs:
   build:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,9 @@
 name: Build docs
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,6 @@
 name: Build docs
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -1,9 +1,6 @@
 name: first startup
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -1,6 +1,9 @@
 name: first startup
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -18,8 +18,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Startup test
     needs: build-client
     runs-on: ubuntu-latest

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -1,9 +1,6 @@
 name: Tool framework tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -1,6 +1,9 @@
 name: Tool framework tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -24,6 +24,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -1,9 +1,6 @@
 name: Workflow framework tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -1,6 +1,9 @@
 name: Workflow framework tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -25,6 +25,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -26,6 +26,11 @@ concurrency:
 permissions: {}
 jobs:
   prepare-mulled-cache:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Prepare mulled resolution cache
     runs-on: ubuntu-latest
     steps:
@@ -74,6 +79,11 @@ jobs:
           retention-days: 1
 
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     needs: prepare-mulled-cache
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,6 +1,9 @@
 name: Integration
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,9 +1,6 @@
 name: Integration
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,9 +1,6 @@
 name: Integration Selenium
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,6 +1,9 @@
 name: Integration Selenium
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -29,8 +29,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     needs: [build-client]
     runs-on: ubuntu-latest

--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -1,6 +1,9 @@
 name: Client linting
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - 'client/**'
       - '.github/workflows/js_lint.yaml'

--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -1,9 +1,6 @@
 name: Client linting
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - 'client/**'
       - '.github/workflows/js_lint.yaml'

--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -14,6 +14,11 @@ concurrency:
 permissions: {}
 jobs:
   client-unit-test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,6 @@
 name: Python linting
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - '**.py'
       - '.github/workflows/lint.yaml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 name: Python linting
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - '**.py'
       - '.github/workflows/lint.yaml'

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -1,9 +1,6 @@
 name: OpenAPI linting
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -1,6 +1,9 @@
 name: OpenAPI linting
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -18,6 +18,11 @@ concurrency:
 permissions: {}
 jobs:
   validate-schema:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Validate OpenAPI schema
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -21,6 +21,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -1,6 +1,9 @@
 name: Main tool tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -1,9 +1,6 @@
 name: Main tool tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -18,6 +18,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -1,9 +1,6 @@
 name: Mulled Unit Tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -1,6 +1,9 @@
 name: Mulled Unit Tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -1,6 +1,9 @@
 name: macOS startup
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -16,8 +16,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Startup test
     runs-on: macos-latest
     needs: build-client

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -1,9 +1,6 @@
 name: macOS startup
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,6 +1,9 @@
 name: Performance tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,9 +1,6 @@
 name: Performance tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -23,6 +23,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,9 +1,6 @@
 name: Playwright tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -30,8 +30,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     needs: [build-client]
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,6 +1,9 @@
 name: Playwright tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -1,9 +1,6 @@
 name: Selenium tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -1,6 +1,9 @@
 name: Selenium tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'packages/**'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -29,8 +29,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     needs: [build-client]
     runs-on: ubuntu-latest

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -1,6 +1,9 @@
 name: Test Galaxy packages
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -1,9 +1,6 @@
 name: Test Galaxy packages
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -14,6 +14,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -1,9 +1,6 @@
 name: Test Galaxy packages for Pulsar
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -1,6 +1,9 @@
 name: Test Galaxy packages for Pulsar
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/test_galaxy_release.yaml
+++ b/.github/workflows/test_galaxy_release.yaml
@@ -20,6 +20,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_galaxy_release.yaml
+++ b/.github/workflows/test_galaxy_release.yaml
@@ -1,9 +1,6 @@
 name: Test Galaxy release script
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - '.github/workflows/test_galaxy_release.yaml'
       - lib/galaxy/dependencies/**

--- a/.github/workflows/test_galaxy_release.yaml
+++ b/.github/workflows/test_galaxy_release.yaml
@@ -1,6 +1,9 @@
 name: Test Galaxy release script
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - '.github/workflows/test_galaxy_release.yaml'
       - lib/galaxy/dependencies/**

--- a/.github/workflows/tool_form_harness.yaml
+++ b/.github/workflows/tool_form_harness.yaml
@@ -1,6 +1,9 @@
 name: Tool form harness tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - 'client/src/components/Form/**'
       - 'client/src/components/Tool/**'

--- a/.github/workflows/tool_form_harness.yaml
+++ b/.github/workflows/tool_form_harness.yaml
@@ -41,8 +41,18 @@ concurrency:
 permissions: {}
 jobs:
   build-client:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     uses: ./.github/workflows/build_client.yaml
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     needs: [build-client]
     runs-on: ubuntu-latest

--- a/.github/workflows/tool_form_harness.yaml
+++ b/.github/workflows/tool_form_harness.yaml
@@ -1,9 +1,6 @@
 name: Tool form harness tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - 'client/src/components/Form/**'
       - 'client/src/components/Tool/**'

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -19,6 +19,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -1,9 +1,6 @@
 name: Toolshed tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -1,6 +1,9 @@
 name: Toolshed tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -1,6 +1,9 @@
 name: Unit w/postgres tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -20,6 +20,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -1,9 +1,6 @@
 name: Unit w/postgres tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,9 +1,6 @@
 name: Unit tests
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,6 +1,9 @@
 name: Unit tests
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths-ignore:
       - 'client/**'
       - 'doc/**'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -18,6 +18,11 @@ concurrency:
 permissions: {}
 jobs:
   test:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -14,6 +14,11 @@ permissions: {}
 
 jobs:
   zizmor:
+    if: >-
+      github.event_name != 'push'
+      || github.repository_owner != 'galaxyproject'
+      || github.ref_name == 'dev'
+      || startsWith(github.ref_name, 'release_')
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,6 +2,9 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
+    branches:
+      - dev
+      - release_*
     paths:
       - '.github/workflows/*'
       - zizmor.yml

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,9 +2,6 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches:
-      - dev
-      - release_*
     paths:
       - '.github/workflows/*'
       - zizmor.yml


### PR DESCRIPTION
Pushes to a branch on `galaxyproject/galaxy` start a full CI run that duplicates the `pull_request` run for the same commits. This is not hypothetical: `dependabot/npm_and_yarn/*` (13 branches at the moment), `copilot/*` and a number of topic branches are pushed directly to this repository. The concurrency group does not dedupe them, because it is `${{ github.workflow }}-${{ github.ref }}` and a push run's ref is `refs/heads/<branch>` while the pull request run's is `refs/pull/<n>/merge`.

The obvious fix — a `branches: [dev, release_*]` filter on the `push` trigger — is the first commit here, and the second commit reverts it. Trigger filters take no expressions, so that filter applies to forks as well, where a contributor may legitimately want CI on their own branches before opening a pull request (at their own account's expense). The third commit gates at the job level instead, which is the only place a repository-dependent condition can live:

```yaml
jobs:
  test:
    if: >-
      github.event_name != 'push'
      || github.repository_owner != 'galaxyproject'
      || github.ref_name == 'dev'
      || startsWith(github.ref_name, 'release_')
```

Applied to 35 jobs across 28 workflows. `github.repository_owner` is used rather than `github.repository` to match the existing conditions in `publish_artifacts.yaml`, `maintenance_bot.yaml`, `labels-verifier.yaml` and others.

Notes:

- `pull_request` triggers are untouched, so pull request CI is unaffected on forks and here. No workflow filters on draft state, so a draft pull request also gets the full suite.
- The `github.event_name != 'push'` clause is what keeps `pull_request` and `schedule` runs alive — without it they would be skipped, since their `ref_name` is neither `dev` nor `release_*`.
- The workflow run is still created for a skipped push; it consumes no runner minutes but does appear in the Actions tab with its jobs skipped. A new job added in the future has to carry the condition or it silently opts out of the gate.
- `build_container_image.yaml` and `codeql-analysis.yml` already have static `branches:` filters and are left alone — the first should stay restricted on forks too, since it publishes images, and the second is deliberately `dev`-only.
- The two jobs disabled with `if: false` (`cwl_conformance.yaml`, `test_galaxy_packages_for_pulsar.yaml`) are left alone.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. The runs on this pull request are all `pull_request`-triggered and must be unaffected — that exercises the `github.event_name != 'push'` clause.
  2. The `push` behaviour cannot be exercised from a fork pull request, since the condition is false only for pushes to `galaxyproject/*`. After merge, a push to a `dependabot/*` branch here should show all jobs skipped, while the pull request run for the same branch runs normally.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
