### PR TITLE
[RFC] Subworkflow design bug report.

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -18,6 +18,7 @@ import {
 
 import advancedStepsJson from "../test-data/parameter_steps.json";
 import simpleStepsJson from "../test-data/simple_steps.json";
+import subworkflowMappingStepsJson from "../test-data/subworkflow_mapping_steps.json";
 import {
     ANY_COLLECTION_TYPE_DESCRIPTION,
     CollectionTypeDescription,
@@ -38,6 +39,7 @@ import {
 
 const advancedSteps = advancedStepsJson as Steps;
 const simpleSteps = simpleStepsJson as Steps;
+const subworkflowMappingSteps = subworkflowMappingStepsJson as Steps;
 
 function useStores(id = "mock-workflow") {
     const connectionStore = useConnectionStore(id);
@@ -1000,76 +1002,85 @@ describe("producesAcceptableDatatype", () => {
     });
 });
 
-const LIST_MAP_OVER = { collectionType: "list", isCollection: true, rank: 1 };
-const LIST_LIST_MAP_OVER = { collectionType: "list:list", isCollection: true, rank: 2 };
+type DataOutputTerminal = OutputTerminal | OutputCollectionTerminal;
+
+function effectiveOutputType(output: DataOutputTerminal) {
+    const declaredType = output.collectionType ?? NULL_COLLECTION_TYPE_DESCRIPTION;
+    const effectiveType = output.mapOver.append(declaredType);
+    return effectiveType.collectionType ?? "data";
+}
 
 describe("subworkflow map over", () => {
-    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
-    let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    let listOutput: OutputCollectionTerminal;
+    let mappedItemInput: InputTerminal;
+    let independentItemsInput: InputCollectionTerminal;
+    let outputFromMappedItem: OutputTerminal;
+    let outputFromIndependentItems: OutputCollectionTerminal;
+
     beforeEach(() => {
         setActivePinia(createPinia());
-        terminals = setupAdvanced();
-        stepStore = useWorkflowStepStore("mock-workflow");
-        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
-            stepStore.addStep(step);
-        });
+        const stores = useStores();
+        const listSource = subworkflowMappingSteps[0]!;
+        const subworkflow = subworkflowMappingSteps[1]!;
+        stores.stepStore.addStep(listSource);
+        stores.stepStore.addStep(subworkflow);
+
+        listOutput = terminalFactory(
+            listSource.id,
+            listSource.outputs[0]!,
+            testDatatypesMapper,
+            stores,
+        ) as OutputCollectionTerminal;
+        mappedItemInput = terminalFactory(
+            subworkflow.id,
+            subworkflow.inputs[0]!,
+            testDatatypesMapper,
+            stores,
+        ) as InputTerminal;
+        independentItemsInput = terminalFactory(
+            subworkflow.id,
+            subworkflow.inputs[1]!,
+            testDatatypesMapper,
+            stores,
+        ) as InputCollectionTerminal;
+        outputFromMappedItem = terminalFactory(
+            subworkflow.id,
+            subworkflow.outputs[0]!,
+            testDatatypesMapper,
+            stores,
+        ) as OutputTerminal;
+        outputFromIndependentItems = terminalFactory(
+            subworkflow.id,
+            subworkflow.outputs[1]!,
+            testDatatypesMapper,
+            stores,
+        ) as OutputCollectionTerminal;
     });
 
-    function listOutput() {
-        return terminals["list input"]!["output"] as OutputCollectionTerminal;
+    function outputTypes() {
+        return [effectiveOutputType(outputFromMappedItem), effectiveOutputType(outputFromIndependentItems)];
     }
 
-    function mapSubworkflowOverList() {
-        const datasetIn = terminals["subworkflow"]!["mapped_dataset"] as InputTerminal;
-        datasetIn.connect(listOutput());
-        return rebuildTerminal(datasetIn);
-    }
-
-    function connectInnerCollection() {
-        const collectionIn = terminals["subworkflow"]!["inner_collection"] as InputCollectionTerminal;
-        collectionIn.connect(listOutput());
-        return rebuildTerminal(collectionIn);
-    }
-
-    /** Map over of the downstream step consuming one of the subworkflow's outputs. */
-    function consumedMapOver(consumerLabel: string, outputName: string) {
-        const consumerIn = terminals[consumerLabel]!["input"] as InputTerminal;
-        consumerIn.connect(rebuildTerminal(terminals["subworkflow"]![outputName] as OutputTerminal));
-        return rebuildTerminal(consumerIn).mapOver;
-    }
-
-    it("describes an unmapped subworkflow by its declared interface", () => {
-        const inheritedOut = terminals["subworkflow"]!["inherited_mapping_output"] as OutputTerminal;
-        const localOut = terminals["subworkflow"]!["local_mapping_output"] as OutputCollectionTerminal;
-        expect(inheritedOut.isCollection).toBeFalsy();
-        expect(localOut.collectionType).toStrictEqual(new CollectionTypeDescription("list"));
-        expect(localOut.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+    it("exposes (data, list<data>) before mapping", () => {
+        expect(outputTypes()).toEqual(["data", "list"]);
     });
 
-    it("maps the whole step over a list connected to one dataset input", () => {
-        const datasetIn = mapSubworkflowOverList();
-        expect(datasetIn.mapOver).toEqual(LIST_MAP_OVER);
-        expect(stepStore.stepMapOver[datasetIn.stepId]).toEqual(LIST_MAP_OVER);
-    });
+    it.each(["mapped item", "independent items"])(
+        "exposes (list<data>, list:list<data>) with %s connected first",
+        (firstInput) => {
+            const inputs =
+                firstInput === "mapped item"
+                    ? [mappedItemInput, independentItemsInput]
+                    : [independentItemsInput, mappedItemInput];
 
-    it("adds the map over to every output, not only the one whose step consumes it", () => {
-        mapSubworkflowOverList();
-        expect(consumedMapOver("simple data", "inherited_mapping_output")).toEqual(LIST_MAP_OVER);
-        expect(consumedMapOver("simple data 2", "local_mapping_output")).toEqual(LIST_LIST_MAP_OVER);
-    });
+            for (const input of inputs) {
+                expect(input.canAccept(listOutput).canAccept).toBe(true);
+                input.connect(listOutput);
+            }
 
-    it("keeps accepting a plain list on the collection input of a mapped over step", () => {
-        mapSubworkflowOverList();
-        const collectionIn = rebuildTerminal(terminals["subworkflow"]!["inner_collection"] as InputCollectionTerminal);
-        expect(collectionIn.canAccept(listOutput()).canAccept).toBe(true);
-        expect(connectInnerCollection().localMapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
-        expect(stepStore.stepMapOver[collectionIn.stepId]).toEqual(LIST_MAP_OVER);
-    });
-
-    it("reports the same output types whichever input is connected first", () => {
-        connectInnerCollection();
-        mapSubworkflowOverList();
-        expect(consumedMapOver("simple data", "inherited_mapping_output")).toEqual(LIST_MAP_OVER);
-        expect(consumedMapOver("simple data 2", "local_mapping_output")).toEqual(LIST_LIST_MAP_OVER);
-    });
+            expect(mappedItemInput.localMapOver.collectionType).toBe("list");
+            expect(independentItemsInput.localMapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+            expect(outputTypes()).toEqual(["list", "list:list"]);
+        },
+    );
 });

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -999,3 +999,77 @@ describe("producesAcceptableDatatype", () => {
         );
     });
 });
+
+const LIST_MAP_OVER = { collectionType: "list", isCollection: true, rank: 1 };
+const LIST_LIST_MAP_OVER = { collectionType: "list:list", isCollection: true, rank: 2 };
+
+describe("subworkflow map over", () => {
+    let terminals: { [index: string]: { [index: string]: ReturnType<typeof terminalFactory> } } = {};
+    let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        terminals = setupAdvanced();
+        stepStore = useWorkflowStepStore("mock-workflow");
+        Object.values(JSON.parse(JSON.stringify(advancedSteps)) as Steps).map((step) => {
+            stepStore.addStep(step);
+        });
+    });
+
+    function listOutput() {
+        return terminals["list input"]!["output"] as OutputCollectionTerminal;
+    }
+
+    function mapSubworkflowOverList() {
+        const datasetIn = terminals["subworkflow"]!["mapped_dataset"] as InputTerminal;
+        datasetIn.connect(listOutput());
+        return rebuildTerminal(datasetIn);
+    }
+
+    function connectInnerCollection() {
+        const collectionIn = terminals["subworkflow"]!["inner_collection"] as InputCollectionTerminal;
+        collectionIn.connect(listOutput());
+        return rebuildTerminal(collectionIn);
+    }
+
+    /** Map over of the downstream step consuming one of the subworkflow's outputs. */
+    function consumedMapOver(consumerLabel: string, outputName: string) {
+        const consumerIn = terminals[consumerLabel]!["input"] as InputTerminal;
+        consumerIn.connect(rebuildTerminal(terminals["subworkflow"]![outputName] as OutputTerminal));
+        return rebuildTerminal(consumerIn).mapOver;
+    }
+
+    it("describes an unmapped subworkflow by its declared interface", () => {
+        const inheritedOut = terminals["subworkflow"]!["inherited_mapping_output"] as OutputTerminal;
+        const localOut = terminals["subworkflow"]!["local_mapping_output"] as OutputCollectionTerminal;
+        expect(inheritedOut.isCollection).toBeFalsy();
+        expect(localOut.collectionType).toStrictEqual(new CollectionTypeDescription("list"));
+        expect(localOut.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
+
+    it("maps the whole step over a list connected to one dataset input", () => {
+        const datasetIn = mapSubworkflowOverList();
+        expect(datasetIn.mapOver).toEqual(LIST_MAP_OVER);
+        expect(stepStore.stepMapOver[datasetIn.stepId]).toEqual(LIST_MAP_OVER);
+    });
+
+    it("adds the map over to every output, not only the one whose step consumes it", () => {
+        mapSubworkflowOverList();
+        expect(consumedMapOver("simple data", "inherited_mapping_output")).toEqual(LIST_MAP_OVER);
+        expect(consumedMapOver("simple data 2", "local_mapping_output")).toEqual(LIST_LIST_MAP_OVER);
+    });
+
+    it("keeps accepting a plain list on the collection input of a mapped over step", () => {
+        mapSubworkflowOverList();
+        const collectionIn = rebuildTerminal(terminals["subworkflow"]!["inner_collection"] as InputCollectionTerminal);
+        expect(collectionIn.canAccept(listOutput()).canAccept).toBe(true);
+        expect(connectInnerCollection().localMapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(stepStore.stepMapOver[collectionIn.stepId]).toEqual(LIST_MAP_OVER);
+    });
+
+    it("reports the same output types whichever input is connected first", () => {
+        connectInnerCollection();
+        mapSubworkflowOverList();
+        expect(consumedMapOver("simple data", "inherited_mapping_output")).toEqual(LIST_MAP_OVER);
+        expect(consumedMapOver("simple data 2", "local_mapping_output")).toEqual(LIST_LIST_MAP_OVER);
+    });
+});

--- a/client/src/components/Workflow/Editor/test-data/parameter_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/parameter_steps.json
@@ -1526,5 +1526,68 @@
       "left": 12.8729248046875,
       "top": 1001.7839660644531
     }
+  },
+  "34": {
+    "id": 34,
+    "type": "subworkflow",
+    "label": "subworkflow",
+    "content_id": "subworkflow",
+    "name": "sub",
+    "tool_state": {},
+    "errors": null,
+    "inputs": [
+      {
+        "name": "mapped_dataset",
+        "label": "mapped_dataset",
+        "multiple": false,
+        "input_type": "dataset",
+        "optional": false,
+        "extensions": [
+          "data"
+        ],
+        "input_subworkflow_step_id": 0
+      },
+      {
+        "name": "inner_collection",
+        "label": "inner_collection",
+        "multiple": false,
+        "input_type": "dataset_collection",
+        "collection_types": [
+          "list"
+        ],
+        "optional": false,
+        "extensions": [
+          "data"
+        ],
+        "input_subworkflow_step_id": 1
+      }
+    ],
+    "outputs": [
+      {
+        "name": "inherited_mapping_output",
+        "extensions": [
+          "input"
+        ],
+        "type": "data",
+        "optional": false
+      },
+      {
+        "name": "local_mapping_output",
+        "extensions": [
+          "input"
+        ],
+        "collection": true,
+        "collection_type": "list",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 1101.7839660644531
+    }
   }
 }

--- a/client/src/components/Workflow/Editor/test-data/parameter_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/parameter_steps.json
@@ -1293,7 +1293,7 @@
     "position": {
       "left": 867.0313110351562,
       "top": 390.6929626464844
-    }    
+    }
   },
   "28": {
     "id": 28,
@@ -1525,69 +1525,6 @@
     "position": {
       "left": 12.8729248046875,
       "top": 1001.7839660644531
-    }
-  },
-  "34": {
-    "id": 34,
-    "type": "subworkflow",
-    "label": "subworkflow",
-    "content_id": "subworkflow",
-    "name": "sub",
-    "tool_state": {},
-    "errors": null,
-    "inputs": [
-      {
-        "name": "mapped_dataset",
-        "label": "mapped_dataset",
-        "multiple": false,
-        "input_type": "dataset",
-        "optional": false,
-        "extensions": [
-          "data"
-        ],
-        "input_subworkflow_step_id": 0
-      },
-      {
-        "name": "inner_collection",
-        "label": "inner_collection",
-        "multiple": false,
-        "input_type": "dataset_collection",
-        "collection_types": [
-          "list"
-        ],
-        "optional": false,
-        "extensions": [
-          "data"
-        ],
-        "input_subworkflow_step_id": 1
-      }
-    ],
-    "outputs": [
-      {
-        "name": "inherited_mapping_output",
-        "extensions": [
-          "input"
-        ],
-        "type": "data",
-        "optional": false
-      },
-      {
-        "name": "local_mapping_output",
-        "extensions": [
-          "input"
-        ],
-        "collection": true,
-        "collection_type": "list",
-        "optional": false
-      }
-    ],
-    "annotation": "",
-    "post_job_actions": {},
-    "workflow_outputs": [],
-    "input_connections": {},
-    "position": {
-      "left": 12.8729248046875,
-      "top": 1101.7839660644531
     }
   }
 }

