### PR TITLE
Normalize failed API responses into real error objects

### DIFF
--- a/client/src/api/client/errorResponseMiddleware.test.ts
+++ b/client/src/api/client/errorResponseMiddleware.test.ts
@@ -1,0 +1,91 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+import { ApiError, errorMessageAsString, rethrowSimpleWithStatus } from "@/utils/simple-error";
+
+import { GalaxyApi } from "./index";
+
+const { server } = useServerMock();
+
+function respondWith(body: string, status: number, contentType = "text/html") {
+    server.use(
+        http.get(
+            "/api/configuration",
+            () => new HttpResponse(body, { status, headers: { "content-type": contentType } }),
+        ),
+    );
+}
+
+async function fetchConfiguration() {
+    return await GalaxyApi().GET("/api/configuration");
+}
+
+describe("errorResponseMiddleware", () => {
+    // Every shape a gateway might answer with. None of them parse, so all take the
+    // same branch -- listed out because these are the bodies seen in the wild.
+    it.each([
+        ["a whole HTML page", "<!DOCTYPE html><html><head><title>504</title></head><body>...</body></html>", 504],
+        ["a fragment with no doctype", "<h1>504 Gateway Time-out</h1><hr><center>nginx</center>", 504],
+        ["a page behind an XML prologue", '<?xml version="1.0"?><!DOCTYPE html><html></html>', 503],
+        ["an empty body", "", 502],
+        ["a body that claims to be JSON but does not parse", '{"err_msg": "upstream closed the conn', 502],
+    ])("normalizes %s into an error object", async (_label, body, status) => {
+        respondWith(body as string, status as number, "application/json");
+
+        const { data, error } = await fetchConfiguration();
+
+        expect(data).toBeUndefined();
+        expect(typeof error).toBe("object");
+        expect(error).toMatchObject({ err_code: status });
+        expect(errorMessageAsString(error)).not.toContain("<");
+    });
+
+    it("names the failure in a way that suits a user", async () => {
+        respondWith("<html><body>gateway timeout</body></html>", 504);
+
+        const { error } = await fetchConfiguration();
+
+        expect(errorMessageAsString(error)).toBe("Galaxy took too long to respond (504)");
+    });
+
+    it("leaves a genuine JSON API error untouched", async () => {
+        respondWith(JSON.stringify({ err_msg: "Dataset not found", err_code: 404 }), 404, "application/json");
+
+        const { error } = await fetchConfiguration();
+
+        expect(errorMessageAsString(error)).toBe("Dataset not found");
+    });
+
+    it("passes through a JSON error that was mislabelled as text", async () => {
+        respondWith(JSON.stringify({ err_msg: "Quota exceeded" }), 400, "text/plain");
+
+        const { error } = await fetchConfiguration();
+
+        expect(errorMessageAsString(error)).toBe("Quota exceeded");
+    });
+
+    it("gives rethrowSimpleWithStatus a readable message and the status", async () => {
+        respondWith("<html><body>gateway timeout</body></html>", 504);
+
+        const { error, response } = await fetchConfiguration();
+
+        try {
+            rethrowSimpleWithStatus(error, response);
+            expect.unreachable("should have thrown");
+        } catch (thrown) {
+            expect(thrown).toBeInstanceOf(ApiError);
+            expect((thrown as ApiError).message).toBe("Galaxy took too long to respond (504)");
+            expect((thrown as ApiError).status).toBe(504);
+        }
+    });
+
+    it("does not disturb a successful response", async () => {
+        server.use(http.get("/api/configuration", () => HttpResponse.json({ brand: "Galaxy" })));
+
+        const { data, error } = await fetchConfiguration();
+
+        expect(error).toBeUndefined();
+        expect(data).toMatchObject({ brand: "Galaxy" });
+    });
+});

