### PR TITLE
[26.1] Fix TestPublishedHistories Selenium failures

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -34,6 +34,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import (
     Any,
+    cast,
     Generic,
     NamedTuple,
     Optional,
@@ -44,6 +45,7 @@ from typing import (
 
 import sqlalchemy
 from sqlalchemy.orm import Query
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.scoping import scoped_session
 from typing_extensions import Protocol
 
@@ -1296,6 +1298,49 @@ def parse_bool(bool_string: Union[str, bool]) -> bool:
 
 def raise_filter_err(attr, op, val, msg):
     raise exceptions.RequestParameterInvalidException(msg, column=attr, operation=op, val=val)
+
+
+# Both an ORM attribute (History.name) and a core column expression (func.lower(...)) can be
+# ordered by, and both carry the .type needed to tell text columns apart.
+SortableColumn = Union["sqlalchemy.ColumnElement[T]", "InstrumentedAttribute[T]"]
+SelectT = TypeVar("SelectT", bound="sqlalchemy.Select[Any]")
+
+
+def sort_expression(column: SortableColumn[T]) -> SortableColumn[T]:
+    """Return the ORDER BY expression for ``column``, ordering text case-insensitively.
+
+    Raw text ordering follows the database collation, so every capitalised value sorts
+    ahead of every lowercase one under SQLite or a C-collation Postgres but not under a
+    locale collation. Filtering already ignores case, so ordering does too. ASCII only:
+    SQLite's lower() folds nothing else and Postgres' is locale dependent.
+    """
+    affinity = column.type._type_affinity
+    if affinity is not None and issubclass(affinity, sqlalchemy.String):
+        return sqlalchemy.func.lower(column)
+    return column
+
+
+def apply_sort_column(
+    stmt: SelectT,
+    column: SortableColumn[Any],
+    sort_desc: Optional[bool],
+    tiebreaker: SortableColumn[Any],
+) -> SelectT:
+    """Order a ``SELECT DISTINCT`` statement by ``column``, breaking ties on ``tiebreaker``.
+
+    Without the tiebreaker, paging with limit/offset over a column holding duplicate
+    values can return a row on two pages, or on none.
+    """
+    expression = sort_expression(column)
+    if expression is not column:
+        # Postgres rejects ordering a SELECT DISTINCT by an expression missing from the
+        # select list. Selecting it cannot change which rows are distinct -- it derives
+        # from a column that is already selected. add_columns() widens the row type, but
+        # the extra column trails the entity that callers read back with scalars().
+        stmt = cast(SelectT, stmt.add_columns(expression))
+    if sort_desc:
+        return stmt.order_by(expression.desc(), tiebreaker.desc())
+    return stmt.order_by(expression, tiebreaker)
 
 
 class SortableManager:

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1302,8 +1302,8 @@ def raise_filter_err(attr, op, val, msg):
 
 # Both an ORM attribute (History.name) and a core column expression (func.lower(...)) can be
 # ordered by, and both carry the .type needed to tell text columns apart.
-SortableColumn = Union["sqlalchemy.ColumnElement[T]", "InstrumentedAttribute[T]"]
-SelectT = TypeVar("SelectT", bound="sqlalchemy.Select[Any]")
+SortableColumn = Union[sqlalchemy.ColumnElement[T], InstrumentedAttribute[T]]
+SelectT = TypeVar("SelectT", bound=sqlalchemy.Select[Any])
 
 
 def sort_expression(column: SortableColumn[T]) -> SortableColumn[T]:

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -42,9 +42,11 @@ from galaxy.managers import (
     sharable,
 )
 from galaxy.managers.base import (
+    apply_sort_column,
     combine_lists,
     ModelDeserializingError,
     Serializer,
+    sort_expression,
     SortableManager,
     StorageCleanerManager,
 )
@@ -230,12 +232,9 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
         sort_column: Any
         if payload.sort_by == "username":
             sort_column = model.User.username
-            stmt = stmt.add_columns(sort_column)
         else:
             sort_column = getattr(model.History, payload.sort_by)
-        if payload.sort_desc:
-            sort_column = sort_column.desc()
-        stmt = stmt.order_by(sort_column)
+        stmt = apply_sort_column(stmt, sort_column, payload.sort_desc, model.History.id)
 
         if payload.limit is not None:
             stmt = stmt.limit(payload.limit)
@@ -357,9 +356,9 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
         if order_by_string == "update_time-asc":
             return asc(self.model_class.update_time)
         if order_by_string in ("name", "name-asc"):
-            return asc(self.model_class.name)
+            return asc(sort_expression(self.model_class.name))
         if order_by_string == "name-dsc":
-            return desc(self.model_class.name)
+            return desc(sort_expression(self.model_class.name))
         # TODO: history columns
         if order_by_string in ("size", "size-dsc"):
             return desc(self.model_class.disk_size)

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -262,9 +262,7 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
         else:
             total_matches = None
         sort_column = getattr(Page, payload.sort_by)
-        if payload.sort_desc:
-            sort_column = sort_column.desc()
-        stmt = stmt.order_by(sort_column)
+        stmt = base.apply_sort_column(stmt, sort_column, payload.sort_desc, Page.id)
         if payload.limit is not None:
             stmt = stmt.limit(payload.limit)
         if payload.offset is not None:

--- a/lib/galaxy/managers/visualizations.py
+++ b/lib/galaxy/managers/visualizations.py
@@ -166,9 +166,7 @@ class VisualizationManager(sharable.SharableModelManager[model.Visualization]):
         else:
             total_matches = None
         sort_column = getattr(model.Visualization, payload.sort_by)
-        if payload.sort_desc:
-            sort_column = sort_column.desc()
-        stmt = stmt.order_by(sort_column)
+        stmt = base.apply_sort_column(stmt, sort_column, payload.sort_desc, model.Visualization.id)
         if payload.limit is not None:
             stmt = stmt.limit(payload.limit)
         if payload.offset is not None:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -56,6 +56,7 @@ from galaxy.managers import (
     sharable,
 )
 from galaxy.managers.base import (
+    apply_sort_column,
     decode_id,
     security_check,
 )
@@ -288,9 +289,7 @@ class WorkflowsManager(sharable.SharableModelManager[model.StoredWorkflow], dele
             stmt = stmt.order_by(desc(StoredWorkflow.update_time))
         else:
             sort_column = getattr(StoredWorkflow, payload.sort_by)
-            if payload.sort_desc:
-                sort_column = sort_column.desc()
-            stmt = stmt.order_by(sort_column)
+            stmt = apply_sort_column(stmt, sort_column, payload.sort_desc, StoredWorkflow.id)
         if payload.limit is not None:
             stmt = stmt.limit(payload.limit)
         if payload.offset is not None:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -586,9 +586,26 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         self.history_panel_create_new()
         self.history_panel_rename(name)
 
+        # A rename typed while the panel is still swapping histories is dropped silently,
+        # leaving "Unnamed history" behind to fail a name lookup in some later test.
+        def renamed(driver=None):
+            return True if self.current_history()["name"] == name else None
+
+        self._wait_on(renamed, f"current history name to become [{name}]", wait_type=WAIT_TYPES.DATABASE_OPERATION)
+
     def history_panel_create_new(self):
-        """Click create new and pause a bit for the history to begin to refresh."""
+        """Click create new and wait for the new history to become the current one."""
+        previous_history_id = self.current_history_id()
         self.history_click_create_new()
+
+        # Callers act on whichever history is current, so wait for the switch rather than
+        # trusting a fixed render delay.
+        def switched(driver=None):
+            return True if self.current_history_id() != previous_history_id else None
+
+        self._wait_on(
+            switched, "current history to switch to the newly created history", wait_type=WAIT_TYPES.DATABASE_OPERATION
+        )
         self.sleep_for(WAIT_TYPES.UX_RENDER)
 
     def history_panel_wait_for_hid_ok(self, hid, allowed_force_refreshes=0):

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -272,6 +272,21 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get(f"histories{query}").json()
             assert len(index_response) == 3
 
+    def test_index_sort_by_name_is_case_insensitive(self):
+        # Codepoint ordering would sort every capitalised name ahead of every lowercase one.
+        with self._different_user(f"user_{uuid4()}@bx.psu.edu"):
+            unique_id = uuid4().hex
+            for name in [f"Zeta_{unique_id}", f"alpha_{unique_id}", f"Beta_{unique_id}"]:
+                self._create_history(name)
+
+            data = dict(search=unique_id, show_published=False, sort_by="name", sort_desc=False)
+            names = [history["name"] for history in self._get("histories", data=data).json()]
+            assert names == [f"alpha_{unique_id}", f"Beta_{unique_id}", f"Zeta_{unique_id}"]
+
+            data["sort_desc"] = True
+            names = [history["name"] for history in self._get("histories", data=data).json()]
+            assert names == [f"Zeta_{unique_id}", f"Beta_{unique_id}", f"alpha_{unique_id}"]
+
     def test_index_advanced_filter(self):
         # Create the histories with a different user to ensure the test
         # is not conflicted with the current user's histories.

--- a/lib/galaxy_test/api/test_visualizations.py
+++ b/lib/galaxy_test/api/test_visualizations.py
@@ -37,6 +37,20 @@ class TestVisualizationsApi(ApiTestCase, SharingApiTests):
         for x in range(2):
             assert index_ids.index(ids[x]) < index_ids.index(ids[x + 1])
 
+    def test_index_sort_by_title_is_case_insensitive(self):
+        # Codepoint ordering would sort every capitalised title ahead of every lowercase one.
+        unique = uuid.uuid4().hex
+        for index, title in enumerate([f"Zeta_{unique}", f"alpha_{unique}", f"Beta_{unique}"]):
+            self._new_viz(title=title, slug=f"slug-case-{unique}-{index}")
+
+        params = dict(search=unique, sort_by="title", sort_desc=False)
+        titles = [entry["title"] for entry in self._index(params)]
+        assert titles == [f"alpha_{unique}", f"Beta_{unique}", f"Zeta_{unique}"]
+
+        params["sort_desc"] = True
+        titles = [entry["title"] for entry in self._index(params)]
+        assert titles == [f"Zeta_{unique}", f"Beta_{unique}", f"alpha_{unique}"]
+
     def test_index_filtering(self):
         ids = []
         for x in range(3):

--- a/lib/galaxy_test/selenium/test_histories_published.py
+++ b/lib/galaxy_test/selenium/test_histories_published.py
@@ -27,7 +27,7 @@ class TestPublishedHistories(SharedStateSeleniumTestCase):
         self.wait_for_and_click_selector('[data-title="Sort by Name ascending"]')
         self.sleep_for(self.wait_types.UX_RENDER)
 
-        sorted_histories = self.get_published_history_names_from_server(sort_by="name")
+        sorted_histories = self.get_published_history_names_from_server(order="name-asc")
         self.assert_histories_present(sorted_histories, sort_by_matters=True)
 
     @selenium_only("Not yet migrated to support Playwright backend")
@@ -39,7 +39,7 @@ class TestPublishedHistories(SharedStateSeleniumTestCase):
         self.wait_for_and_click_selector('[data-title="Sort by Update time ascending"]')
         self.sleep_for(self.wait_types.UX_RENDER)
 
-        expected_history_names = self.get_published_history_names_from_server(sort_by="update_time")
+        expected_history_names = self.get_published_history_names_from_server(order="update_time-asc")
         self.assert_histories_present(expected_history_names, sort_by_matters=True)
 
     @selenium_only("Not yet migrated to support Playwright backend")
@@ -107,14 +107,12 @@ class TestPublishedHistories(SharedStateSeleniumTestCase):
             else:
                 assert history_name == expected_histories[index]
 
-    def get_published_history_names_from_server(self, sort_by=None):
-        published_histories = self.dataset_populator._get("histories/published").json()
-        if sort_by:
-            published_histories = sorted(published_histories, key=lambda x: x[sort_by])
-        all_published_history_names = []
-        for his in published_histories:
-            all_published_history_names.append(his["name"])
-        return all_published_history_names
+    def get_published_history_names_from_server(self, order=None):
+        # The database collation decides name ordering, so re-sorting the response here
+        # could only ever agree with one backend. Let the server order it, like the grid.
+        params = {"order": order} if order else None
+        published_histories = self.dataset_populator._get("histories/published", params).json()
+        return [history["name"] for history in published_histories]
 
     def get_present_histories(self):
         self.sleep_for(self.wait_types.UX_RENDER)


### PR DESCRIPTION
Fixes three of the `TestPublishedHistories` failures on `release_26.1`. Two
independent causes; the third commit follows from the second.

Evidence: [run 33304188966](https://github.com/galaxyproject/galaxy/actions/runs/33304188966)
(Selenium tests, shard 3.10/1) on #23400, which branches from `release_26.1`
and does not touch either area. `search_advanced` and `tag_click` also failed
on `release_26.1` directly in
[33135225488](https://github.com/galaxyproject/galaxy/actions/runs/33135225488)
— they appear in the table in #23406, which listed them but fixed other tests.

| test | 33304188966 |
|---|---|
| `test_published_histories_sort_by_name` | FAIL |
| `test_published_histories_tag_click` | FAIL |
| `test_published_histories_search_advanced` | FAIL |
| `sort_by_last_update`, `username_filter`, `search_standard` | pass |

## `tag_click` and `search_advanced`: the rename is dropped

`history_panel_create_new()` clicked "create new", slept `UX_RENDER`, and let
callers rename the history. When the panel had not yet swapped in the new
history the rename went into the outgoing input and was discarded without an
error, leaving the history named "Unnamed history".

`setup_shared_state` then completed with wrong data instead of failing:
history3 received its tags, annotation and publish under the default name. The
two tests that look it up by name failed afterwards:

```
AssertionError: Failed to find card with name [tqf9wbmfne]
```

`search_advanced` timed out rather than asserting, because its filter matched
nothing and the grid renders `#no-history-found`, not `.history-card-list`:

```
TimeoutException: Timeout waiting on CSS selector [.history-card-list] to become present.
```

What pins this to the rename: the published "Unnamed history" card in the
artifacts belongs to user1 and carries history3's annotation and its single
tag, while history1 has both tags.

Waits for the current history to change before renaming, and checks the name
landed so a remaining failure reports itself where it happens.

## `sort_by_name`: the expected order was computed in Python

`get_published_history_names_from_server` rebuilt the order with `sorted()`,
which compares codepoints and puts a capitalised name first. The grid renders
the order the database produced, and CI's Postgres uses `en_US.UTF-8`, where a
lowercase name sorts first:

```
AssertionError: assert 'g2j47ajfe7' == 'Unnamed history'
```

It only fails when a capitalised name is among the published set, which is what
the rename bug above supplied. No Python sort key satisfies both collations, so
the test passes `order=name-asc` and compares against the response.

## Ordering consistency

The above showed that name ordering depends on the database collation, so the
same grid ordered differently per deployment: case-insensitively under a locale
collation, by codepoint under SQLite or a C-collation Postgres. Filtering
already ignores case (`func.lower` throughout `managers/base.py`,
`taggable.py`, `folders.py`), so ordering now does too, for the histories,
pages, visualizations and workflows indexes and the `order=` parameter.

ASCII only: SQLite's `lower()` folds nothing else and Postgres' is locale
dependent. Ordering also breaks ties on `id`; paging with limit/offset over a
column holding duplicate values could return a row on two pages or on none.

The `ORDER BY` expression has to be added to the select list. These are
`SELECT DISTINCT` queries and Postgres rejects ordering by an expression
missing from it; SQLAlchemy 2.0 does not add it.

Don't pick this commit without the preceding one. On its own it makes
`sort_by_name` fail on every backend instead of only under a locale collation,
because the server would order case-insensitively while the test still sorted
by codepoint (measured on SQLite: `assert 'alpha history' == 'Zebra history'`).

## Checks

`test_histories_published.py` and `test_histories_list.py`: 21 pass on
`en_US.UTF-8` Postgres and on SQLite. `sort_by_name` reproduced first by
forcing a capitalised published name, failing with the assertion above and
passing after. New API tests for case-insensitive ordering (histories,
visualizations) fail on SQLite without the change. The four grids' index/sort
tests return the same results on both backends (52 Postgres, 32 SQLite).
`tox -e lint,format,mypy` clean.

Not included: `test_galaxyai.py::test_delete_chats_via_selection` from the same
run. #23316 fixed one path for it on `dev` and the failure recurred with that
fix present in the tree, so it needs separate work; #23316 is not on
`release_26.1` in any case.
