### PR TITLE
Resolve a conditional boolean test value the way the tool loader does

### DIFF
--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -418,7 +418,7 @@ def _merge_into_state(
         handled_inputs.update(_merge_into_state(test_parameter, context, conditional_state, state_path))
         # If the discriminator was omitted, record the when _select_which_when chose so the state
         # validates against that branch rather than the phantom __absent__ branch.
-        if test_parameter.name not in conditional_state and when.discriminator is not None:
+        if when.discriminator is not None and conditional_state.get(test_parameter.name) is None:
             conditional_state[test_parameter.name] = when.discriminator
         # Mark this conditional's discriminator consumed so a nested conditional's loose fallbacks
         # do not re-match it.
@@ -545,7 +545,14 @@ def _select_which_when(
     matched_name = test_input["name"] if test_input else None
     explicit_test_value = test_input["value"] if test_input else None
     if is_boolean and isinstance(explicit_test_value, str):
-        explicit_test_value = asbool(explicit_test_value)
+        truevalue = getattr(test_parameter, "truevalue", None)
+        falsevalue = getattr(test_parameter, "falsevalue", None)
+        if truevalue is not None and explicit_test_value == truevalue:
+            explicit_test_value = True
+        elif falsevalue is not None and explicit_test_value == falsevalue:
+            explicit_test_value = False
+        else:
+            explicit_test_value = asbool(explicit_test_value)
     test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
     if test_value is None:
         # Discriminator omitted: infer the active when from the params the test provides (like

--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -354,6 +354,10 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             BooleanParameterModel | SelectParameterModel,
             _from_input_source_galaxy(test_param_input_source, profile),
         )
+        if isinstance(test_parameter, BooleanParameterModel) and test_parameter.optional:
+            test_parameter.optional = False
+            if test_parameter.value is None:
+                test_parameter.value = False
         whens = []
         default_test_value = cond_test_parameter_default_value(test_parameter)
         for value, case_inputs_sources in input_source.parse_when_input_sources():

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -55,11 +55,7 @@ TOOLS_THAT_USE_SELECT_BY_VALUE = [
     "multi_select.xml",
 ]
 
-# Figure out the problem and resolve.
-TOOLS_THAT_ARE_OUTSTANDING_ISSUES = [
-    "gx_conditional_boolean_optional.xml",
-    "gx_conditional_boolean_discriminate_on_string_value.xml",
-]
+TOOLS_THAT_ARE_OUTSTANDING_ISSUES: list[str] = []
 
 TEST_TOOL_THAT_DO_NOT_VALIDATE = (
     TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS


### PR DESCRIPTION
Six framework tool tests cannot build a typed request on dev and fail under `never`. CI only runs `if_needed` and `always`, and `if_needed` silently falls back to the legacy API, hiding these failures.

Three changes fix them. In `factory.py`, conditional boolean test parameters are forced non-optional so an omitted discriminator resolves to a default branch, matching the tool loader. In `case.py`, `truevalue` and `falsevalue` are mapped before `asbool`, and a branch is recorded when the discriminator is explicitly null so `None` is not rendered as the tag `"None"`.

Both fixtures were previously excluded through `TOOLS_THAT_ARE_OUTSTANDING_ISSUES`.

The conditional boolean tools go from 6 failed / 22 passed to 28 passed under `never`, and are unchanged under `if_needed` and `always`.