### PR TITLE
Serve workspace packages from the Vite dev server

### DIFF
--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -158,8 +158,12 @@ export default defineConfig(({ command }) => ({
         port: process.env.VITE_PORT || 5173,
         host: "0.0.0.0",
         proxy: {
-            // Proxy everything except Vite's own routes to Galaxy backend
-            "^/(?!(@|src/|node_modules/|__vite))": {
+            // Proxy everything except Vite's own routes to Galaxy backend.
+            // `packages/` is served by Vite as well: the workspace packages are
+            // aliased to their sources (see `resolve.alias`), so proxying them
+            // to Galaxy would leave `@galaxyproject/galaxy-ui` unresolved and
+            // the client would never boot on the dev server.
+            "^/(?!(@|src/|packages/|node_modules/|__vite))": {
                 target: process.env.GALAXY_URL || "http://127.0.0.1:8080",
                 changeOrigin: true,
                 secure: false,


### PR DESCRIPTION
The Vite dev server proxies every path except Vite's own routes to the Galaxy backend. Since `@galaxyproject/galaxy-ui` was scaffolded, both workspace packages are aliased to their sources under `client/packages/` during `vite serve`:

- `@galaxyproject/galaxy-ui` → `client/packages/ui/src/index.ts`
- `@galaxyproject/galaxy-api-client` → `client/packages/api-client/src/index.ts` (serve only)

The Vite root is `client/`, so those sources are requested as `/packages/ui/src/...`. That path matched the catch-all proxy rule, so the request went to the Galaxy backend and came back as a 404 instead of being served by Vite. `@galaxyproject/galaxy-ui` never resolved and the client did not boot on the dev server.

This adds `packages/` to the proxy's exclusion list so Vite serves the workspace sources itself. Galaxy has no backend route under `/packages/`, so nothing that previously reached the backend stops doing so.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start a Galaxy backend (or point at a remote one with `GALAXY_URL`).
  2. Run `make client-dev-server` from the repository root.
  3. Open the dev server in a browser. Before this change, the console shows a failed request for `/packages/ui/src/index.ts` and the client does not load; after it, the client boots normally.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).