--- a/client/src/components/Workflow/Editor/test-data/subworkflow_mapping_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/subworkflow_mapping_steps.json
@@ -1,0 +1,64 @@
+{
+  "0": {
+    "id": 0,
+    "type": "data_collection_input",
+    "label": "list source",
+    "name": "Input dataset collection",
+    "tool_state": {},
+    "input_connections": {},
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": ["input"],
+        "collection": true,
+        "collection_type": "list",
+        "optional": false
+      }
+    ]
+  },
+  "1": {
+    "id": 1,
+    "type": "subworkflow",
+    "label": "subworkflow",
+    "name": "sub",
+    "tool_state": {},
+    "input_connections": {},
+    "inputs": [
+      {
+        "name": "mapped_item",
+        "label": "mapped_item",
+        "multiple": false,
+        "input_type": "dataset",
+        "optional": false,
+        "extensions": ["data"],
+        "input_subworkflow_step_id": 0
+      },
+      {
+        "name": "independent_items",
+        "label": "independent_items",
+        "multiple": false,
+        "input_type": "dataset_collection",
+        "collection_types": ["list"],
+        "optional": false,
+        "extensions": ["data"],
+        "input_subworkflow_step_id": 1
+      }
+    ],
+    "outputs": [
+      {
+        "name": "output_from_mapped_item",
+        "extensions": ["input"],
+        "type": "data",
+        "optional": false
+      },
+      {
+        "name": "output_from_independent_items",
+        "extensions": ["input"],
+        "collection": true,
+        "collection_type": "list",
+        "optional": false
+      }
+    ]
+  }
+}

