### PR TITLE
[26.1] Validate BCO exports against vendored IEEE-2791 schemas

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4523,17 +4523,6 @@ input_1:
             assert "History dataset collection association not found" in error_entry["error"]
 
     @skip_without_tool("cat1")
-    def test_export_invocation_bco(self):
-        with self.dataset_populator.test_history() as history_id:
-            summary = self._run_workflow(WORKFLOW_SIMPLE, test_data={"input1": "hello world"}, history_id=history_id)
-            invocation_id = summary.invocation_id
-            bco_path = self.workflow_populator.download_invocation_to_store(invocation_id, extension="bco.json")
-            with open(bco_path) as f:
-                bco = json.load(f)
-            self.workflow_populator.validate_biocompute_object(bco)
-            assert bco["provenance_domain"]["name"] == "Simple Workflow"
-
-    @skip_without_tool("cat1")
     def test_export_invocation_ro_crate(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(WORKFLOW_SIMPLE, test_data={"input1": "hello world"}, history_id=history_id)

--- a/lib/galaxy_test/base/json_schema_utils.py
+++ b/lib/galaxy_test/base/json_schema_utils.py
@@ -1,13 +1,39 @@
+import json
+from functools import lru_cache
+from pathlib import Path
 from typing import (
     Any,
+    Optional,
 )
 
 import jsonschema
+from referencing import (
+    Registry,
+    Resource,
+)
+from referencing.exceptions import NoSuchResource
 
 from galaxy.util import requests
 from galaxy_test.base import api_asserts
 
+VENDORED_SCHEMAS_DIR = Path(__file__).parent / "schemas"
+
 schema_store: dict[str, Any] = {}
+
+
+@lru_cache(maxsize=1)
+def vendored_schema_registry() -> Registry:
+    """Build a registry mapping each vendored schema's ``$id`` URL to its local copy.
+
+    Validation against these schemas resolves ``$ref``s entirely from the registry,
+    so no network access is required.
+    """
+    resources = []
+    for schema_path in sorted(VENDORED_SCHEMAS_DIR.glob("**/*.json")):
+        with schema_path.open() as f:
+            contents = json.load(f)
+        resources.append((contents["$id"], Resource.from_contents(contents)))
+    return Registry().with_resources(resources)
 
 
 class JsonSchemaValidator:
@@ -22,10 +48,22 @@ class JsonSchemaValidator:
         JsonSchemaValidator.validate(instance, schema)
 
     @staticmethod
-    def validate(instance: dict, schema: dict):
+    def validate_using_vendored_schema(instance: dict, schema_url: str):
+        registry = vendored_schema_registry()
+        try:
+            schema = registry.contents(schema_url)
+        except NoSuchResource:
+            raise AssertionError(f"No vendored copy of schema {schema_url} found under {VENDORED_SCHEMAS_DIR}.")
+        JsonSchemaValidator.validate(instance, schema, registry=registry)
+
+    @staticmethod
+    def validate(instance: dict, schema: dict, registry: Optional[Registry] = None):
         try:
             schema_version = schema.get("$id", "Unknown schema version")
-            jsonschema.validate(instance=instance, schema=schema)
+            if registry is not None:
+                jsonschema.validate(instance=instance, schema=schema, registry=registry)
+            else:
+                jsonschema.validate(instance=instance, schema=schema)
         except jsonschema.exceptions.ValidationError as err:
             raise AssertionError(
                 f"The instance does not validate against the schema: {schema_version}.\nReasons:\n{err}"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2762,7 +2762,7 @@ class BaseWorkflowPopulator(BasePopulator):
     def validate_biocompute_object(
         self, bco, expected_schema_version="https://w3id.org/ieee/ieee-2791-schema/2791object.json"
     ):
-        JsonSchemaValidator.validate_using_schema_url(bco, expected_schema_version)
+        JsonSchemaValidator.validate_using_vendored_schema(bco, expected_schema_version)
 
     def get_ro_crate(self, invocation_id, include_files=False):
         crate_response = self.download_invocation_to_store(

--- a/lib/galaxy_test/base/schemas/ieee-2791/2791object.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/2791object.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/2791object.json",
+    "type": "object",
+    "title": "Base type for all IEEE-2791 Objects",
+    "description": "All IEEE-2791 object types must adhear to this type in order to be compliant with IEEE-2791 standard",
+    "required": [
+        "object_id",
+        "spec_version",
+        "etag",
+        "provenance_domain",
+        "usability_domain",
+        "description_domain",
+        "execution_domain",
+        "io_domain"
+    ],
+    "definitions": {
+        "object_id": {
+            "type": "string",
+            "description": "A unique identifier that should be applied to each IEEE-2791 Object instance, generated and assigned by a IEEE-2791 database engine. IDs should never be reused"
+        },
+        "uri": {
+            "type": "object",
+            "description": "Any of the four Resource Identifers defined at https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.5",
+            "additionalProperties": false,
+            "required": [
+                "uri"
+            ],
+            "properties": {
+                "filename": {
+                    "type": "string"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "access_time": {
+                    "type": "string",
+                    "description": "Time stamp of when the request for this data was submitted",
+                    "format": "date-time"
+                },
+                "sha1_checksum": {
+                    "type": "string",
+                    "description": "output of hash function that produces a message digest",
+                    "pattern": "[A-Za-z0-9]+"
+                }
+            }
+        }, 
+        "contributor": {
+            "type": "object",
+            "description": "Contributor identifier and type of contribution (determined according to PAV ontology) is required",
+            "required": [
+                "contribution",
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of contributor",
+                    "examples": [
+                        "Charles Darwin"
+                    ]
+                },
+                "affiliation": {
+                    "type": "string",
+                    "description": "Organization the particular contributor is affiliated with",
+                    "examples": [
+                        "HMS Beagle"
+                    ]
+                },
+                "email": {
+                    "type": "string",
+                    "description": "electronic means for identification and communication purposes",
+                    "examples": [
+                        "name@example.edu"
+                    ],
+                    "format": "email"
+                },
+                "contribution": {
+                    "type": "array",
+                    "description": "type of contribution determined according to PAV ontology",
+                    "reference": "https://doi.org/10.1186/2041-1480-4-37",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "authoredBy",
+                            "contributedBy",
+                            "createdAt",
+                            "createdBy",
+                            "createdWith",
+                            "curatedBy",
+                            "derivedFrom",
+                            "importedBy",
+                            "importedFrom",
+                            "providedBy",
+                            "retrievedBy",
+                            "retrievedFrom",
+                            "sourceAccessedBy"
+                        ]
+                    }
+                },
+                "orcid": {
+                    "type": "string",
+                    "description": "Field to record author information. ORCID identifiers allow for the author to curate their information after submission. ORCID identifiers must be valid and must have the prefix ‘https://orcid.org/’",
+                    "examples": [
+                        "http://orcid.org/0000-0002-1825-0097"
+                    ],
+                    "format": "uri"
+                }
+            }
+        }
+    },
+    "additionalProperties": false,
+    "properties": {
+        "object_id": {
+            "$ref": "#/definitions/object_id",
+            "readOnly": true
+        },
+        "spec_version": {
+            "type": "string",
+            "description": "Version of the IEEE-2791 specification used to define this document",
+            "examples": [
+                "https://w3id.org/ieee/ieee-2791-schema/"
+            ],
+            "readOnly": true,
+            "format": "uri"
+        },
+        "etag": {
+            "type": "string",
+            "description": "See https://tools.ietf.org/html/rfc7232#section-2.1 for full description. It is recommended that the ETag be deleted or updated if the object file is changed (except in cases using weak ETags in which the entirety of the change comprises a simple re-writing of the JSON).",
+            "examples": [
+                "5986B05969341343E77A95B4023600FC8FEF48B7E79F355E58B0B404A4F50995"
+            ],
+            "readOnly": true,
+            "pattern": "^([A-Za-z0-9]+)$"
+        },
+        "provenance_domain": {
+            "$ref": "provenance_domain.json"
+        },
+        "usability_domain": {
+            "$ref": "usability_domain.json"
+        },
+        "extension_domain": {
+            "type": "array",
+            "description": "An optional domain that contains user-defined fields.",
+            "items":{
+                "required":[
+                    "extension_schema"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                    "extension_schema":{
+                        "title": "Extension Schema",
+                        "description": "resolving this URI should provide this extension's JSON Schema",
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            }
+        },
+        "description_domain": {
+            "$ref": "description_domain.json"
+        },
+        "execution_domain": {
+            "$ref": "execution_domain.json"
+        },
+        "parametric_domain": {
+            "$ref": "parametric_domain.json"
+        },
+        "io_domain": {
+            "$ref": "io_domain.json"
+        },
+        "error_domain": {
+            "$ref": "error_domain.json"
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/README.md
+++ b/lib/galaxy_test/base/schemas/ieee-2791/README.md
@@ -4,6 +4,10 @@ Vendored copies of the IEEE-2791-2020 schema set, fetched verbatim on 2026-09-02
 `https://w3id.org/ieee/ieee-2791-schema/<filename>` (which redirects to the IEEE
 OpenSource hosting of https://opensource.ieee.org/2791-object/ieee-2791-schema).
 
+Do not edit the JSON files by hand — refresh them with
+`python scripts/update_ieee_2791_schemas.py` (run from the repository root), which
+re-fetches the whole set by walking the `$ref`s, then update the fetch date above.
+
 `2791object.json` is the top-level schema; it `$ref`s the sibling `*_domain.json`
 files by relative URL. Tests validate BCO exports against these local copies via
 `galaxy_test.base.json_schema_utils.vendored_schema_registry`, keyed by each file's

--- a/lib/galaxy_test/base/schemas/ieee-2791/README.md
+++ b/lib/galaxy_test/base/schemas/ieee-2791/README.md
@@ -1,0 +1,11 @@
+# IEEE-2791 (BioCompute Object) JSON schemas
+
+Vendored copies of the IEEE-2791-2020 schema set, fetched verbatim on 2026-09-02 from
+`https://w3id.org/ieee/ieee-2791-schema/<filename>` (which redirects to the IEEE
+OpenSource hosting of https://opensource.ieee.org/2791-object/ieee-2791-schema).
+
+`2791object.json` is the top-level schema; it `$ref`s the sibling `*_domain.json`
+files by relative URL. Tests validate BCO exports against these local copies via
+`galaxy_test.base.json_schema_utils.vendored_schema_registry`, keyed by each file's
+`$id`, so validation makes no network requests (the w3id.org/IEEE host sits behind a
+bot-challenge WAF that intermittently blocks CI runner IPs).

--- a/lib/galaxy_test/base/schemas/ieee-2791/description_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/description_domain.json
@@ -1,0 +1,165 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/description_domain.json",
+    "type": "object",
+    "title": "Description Domain",
+    "description": "Structured field for description of external references, the pipeline steps, and the relationship of I/O objects.",
+    "required": [
+        "keywords",
+        "pipeline_steps"
+    ],
+    "properties": {
+        "keywords": {
+            "type": "array",
+            "description": "Keywords to aid in search-ability and description of the object.",
+            "items": {
+                "type": "string",
+                "description": "This field should take free text value using common biological research terminology.",
+                "examples": [
+                    "HCV1a",
+                    "Ledipasvir",
+                    "antiviral resistance",
+                    "SNP",
+                    "amino acid substitutions"
+                ]
+            }
+        },
+        "xref": {
+            "type": "array",
+            "description": "List of the databases or ontology IDs that are cross-referenced in the IEEE-2791 Object.",
+            "items": {
+                "type": "object",
+                "description": "External references are stored in the form of prefixed identifiers (CURIEs). These CURIEs map directly to the URIs maintained by Identifiers.org.",
+                "reference": "https://identifiers.org/",
+                "required": [
+                    "namespace",
+                    "name",
+                    "ids",
+                    "access_time"
+                ],
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "External resource vendor prefix",
+                        "examples": [
+                            "pubchem.compound"
+                        ]
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of external reference",
+                        "examples": [
+                            "PubChem-compound"
+                        ]
+                    },
+                    "ids": {
+                        "type": "array",
+                        "description": "List of reference identifiers",
+                        "items": {
+                            "type": "string",
+                            "description": "Reference identifier",
+                            "examples": [
+                                "67505836"
+                            ]
+                        }
+                    },
+                    "access_time": {
+                        "type": "string",
+                        "description": "Date and time the external reference was accessed",
+                        "format": "date-time"
+                    }
+                }
+            }
+        },
+        "platform": {
+            "type": "array",
+            "description": "reference to a particular deployment of an existing platform where this IEEE-2791 Object can be reproduced.",
+            "items": {
+                "type": "string",
+                "examples": [
+                    "hive"
+                ]
+            }
+        },
+        "pipeline_steps": {
+            "type": "array",
+            "description": "Each individual tool (or a well defined and reusable script) is represented as a step. Parallel processes are given the same step number.",
+            "items": {
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "step_number",
+                    "name",
+                    "description",
+                    "input_list",
+                    "output_list"
+                ],
+                "properties": {
+                    "step_number": {
+                        "type": "integer",
+                        "description": "Non-negative integer value representing the position of the tool in a one-dimensional representation of the pipeline."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "This is a recognized name of the software tool",
+                        "examples": [
+                            "HIVE-hexagon"
+                        ]
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Specific purpose of the tool.",
+                        "examples": [
+                            "Alignment of reads to a set of references"
+                        ]
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Version assigned to the instance of the tool used corresponding to the upstream release.",
+                        "examples": [
+                            "1.3"
+                        ]
+                    },
+                    "prerequisite": {
+                        "type": "array",
+                        "description": "Reference or required prereqs",
+                        "items": {
+                            "type": "object",
+                            "description": "Text value to indicate a package or prerequisite for running the tool used.",
+                            "required": [
+                                "name",
+                                "uri"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Public searchable name for reference or prereq.",
+                                    "examples": [
+                                        "Hepatitis C virus genotype 1"
+                                    ]
+                                },
+                                "uri": {
+                                    "$ref": "2791object.json#/definitions/uri"
+                                }
+                            }
+                        }
+                    },
+                    "input_list": {
+                        "type": "array",
+                        "description": "URIs (expressed as a URN or URL) of the input files for each tool.",
+                        "items": {
+                            "$ref": "2791object.json#/definitions/uri"
+                        }
+                    },
+                    "output_list": {
+                        "type": "array",
+                        "description": "URIs (expressed as a URN or URL) of the output files for each tool.",
+                        "items": {
+                            "$ref": "2791object.json#/definitions/uri"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/error_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/error_domain.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/error_domain.json",
+    "type": "object",
+    "title": "Error Domain",
+    "description": "Fields in the Error Domain are open-ended and not restricted nor defined by the IEEE-2791 standard. It is RECOMMENDED that the keys directly under empirical_error and algorithmic_error use a full URI. Resolving the URI SHOULD give a JSON Schema or textual definition of the field. Other keys are not allowed error_domain",
+    "additionalProperties": false,
+    "required": [
+        "empirical_error",
+        "algorithmic_error"
+    ],
+    "properties": {
+        "empirical_error": {
+            "type": "object",
+            "title": "Empirical Error",
+            "description": "empirically determined values such as limits of detectability, false positives, false negatives, statistical confidence of outcomes, etc. This can be measured by running the algorithm on multiple data samples of the usability domain or through the use of carefully designed in-silico data."
+        },
+        "algorithmic_error": {
+            "type": "object",
+            "title": "Algorithmic Error",
+            "description": "descriptive of errors that originate by fuzziness of the algorithms, driven by stochastic processes, in dynamically parallelized multi-threaded executions, or in machine learning methodologies where the state of the machine can affect the outcome."
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/execution_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/execution_domain.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/execution_domain.json",
+    "type": "object",
+    "title": "Execution Domain",
+    "description": "The fields required for execution of the IEEE-2791 Object are herein encapsulated together in order to clearly separate information needed for deployment, software configuration, and running applications in a dependent environment",
+    "required": [
+        "script",
+        "script_driver",
+        "software_prerequisites",
+        "external_data_endpoints",
+        "environment_variables"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "script": {
+            "type": "array",
+            "description": "points to a script object or objects that was used to perform computations for this IEEE-2791 Object instance.",
+            "items": {
+                "additionalProperties": false,
+                "properties": {
+                    "uri": {
+                        "$ref": "2791object.json#/definitions/uri"
+                    }
+                }
+			}
+        },
+        "script_driver": {
+            "type": "string",
+            "description": "Indication of the kind of executable that can be launched in order to perform a sequence of commands described in the script in order to run the pipelin",
+            "examples": [
+                "hive",
+                "cwl-runner",
+                "shell"
+            ]
+        },
+        "software_prerequisites": {
+            "type": "array",
+            "description": "Minimal necessary prerequisites, library, tool versions needed to successfully run the script to produce this IEEE-2791 Object.",
+            "items": {
+                "type": "object",
+                "description": "A necessary prerequisite, library, or tool version.",
+                "required": [
+                    "name",
+                    "version",
+                    "uri"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Names of software prerequisites",
+                        "examples": [
+                            "HIVE-hexagon"
+                        ]
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Versions of the software prerequisites",
+                        "examples": [
+                            "babajanian.1"
+                        ]
+                    },
+                    "uri": {
+                        "$ref": "2791object.json#/definitions/uri"
+                    }
+                }
+            }
+        },
+        "external_data_endpoints": {
+            "type": "array",
+            "description": "Minimal necessary domain-specific external data source access in order to successfully run the script to produce this IEEE-2791 Object.",
+            "items": {
+                "type": "object",
+                "description": "Requirement for network protocol endpoints used by a pipeline’s scripts, or other software.",
+                "required": [
+                    "name",
+                    "url"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Description of the service that is accessed",
+                        "examples": [
+                            "HIVE",
+                            "access to e-utils"
+                        ]
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "The endpoint to be accessed.",
+                        "examples": [
+                            "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=login"
+                        ]
+                    }
+                }
+            }
+        },
+        "environment_variables": {
+            "type": "object",
+            "description": "Environmental parameters that are useful to configure the execution environment on the target platform.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z_]+[a-zA-Z0-9_]*$": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/io_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/io_domain.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/io_domain.json",
+    "type": "object",
+    "title": "Input and Output Domain",
+    "description": "The list of global input and output files created by the computational workflow, excluding the intermediate files. Custom to every specific IEEE-2791 Object implementation, these fields are pointers to objects that can reside in the system performing the computation or any other accessible system.",
+    "required": [
+        "input_subdomain",
+        "output_subdomain"
+    ],
+    "properties": {
+        "input_subdomain": {
+            "type": "array",
+            "title": "input_domain",
+            "description": "A record of the references and input files for the entire pipeline. Each type of input file is listed under a key for that type.",
+            "items": {
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "uri"
+                ],
+                "properties": {
+                    "uri": {
+                        "$ref": "2791object.json#/definitions/uri"
+                    }
+                }
+            }
+        },
+        "output_subdomain": {
+            "type": "array",
+            "title": "output_subdomain",
+            "description": "A record of the outputs for the entire pipeline.",
+            "items": {
+                "type": "object",
+                "title": "The Items Schema",
+                "required": [
+                    "mediatype",
+                    "uri"
+                ],
+                "properties": {
+                    "mediatype": {
+                        "type": "string",
+                        "title": "mediatype",
+                        "description": "https://www.iana.org/assignments/media-types/",
+                        "default": "application/octet-stream",
+                        "examples": [
+                            "text/csv"
+                        ],
+                        "pattern": "^(.*)$"
+                    },
+                    "uri": {
+                        "$ref": "2791object.json#/definitions/uri"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/parametric_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/parametric_domain.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/parametric_domain.json",
+    "type": "array",
+    "title": "Parametric Domain",
+    "description": "This represents the list of NON-default parameters customizing the computational flow which can affect the output of the calculations. These fields can be custom to each kind of analysis and are tied to a particular pipeline implementation",
+    "items":{
+        "required": [
+            "param",
+            "value",
+            "step"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "param": {
+                "type": "string",
+                "title": "param",
+                "description": "Specific variables for the computational workflow",
+                "examples": [
+                    "seed"
+                ]
+            },
+            "value": {
+                "type": "string",
+                "description": "Specific (non-default) parameter values for the computational workflow",
+                "title": "value",
+                "examples": [
+                    "14"
+                ]
+            },
+            "step": {
+                "type": "string",
+                "title": "step",
+                "description": "Refers to the specific step of the workflow relevant to the parameters specified in 'param' and 'value'",
+                "examples": [
+                    "1"
+                ],
+                "pattern": "^(.*)$"
+            }
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/provenance_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/provenance_domain.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/provenance_domain.json",
+    "type": "object",
+    "title": "Provenance Domain",
+    "description": "Structured field for tracking data through transformations, including contributors, reviewers, and versioning.",
+    "required": [
+        "name",
+        "version",
+        "created",
+        "modified",
+        "contributors",
+        "license"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Public searchable name for IEEE-2791 Object. This public field should take free text value using common biological research terminology supporting the terminology used in the usability_domain, external references (xref), and keywords sections.",
+            "examples": [
+                "HCV1a ledipasvir resistance SNP detection"
+            ]
+        },
+        "version": {
+            "type": "string",
+            "description": "Records the versioning of this IEEE-2791 Object instance. IEEE-2791 Object Version should adhere to semantic versioning as recommended by Semantic Versioning 2.0.0.",
+            "reference": "https://semver.org/spec/v2.0.0.html",
+            "examples": [
+                "2.9"
+            ]
+        },
+        "review": {
+            "type": "array",
+            "description": "Description of the current verification status of an object in the review process. The unreviewed flag indicates that the object has been submitted, but no further evaluation or verification has occurred. The in-review flag indicates that verification is underway. The approved flag indicates that the IEEE-2791 Object has been verified and reviewed. The suspended flag indicates an object that was once valid is no longer considered valid. The rejected flag indicates that an error or inconsistency was detected in the IEEE-2791 Object, and it has been removed or rejected. The fields from the contributor object (described in section 2.1.10) is inherited to populate the reviewer section.",
+            "items": {
+                "type": "object",
+                "required": [
+                    "status",
+                    "reviewer"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reviewer": {
+                        "$ref": "2791object.json#/definitions/contributor",
+                        "description": "Contributer that assigns IEEE-2791 review status."
+                    },
+                    "reviewer_comment": {
+                        "type": "string",
+                        "description": "Optional free text comment by reviewer",
+                        "examples": [
+                            "Approved by research institution staff. Waiting for approval from regulator"
+                        ]
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "unreviewed",
+                            "in-review",
+                            "approved",
+                            "rejected",
+                            "suspended"
+                        ],
+                        "description": "Current verification status of the IEEE-2791 Object",
+                        "default": "unreviewed"
+                    }
+                }
+            }
+        },
+        "derived_from": {
+            "description": "value of `ieee2791_id` field of another IEEE-2791 that this object is partially or fully derived from",
+            "$ref": "2791object.json#/definitions/object_id"
+        },
+        "obsolete_after": {
+            "type": "string",
+            "description": "If the object has an expiration date, this optional field will specify that using the ‘datetime’ type described in ISO-8601 format, as clarified by W3C https://www.w3.org/TR/NOTE-datetime.",
+            "format": "date-time"
+        },
+        "embargo": {
+            "type": "object",
+            "description": "If the object has a period of time during which it shall not be made public, that range can be specified using these optional fields. Using the datetime type, a start and end time are specified for the embargo.",
+            "additionalProperties": false,
+            "properties": {
+                "start_time": {
+                    "type": "string",
+                    "description": "Beginning date of embargo period.",
+                    "format": "date-time"
+                },
+                "end_time": {
+                    "type": "string",
+                    "description": "End date of embargo period.",
+                    "format": "date-time"
+                }
+            }
+        },
+        "created": {
+            "type": "string",
+            "description": "Date and time of the IEEE-2791 Object creation",
+            "readOnly": true,
+            "format": "date-time"
+        },
+        "modified": {
+            "type": "string",
+            "description": "Date and time the IEEE-2791 Object was last modified",
+            "readOnly": true,
+            "format": "date-time"
+        },
+        "contributors": {
+            "type": "array",
+            "description": "This is a list to hold contributor identifiers and a description of their type of contribution, including a field for ORCIDs to record author information, as they allow for the author to curate their information after submission. The contribution type is a choice taken from PAV ontology: provenance, authoring and versioning, which also maps to the PROV-O.",
+            "items": {
+                "$ref": "2791object.json#/definitions/contributor"
+            }
+        },
+        "license": {
+            "type": "string",
+            "description": "Creative Commons license or other license information (text) space. The default or recommended license can be Attribution 4.0 International as shown in example",
+            "examples": [
+                "https://spdx.org/licenses/CC-BY-4.0.html"
+            ]
+        }
+    }
+}

--- a/lib/galaxy_test/base/schemas/ieee-2791/usability_domain.json
+++ b/lib/galaxy_test/base/schemas/ieee-2791/usability_domain.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/ieee/ieee-2791-schema/usability_domain.json",
+    "type": "array",
+    "title": "Usability Domain",
+    "description": "Author-defined usability domain of the IEEE-2791 Object. This field is to aid in search-ability and provide a specific description of the function of the object.",
+    "items": {
+        "type": "string",
+        "description": "Free text values that can be used to provide scientific reasoning and purpose for the experiment",
+        "examples": [
+            "Identify baseline single nucleotide polymorphisms SNPs [SO:0000694], insertions [so:SO:0000667], and deletions [so:SO:0000045] that correlate with reduced ledipasvir [pubchem.compound:67505836] antiviral drug efficacy in Hepatitis C virus subtype 1 [taxonomy:31646]",
+            "Identify treatment emergent amino acid substitutions [so:SO:0000048] that correlate with antiviral drug treatment failure",
+            "Determine whether the treatment emergent amino acid substitutions [so:SO:0000048] identified correlate with treatment failure involving other drugs against the same virus"
+        ]
+    }
+}

--- a/scripts/update_ieee_2791_schemas.py
+++ b/scripts/update_ieee_2791_schemas.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Update the vendored IEEE-2791 (BioCompute Object) JSON schemas.
+
+Fetches 2791object.json and every sibling schema it transitively ``$ref``s from
+https://w3id.org/ieee/ieee-2791-schema/ and writes them verbatim to
+lib/galaxy_test/base/schemas/ieee-2791/, removing vendored schemas that are no
+longer referenced. After running, update the fetch date in the README next to
+the schemas.
+"""
+
+import json
+import urllib.request
+from pathlib import Path
+
+BASE_URL = "https://w3id.org/ieee/ieee-2791-schema/"
+TOP_LEVEL_SCHEMA = "2791object.json"
+DEST_DIR = Path(__file__).parent.parent / "lib" / "galaxy_test" / "base" / "schemas" / "ieee-2791"
+
+
+def collect_sibling_refs(schema) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(schema, dict):
+        for key, value in schema.items():
+            if key == "$ref" and isinstance(value, str):
+                filename = value.split("#")[0]
+                if filename.endswith(".json") and "/" not in filename:
+                    refs.add(filename)
+            else:
+                refs.update(collect_sibling_refs(value))
+    elif isinstance(schema, list):
+        for item in schema:
+            refs.update(collect_sibling_refs(item))
+    return refs
+
+
+def fetch(filename: str) -> bytes:
+    # the IEEE host answers 418 to Python's default User-Agent
+    request = urllib.request.Request(BASE_URL + filename, headers={"User-Agent": "curl/8"})
+    with urllib.request.urlopen(request) as response:
+        content = response.read()
+    # the IEEE host sits behind a bot-challenge WAF that can serve HTML with a
+    # 200 status; make sure we actually got JSON before vendoring it
+    json.loads(content)
+    return content
+
+
+def main() -> None:
+    fetched: dict[str, bytes] = {}
+    pending = {TOP_LEVEL_SCHEMA}
+    while pending:
+        filename = pending.pop()
+        content = fetch(filename)
+        fetched[filename] = content
+        pending.update(collect_sibling_refs(json.loads(content)) - fetched.keys())
+    for stale_path in DEST_DIR.glob("*.json"):
+        if stale_path.name not in fetched:
+            stale_path.unlink()
+            print(f"Removed {stale_path.name}")
+    for filename, content in sorted(fetched.items()):
+        (DEST_DIR / filename).write_bytes(content)
+        print(f"Wrote {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -13,13 +13,17 @@ from typing import (
 )
 
 from galaxy.util.compression_utils import CompressedFile
-from galaxy_test.api.test_workflows import RunsWorkflowFixtures
+from galaxy_test.api.test_workflows import (
+    RunsWorkflowFixtures,
+    WORKFLOW_SIMPLE,
+)
 from galaxy_test.base import api_asserts
 from galaxy_test.base.api import UsesCeleryTasks
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     RunJobsSummary,
+    skip_without_tool,
     WorkflowPopulator,
 )
 from galaxy_test.driver.integration_setup import PosixFileSourceSetup
@@ -73,6 +77,17 @@ class TestWorkflowTasksIntegration(PosixFileSourceSetup, IntegrationTestCase, Us
         with open(bco_path) as f:
             bco = json.load(f)
         self.workflow_populator.validate_biocompute_object(bco)
+
+    @skip_without_tool("cat1")
+    def test_export_invocation_bco(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(WORKFLOW_SIMPLE, test_data={"input1": "hello world"}, history_id=history_id)
+            invocation_id = summary.invocation_id
+            bco_path = self.workflow_populator.download_invocation_to_store(invocation_id, extension="bco.json")
+            with open(bco_path) as f:
+                bco = json.load(f)
+            self.workflow_populator.validate_biocompute_object(bco)
+            assert bco["provenance_domain"]["name"] == "Simple Workflow"
 
     def test_export_ro_crate_with_optional_parameter_without_value(self):
         """Test exporting invocation with optional text parameter that has no value.


### PR DESCRIPTION
Fixes the CI-wide failures of `test_export_invocation_bco` and `test_export_bco_basic` that started 2026-09-01 (~22:00 UTC): the w3id.org → IEEE schema host sits behind an F5/TSPD bot-challenge WAF that intermittently serves challenge HTML (HTTP 200) to GitHub-runner IPs, so `validate_using_schema_url` blew up with a `JSONDecodeError` on every run regardless of branch. Evidence in the discussion on #23423.

## What this does

- **Vendors the IEEE-2791 schema set** under `lib/galaxy_test/base/schemas/ieee-2791/` — the top-level `2791object.json` plus the seven sibling `*_domain.json` schemas it `$ref`s by relative URL (mocking only the top-level document would still hit the WAF when jsonschema resolves the refs). Files fetched verbatim on 2026-09-02; source URL and date noted in the accompanying README.
- **Validates offline**: `validate_biocompute_object` now goes through a new `JsonSchemaValidator.validate_using_vendored_schema`, backed by a `referencing.Registry` keyed by each schema's `$id`. The public schema URL stays as the identifier; no network request can occur (an unvendored URL is a hard error, not a live fetch).
- **Moves `test_export_invocation_bco`** from `TestWorkflowsApi` into `TestWorkflowTasksIntegration` (`test/integration/test_workflow_tasks.py`), next to `test_export_bco_basic`, preserving its assertions. The API suite no longer touches BCO export.

## Verification

- `pytest test/integration/test_workflow_tasks.py -k bco -q` → 2 passed; no requests to w3id.org/IEEE hosts.
- Offline behavior proven with sockets monkeypatched out: a valid BCO validates, a BCO with a corrupted `provenance_domain` (validated via a `$ref`'d sibling schema) is rejected, and an unvendored schema URL raises instead of fetching.
- ruff (pinned 0.16.5), black, isort, mypy clean on the changed files.

## Open questions (flagging rather than guessing)

- **Vendoring location**: `lib/galaxy_test/base/schemas/ieee-2791/` follows the existing `lib/galaxy_test/base/data/` precedent and ships with `galaxy-test-base` via `include_package_data`; happy to move it if there's a preferred spot.
- **`validate_using_schema_url`**: kept with its live-fetch semantics for any external callers (nothing in-tree calls it anymore). Could be deprecated/removed instead.

## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. `pytest test/integration/test_workflow_tasks.py -k bco`

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

Update 2026-09-02: added `scripts/update_ieee_2791_schemas.py` to refresh the vendored set (walks the `$ref`s, verifies each response is JSON); the README tells maintainers to use it instead of editing the files by hand. Running it reproduces the vendored files byte for byte.