--- a/client/src/api/client/errorResponseMiddleware.ts
+++ b/client/src/api/client/errorResponseMiddleware.ts
@@ -1,0 +1,60 @@
+import type { Middleware } from "openapi-fetch";
+
+/** The error shape Galaxy's API returns. */
+interface NormalizedApiError {
+    err_msg: string;
+    err_code: number;
+}
+
+const GATEWAY_MESSAGES: Record<number, string> = {
+    502: "Galaxy is temporarily unavailable",
+    503: "Galaxy is temporarily unavailable",
+    504: "Galaxy took too long to respond",
+};
+
+function statusMessage(status: number, statusText: string): string {
+    const description = GATEWAY_MESSAGES[status] ?? statusText?.trim();
+    return description ? `${description} (${status})` : `The request failed (${status})`;
+}
+
+function hasStructuredBody(body: string): boolean {
+    try {
+        const parsed = JSON.parse(body);
+        return parsed !== null && typeof parsed === "object";
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Normalizes a failed response whose body is not JSON into the `{err_msg, err_code}`
+ * shape the API returns, so callers always receive an error object rather than
+ * whatever happened to answer the request.
+ */
+export const errorResponseMiddleware: Middleware = {
+    async onResponse({ response }) {
+        if (response.ok) {
+            return undefined;
+        }
+
+        // openapi-fetch decides string-or-object by whether the body parses rather
+        // than by content-type, so the same question has to be asked here: a malformed
+        // body labelled as JSON would otherwise still reach the caller as a string.
+        // Cloned so the original stays readable when it is handed back untouched.
+        const body = await response.clone().text();
+        if (hasStructuredBody(body)) {
+            return undefined;
+        }
+
+        const normalized: NormalizedApiError = {
+            err_msg: statusMessage(response.status, response.statusText),
+            err_code: response.status,
+        };
+
+        return new Response(JSON.stringify(normalized), {
+            status: response.status,
+            statusText: response.statusText,
+            headers: { "content-type": "application/json" },
+        });
+    },
+};

--- a/client/src/api/client/index.ts
+++ b/client/src/api/client/index.ts
@@ -1,5 +1,6 @@
 import createClient from "openapi-fetch";
 
+import { errorResponseMiddleware } from "@/api/client/errorResponseMiddleware";
 import { pendingRequestsMiddleware } from "@/api/client/pendingRequestsMiddleware";
 import { createRateLimiterMiddleware } from "@/api/client/rateLimiter";
 import type { GalaxyApiPaths } from "@/api/schema";
@@ -12,6 +13,11 @@ function getBaseUrl() {
 
 function apiClientFactory() {
     const client = createClient<GalaxyApiPaths>({ baseUrl: getBaseUrl() });
+
+    // Response middleware runs in reverse registration order, so registering this
+    // first means it normalizes whatever the chain finally settles on -- including
+    // a response the rate limiter produced by retrying outside the chain.
+    client.use(errorResponseMiddleware);
 
     // Registered first so aborted requests bypass the rate-limiter queue.
     client.use(pendingRequestsMiddleware);

--- a/client/src/components/GalaxyAI.newchat.test.ts
+++ b/client/src/components/GalaxyAI.newchat.test.ts
@@ -205,4 +205,51 @@ describe("GalaxyAI", () => {
         expect(wrapper.find(".loading-entry").exists()).toBe(false);
         expect(chatStore.activeChatId).toBe("exchange-2");
     });
+
+    it("uses its own wording for a gateway failure rather than the normalized one", async () => {
+        mockPost.mockResolvedValue({
+            data: undefined,
+            error: { err_msg: "Galaxy took too long to respond (504)", err_code: 504 },
+            response: { status: 504 },
+        });
+        const { wrapper } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "how do I remove the first row of a table?");
+
+        const texts = messageTexts(wrapper);
+        expect(texts[texts.length - 1]).toBe("Error: GalaxyAI took too long to respond (504). Please try again.");
+    });
+
+    it("shows the message from a genuine API error", async () => {
+        mockPost.mockResolvedValue({
+            data: undefined,
+            error: { err_msg: "No agent is configured for that request", err_code: 400 },
+            response: { status: 400 },
+        });
+        const { wrapper } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "route this somewhere");
+
+        const texts = messageTexts(wrapper);
+        expect(texts[texts.length - 1]).toContain("No agent is configured for that request");
+    });
+
+    // The API client normalizes failures into objects, so this only bites if a
+    // response reaches the chat without going through it.
+    it("never puts an unparsed body in the conversation", async () => {
+        mockPost.mockResolvedValue({
+            data: undefined,
+            error: "<h1>500 Internal Server Error</h1><hr><center>nginx</center>",
+            response: { status: 500 },
+        });
+        const { wrapper } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "anything");
+
+        const texts = messageTexts(wrapper);
+        expect(texts[texts.length - 1]).toBe("Error: GalaxyAI could not answer that request (500). Please try again.");
+    });
 });

--- a/client/src/components/GalaxyAI.vue
+++ b/client/src/components/GalaxyAI.vue
@@ -222,6 +222,25 @@ function showWelcome() {
     });
 }
 