--- a/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf-tests.yml
@@ -1,0 +1,57 @@
+- doc: |
+    Two elements are mapped over the subworkflow and three are connected to its
+    collection input, so the outputs come back as flat lists of two and three
+    elements rather than being multiplied or matched up element by element.
+  job:
+    outer_mapping_source:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: X
+          class: File
+          contents: "from_X"
+        - identifier: Y
+          class: File
+          contents: "from_Y"
+    inner_mapping_source:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: P
+          class: File
+          contents: "P_content"
+        - identifier: Q
+          class: File
+          contents: "Q_content"
+        - identifier: R
+          class: File
+          contents: "R_content"
+  outputs:
+    inherited_mapping_output:
+      class: Collection
+      collection_type: list
+      elements:
+        X:
+          asserts:
+          - that: has_text
+            text: "from_X"
+        Y:
+          asserts:
+          - that: has_text
+            text: "from_Y"
+    local_mapping_output:
+      class: Collection
+      collection_type: list
+      elements:
+        P:
+          asserts:
+          - that: has_text
+            text: "P_content"
+        Q:
+          asserts:
+          - that: has_text
+            text: "Q_content"
+        R:
+          asserts:
+          - that: has_text
+            text: "R_content"

--- a/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
@@ -1,0 +1,49 @@
+class: GalaxyWorkflow
+doc: |
+  Test that mapping is resolved per step inside a mapped subworkflow. The child
+  workflow runs as a single invocation, so consume_outer_mapping_source maps over
+  the collection mapped over the subworkflow while consume_inner_mapping_source
+  maps over the collection connected to the subworkflow's own collection input.
+  Each output matches only the collection its step mapped over - the differing
+  element counts show the two are neither multiplied together nor matched up
+  element by element.
+inputs:
+  outer_mapping_source:
+    type: collection
+    collection_type: list
+  inner_mapping_source:
+    type: collection
+    collection_type: list
+outputs:
+  inherited_mapping_output:
+    outputSource: sub/inherited_mapping_output
+  local_mapping_output:
+    outputSource: sub/local_mapping_output
+steps:
+  sub:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        mapped_dataset: data
+        inner_collection:
+          type: collection
+          collection_type: list
+      outputs:
+        inherited_mapping_output:
+          outputSource: consume_outer_mapping_source/out_file1
+        local_mapping_output:
+          outputSource: consume_inner_mapping_source/out_file1
+      steps:
+        consume_outer_mapping_source:
+          tool_id: cat
+          in:
+            input1:
+              source: mapped_dataset
+        consume_inner_mapping_source:
+          tool_id: cat
+          in:
+            input1:
+              source: inner_collection
+    in:
+      mapped_dataset: outer_mapping_source
+      inner_collection: inner_mapping_source

