### PR TITLE
Enable hash-based job matching for datasets without extra files

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -199,30 +199,30 @@ def has_same_hash(
 
     Datasets with extra files (e.g. composite datasets) are excluded from hash-based matching
     for now.
+
+    The hash match is expressed as plain joins to ``a``'s and ``b``'s primary-file hash rows
+    (at most one each, since a dataset's hash is only ever computed once) rather than a
+    correlated subquery, so the planner can fold it into the surrounding join graph instead of
+    re-evaluating it once per candidate ``b`` row.
     """
     a_hash = aliased(model.DatasetHash)
     b_hash = aliased(model.DatasetHash)
+    stmt = stmt.outerjoin(a_hash, and_(a_hash.dataset_id == a.dataset_id, a_hash.extra_files_path.is_(None)))
+    stmt = stmt.outerjoin(
+        b_hash,
+        and_(
+            b_hash.hash_function == a_hash.hash_function,
+            b_hash.hash_value == a_hash.hash_value,
+            b_hash.extra_files_path.is_(None),
+        ),
+    )
     stmt = stmt.join(
         b,
         or_(
             # Direct dataset match
             b.dataset_id == a.dataset_id,
             # Hash match: b's dataset has a primary-file hash equal to a's primary-file hash
-            b.dataset_id.in_(
-                select(b_hash.dataset_id)
-                .join(
-                    a_hash,
-                    and_(
-                        a_hash.hash_function == b_hash.hash_function,
-                        a_hash.hash_value == b_hash.hash_value,
-                    ),
-                )
-                .where(
-                    a_hash.dataset_id == a.dataset_id,
-                    a_hash.extra_files_path.is_(None),
-                    b_hash.extra_files_path.is_(None),
-                )
-            ),
+            b.dataset_id == b_hash.dataset_id,
         ),
     )
     return stmt

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -192,6 +192,42 @@ def safe_aliased(model_class: type[T], name: str) -> type[T]:
     return aliased(model_class, name=safe_label_or_none(name))
 
 
+def has_same_hash(
+    stmt: "Select[tuple[int]]", a: type[model.HistoryDatasetAssociation], b: type[model.HistoryDatasetAssociation]
+) -> "Select[tuple[int]]":
+    """Join ``b`` to ``a``, matching either on identical dataset or identical dataset hash.
+
+    Datasets with extra files (e.g. composite datasets) are excluded from hash-based matching
+    for now.
+    """
+    a_hash = aliased(model.DatasetHash)
+    b_hash = aliased(model.DatasetHash)
+    stmt = stmt.join(
+        b,
+        or_(
+            # Direct dataset match
+            b.dataset_id == a.dataset_id,
+            # Hash match: b's dataset has a primary-file hash equal to a's primary-file hash
+            b.dataset_id.in_(
+                select(b_hash.dataset_id)
+                .join(
+                    a_hash,
+                    and_(
+                        a_hash.hash_function == b_hash.hash_function,
+                        a_hash.hash_value == b_hash.hash_value,
+                    ),
+                )
+                .where(
+                    a_hash.dataset_id == a.dataset_id,
+                    a_hash.extra_files_path.is_(None),
+                    b_hash.extra_files_path.is_(None),
+                )
+            ),
+        ),
+    )
+    return stmt
+
+
 class JobManager:
     def __init__(self, app: StructuredApp, history_manager: HistoryManager):
         self.app = app
@@ -828,7 +864,8 @@ class JobSearch:
         used_ids.append(labeled_col)
         stmt = stmt.join(a, a.job_id == model.Job.id)
         # b is the HDA used for the job
-        stmt = stmt.join(b, a.dataset_id == b.id).join(c, c.dataset_id == b.dataset_id)
+        stmt = stmt.join(b, a.dataset_id == b.id)
+        stmt = has_same_hash(stmt, b, c)
         name_condition = []
         hda_history_join_conditions = [
             e.history_dataset_association_id == b.id,

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -727,6 +727,12 @@ def test_job_cache_with_dataset_hash(target_history: TargetHistory, required_too
     job = execution.assert_has_single_job
     assert job.final_details["copied_from_job_id"]
 
+    # A dataset with different content (and hence a different hash) must not be cached.
+    other_hda = target_history.with_dataset("4\t5\t6", "dataset2")
+    other_execution = required_tool.execute(use_cached_job=True).with_inputs({"parameter": other_hda.src_dict})
+    other_job = other_execution.assert_has_single_job
+    assert not other_job.final_details["copied_from_job_id"]
+
 
 @requires_tool_id("gx_repeat_boolean_min")
 def test_optional_repeats_with_mins_filled_id(target_history: TargetHistory, required_tool: RequiredTool):

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -718,6 +718,16 @@ def test_map_over_data_param_with_list_of_lists(target_history: TargetHistory, r
     execute.assert_creates_implicit_collection(0)
 
 
+@requires_tool_id("gx_data")
+def test_job_cache_with_dataset_hash(target_history: TargetHistory, required_tool: RequiredTool) -> None:
+    hda = target_history.with_dataset("1\t2\t3", "dataset1")
+    _ = required_tool.execute().with_inputs({"parameter": hda.src_dict}).assert_has_single_job
+    new_hda = target_history.with_dataset("1\t2\t3", "dataset1")
+    execution = required_tool.execute(use_cached_job=True).with_inputs({"parameter": new_hda.src_dict})
+    job = execution.assert_has_single_job
+    assert job.final_details["copied_from_job_id"]
+
+
 @requires_tool_id("gx_repeat_boolean_min")
 def test_optional_repeats_with_mins_filled_id(target_history: TargetHistory, required_tool: RequiredTool):
     # we have a tool test for this but I wanted to verify it wasn't just the

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -7,7 +7,9 @@ keep things like testing other tool APIs in ./test_tools.py (index, search, tool
 files, etc..).
 """
 
+import copy
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
@@ -732,6 +734,34 @@ def test_job_cache_with_dataset_hash(target_history: TargetHistory, required_too
     other_execution = required_tool.execute(use_cached_job=True).with_inputs({"parameter": other_hda.src_dict})
     other_job = other_execution.assert_has_single_job
     assert not other_job.final_details["copied_from_job_id"]
+
+
+@requires_tool_id("gx_data")
+def test_job_cache_not_used_for_datasets_with_different_extra_files(
+    target_history: TargetHistory, required_tool: RequiredTool
+) -> None:
+    velvet_upload_request: dict[str, Any] = {
+        "src": "composite",
+        "ext": "velvet",
+        "composite": {
+            "items": [
+                {"src": "pasted", "paste_content": "sequences content"},
+                {"src": "pasted", "paste_content": "roadmaps content"},
+                {"src": "pasted", "paste_content": "log content"},
+            ]
+        },
+    }
+    velvet1_hda = target_history._dataset_populator.fetch_hda(target_history.id, velvet_upload_request, wait=True)
+    velvet1 = {"src": "hda", "id": velvet1_hda["id"]}
+    _ = required_tool.execute().with_inputs({"parameter": velvet1}).assert_has_single_job
+
+    # Same primary file ("sequences"), but a different extra file ("roadmaps").
+    velvet_modified_request = copy.deepcopy(velvet_upload_request)
+    velvet_modified_request["composite"]["items"][1]["paste_content"] = "roadmaps content MODIFIED"
+    velvet2_hda = target_history._dataset_populator.fetch_hda(target_history.id, velvet_modified_request, wait=True)
+    velvet2 = {"src": "hda", "id": velvet2_hda["id"]}
+    job = required_tool.execute(use_cached_job=True).with_inputs({"parameter": velvet2}).assert_has_single_job
+    assert not job.final_details["copied_from_job_id"]
 
 
 @requires_tool_id("gx_repeat_boolean_min")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4651,10 +4651,10 @@ class DescribeJob:
         self._job_id = job_id
         self._final_details: dict[str, Any] | None = None
 
-    def _wait_for(self):
+    def _wait_for(self) -> None:
         if self._final_details is None:
             self._dataset_populator.wait_for_job(self._job_id, assert_ok=False)
-            self._final_details = self._dataset_populator.get_job_details(self._job_id).json()
+            self._final_details = self._dataset_populator.get_job_details(self._job_id, full=True).json()
 
     @property
     def final_details(self) -> dict[str, Any]:


### PR DESCRIPTION
Match candidate job-cache HDAs on primary-file hash in addition to the existing direct dataset match, restricted to datasets without extra files (`has_same_hash()` only matches `DatasetHash` rows with a NULL extra_files_path). Computing and storing the primary-file hash already happens on dev; this wires it into job search.

This implements Phase 1a of https://github.com/galaxyproject/galaxy/issues/21676 and derives from https://github.com/galaxyproject/galaxy/pull/19112 .

Claude suggested adding a database index on the (hash_function, hash_value) column pair of `DatasetHash`, but it may become redundant in later phases of the plan. Happy to add it if people feel there would be a performance issue without it.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