+/** The message to show for a failed chat request. */
+function chatFailureMessage(error: unknown, status?: number): string {
+    // A gateway answers about itself, so its body says nothing about this chat.
+    switch (status) {
+        case 504:
+            return `GalaxyAI took too long to respond (${status}). Please try again.`;
+        case 502:
+        case 503:
+            return `GalaxyAI is temporarily unavailable (${status}). Please try again in a few minutes.`;
+    }
+
+    const fallback =
+        status === undefined
+            ? "Failed to get response from GalaxyAI."
+            : `GalaxyAI could not answer that request (${status}). Please try again.`;
+    // A string means nothing parsed the body, so there is no message to find in it.
+    return error !== null && typeof error === "object" ? errorMessageAsString(error, fallback) : fallback;
+}
+
 async function submitQuery() {
     if (!query.value.trim()) {
         return;
@@ -253,7 +272,7 @@ async function submitQuery() {
         const resolved = resolveMentions(parsed);
         const entityContext = buildEntityContext(resolved);
 
-        const { data, error } = await GalaxyApi().POST("/api/chat", {
+        const { data, error, response } = await GalaxyApi().POST("/api/chat", {
             params: {
                 query: {
                     agent_type: selectedAgentType.value,
@@ -272,7 +291,7 @@ async function submitQuery() {
         }
 
         if (error) {
-            const errorText = errorMessageAsString(error, "Failed to get response from GalaxyAI.");
+            const errorText = chatFailureMessage(error, response?.status);
             const errorMsg: ChatMessage = {
                 id: generateId(),
                 role: "assistant",


### PR DESCRIPTION
Someone asked usegalaxy.eu's chat how to remove the first row of a table and got a 504 page back as the answer -- the whole document, inlined CSS and license blocks and all. The request really had timed out, so a failure was fair enough. What made it bad is what the client did with the body.

`openapi-fetch` reads a failed response as text and tries to parse it as JSON, handing over whatever survives when that throws:

```js
let error = await response.text();
try { error = JSON.parse(error); } catch { /* noop */ }
return { error, response };
```

So a caller can be handed a structured API error or an entire HTML document, with nothing to distinguish them. `errorMessageAsString` falls through to its plain-string branch and returns the document verbatim, and the chat interpolates that into `Error: ${errorText}` and renders it as the assistant's reply.

My first attempt at this sniffed the string for markup, which I don't think is the right shape of fix -- it caught the page that prompted it and missed its neighbours. A bare `<h1>` fragment returned with a 500 still put nginx's markup into the conversation, and an XML prologue ahead of a doctype hid the page just as easily. Every miss is the same bug again, and ~260 call sites would each have to remember they might be holding a webpage. There's no downstream sniffing left in here at all -- I tried keeping a narrow one as a backstop, then couldn't construct a live path that reaches it once the client normalizes, so it's gone and `errorMessageAsString` is untouched.

That parse runs *after* response middleware, though, so there's a place to fix it once. `errorResponseMiddleware` normalizes any non-JSON body on a failed request into `{err_msg, err_code}` -- the same shape the API already returns -- so callers can't tell whether Galaxy or a proxy answered, and nothing downstream changes to benefit. Bodies that do parse are passed through untouched, tested against `openapi-fetch`'s own rule rather than a content-type header, so a mislabelled but valid JSON error still arrives intact.

That turned out to fix more than the chat. `rethrowSimpleWithStatus` formats the raw error value, so a gateway page was becoming the thrown `ApiError`'s message at the couple dozen stores that use it -- the status was there for the retry helpers, but the message was a document. The chat is only where anyone noticed, because it renders into a bubble instead of a toast.

The chat still writes its own line for gateway statuses. A normalized "Galaxy took too long to respond" is accurate, but it's a fact about the proxy rather than an answer to the person who asked something, so a 504 now says GalaxyAI took too long and suggests trying again.

### What this doesn't fix

The 504 itself. `/api/chat` is a blocking POST and an agent turn can outlive the gateway's patience, which is why the report reproduced. That needs solving where the deployment or the endpoint lives -- either the proxy timeout for that route or making the endpoint stream. This just means the failure is legible when it happens instead of dumping a webpage into the conversation.

### Related

#23413 is the same failure shape one layer up. With `structured_output: false` the model narrates the tool call it meant to make, and `extract_result_content` returns that text verbatim, so the chat shows a `<call>` or a bare search query where a result should be. Different cause and a backend fix, so it isn't in here -- this only covers bodies that arrive on a *failed* request, and those come back 200 OK. Worth fixing on the same principle though: don't serve an unparsed intermediate as if it were an answer.

### Testing

The middleware tests go through the real client with a mock server returning actual gateway pages, rather than mocking what the client would have returned, so they exercise the middleware chain and `openapi-fetch`'s parse for real. I checked they fail with the middleware unregistered -- seven of ten, one of them putting `<h1>504 Gateway Time-out</h1><hr><center>nginx</center>` straight into the message.

The gateway-status assertions are exact matches rather than substring checks on purpose. The EU error page contains both "504" and "too long", so a loose match passes against the unfixed code -- which it did, until I tightened them.