--- a/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_per_step.gxwf.yml
@@ -1,8 +1,8 @@
 class: GalaxyWorkflow
 doc: |
   Test that mapping is resolved per step inside a mapped subworkflow. The child
-  workflow runs as a single invocation, so consume_outer_mapping_source maps over
-  the collection mapped over the subworkflow while consume_inner_mapping_source
+  workflow runs as a single invocation, so cat_outer_mapping_source maps over
+  the collection mapped over the subworkflow while cat_inner_mapping_source
   maps over the collection connected to the subworkflow's own collection input.
   Each output matches only the collection its step mapped over - the differing
   element counts show the two are neither multiplied together nor matched up
@@ -30,16 +30,16 @@ steps:
           collection_type: list
       outputs:
         inherited_mapping_output:
-          outputSource: consume_outer_mapping_source/out_file1
+          outputSource: cat_outer_mapping_source/out_file1
         local_mapping_output:
-          outputSource: consume_inner_mapping_source/out_file1
+          outputSource: cat_inner_mapping_source/out_file1
       steps:
-        consume_outer_mapping_source:
+        cat_outer_mapping_source:
           tool_id: cat
           in:
             input1:
               source: mapped_dataset
-        consume_inner_mapping_source:
+        cat_inner_mapping_source:
           tool_id: cat
           in:
             input1:


### PR DESCRIPTION
Stripping down https://github.com/galaxyproject/galaxy/pull/23369 instead of adding more...

Assuming this test goes green I think we have a serious bug. Sub-workflow ``sub`` below consumes a dataset and a list - and produces two outputs ``(dataset, list<dataset>)``. The list is passed through as is but the dataset is mapped over by a second list. ``map_over(sub, list<data>)`` should therefore yield ``(list<data>, list:list<data>)`` (each output mapped over by one level of list). This is I think the logic the workflow terminals abide by because it treats the subworkflow as a black box (rightfully). At runtime - I think since the mapped over list isn't included as an explicit input to ``sub/consume_inner_mapping_source`` - that tool step and its output don't get mapped over and the subworkflow is producing ``(list<dataset>, list<dataset>)``.

Maybe the best agent description:

> What's actually going on: Galaxy has subworkflow-as-inlining in the scheduler and subworkflow-as-function in the editor, UI, and signature. Inlining is self-consistent on its own terms — push the mapping down per step, no extra dimensionality, one child invocation. The bug is that nothing else in the system agrees with it. sub's output cardinality depends on its internal wiring rather than its interface, which means you can't reason about a subworkflow from its signature and can't substitute an equivalent one.

When stuff was sort of a symptom of the problem instead of the problem.

I don't have a solution yet - but I just wanted to get a second, smarter human opinion on this bug - i.e. @mvdbeek.

-John

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
