### PR TITLE
Bug fix - pick_values inputs need to be available before picking.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2175,19 +2175,21 @@ class PickValueModule(WorkflowModule):
         return state
 
     @staticmethod
-    def _is_null_or_skipped(value) -> bool:
+    def _is_null_or_skipped(value, step: WorkflowStep) -> bool:
         """Check if a replacement value represents a skipped/null output."""
         if value is NO_REPLACEMENT:
             return True
         if isinstance(value, model.HistoryDatasetAssociation):
-            if value.extension == "expression.json" and value.blurb == "skipped":
-                return True
+            if value.extension == "expression.json":
+                if value.blurb == "skipped":
+                    return True
+                return read_expression_json(value, step=step) is None
         return False
 
     def _pick_from_replacements(self, trans: "ProvidesHistoryContext", invocation_step, mode, replacements):
         """Apply pick logic to a list of replacement values. Returns the picked output."""
         step = invocation_step.workflow_step
-        non_null = [r for r in replacements if not self._is_null_or_skipped(r)]
+        non_null = [r for r in replacements if not self._is_null_or_skipped(r, step)]
 
         if mode == "first_non_null":
             if not non_null:
@@ -2389,7 +2391,7 @@ class PickValueModule(WorkflowModule):
         Uses execute_on_mapped_over which operates on step_outputs dict
         rather than requiring a Job object. Skipped outputs are left untouched.
         """
-        if self._is_null_or_skipped(output):
+        if self._is_null_or_skipped(output, step):
             return
         step_outputs = {"output": output}
         step_inputs: dict[str, Any] = {}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2231,6 +2231,8 @@ class PickValueModule(WorkflowModule):
         mode = step.tool_inputs.get("mode", "first_non_null") if step.tool_inputs else "first_non_null"
         all_inputs = self.get_all_inputs()
 
+        self._ensure_inputs_ready(trans, progress, step, all_inputs)
+
         collection_info = self.compute_collection_info(progress, step, all_inputs)
 
         if collection_info:
@@ -2247,6 +2249,17 @@ class PickValueModule(WorkflowModule):
         progress.set_step_outputs(invocation_step, {"output": output})
         self._apply_post_job_actions(trans, step, output, progress.effective_replacement_dict())
         return None
+
+    def _ensure_inputs_ready(self, trans: "WorkRequestContext", progress: "WorkflowProgress", step, all_inputs) -> None:
+        """Delay this step until the inputs it picks from have been produced.
+
+        A tool step can be scheduled against a dataset that is still running - the job queue
+        orders the work. This module cannot. It reads the inputs to decide which one to pick,
+        and the picked output aliases that dataset rather than copying it, so a post job
+        action on this step mutates an upstream job's output. Both need that job finished.
+        """
+        for input_dict in all_inputs:
+            progress.replacement_for_input(trans, step, input_dict, require_ready=True)
 
     def _execute_mapped(self, trans: "ProvidesHistoryContext", invocation_step, mode, all_inputs, collection_info):
         """Execute pick_value mapped over collection inputs."""

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2183,6 +2183,10 @@ class PickValueModule(WorkflowModule):
             if value.extension == "expression.json":
                 if value.blurb == "skipped":
                     return True
+                if not value.is_ok:
+                    # A failed expression output has no readable value, but failure is
+                    # not null. Preserve it so downstream failure filters can handle it.
+                    return False
                 return read_expression_json(value, step=step) is None
         return False
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -460,7 +460,11 @@ class WorkflowProgress:
         return remaining_steps
 
     def replacement_for_input(
-        self, trans: "ProvidesHistoryContext", step: "WorkflowStep", input_dict: dict[str, Any]
+        self,
+        trans: "ProvidesHistoryContext",
+        step: "WorkflowStep",
+        input_dict: dict[str, Any],
+        require_ready: bool = False,
     ) -> modules.StepInputReplacement:
         replacement: modules.StepInputReplacement = NO_REPLACEMENT
         prefixed_name = input_dict["name"]
@@ -469,7 +473,7 @@ class WorkflowProgress:
         if prefixed_name in step.input_connections_by_name:
             connection = step.input_connections_by_name[prefixed_name]
             if input_dict["input_type"] == "dataset" and multiple:
-                temp = [self.replacement_for_connection(c) for c in connection]
+                temp = [self.replacement_for_connection(c, require_ready=require_ready) for c in connection]
                 # If replacement is just one dataset collection, replace tool
                 # input_dict with dataset collection - tool framework will extract
                 # datasets properly.
@@ -481,7 +485,9 @@ class WorkflowProgress:
                 else:
                     replacement = temp
             else:
-                replacement = self.replacement_for_connection(connection[0], is_data=is_data)
+                replacement = self.replacement_for_connection(
+                    connection[0], is_data=is_data, require_ready=require_ready
+                )
         elif (
             step.state
             and (state_input := get_path(step.state.inputs, nested_key_to_path(prefixed_name), None))
@@ -497,7 +503,9 @@ class WorkflowProgress:
                 replacement = raw_to_galaxy(trans.app, trans.history, step_input.default_value)
         return replacement
 
-    def replacement_for_connection(self, connection: "WorkflowStepConnection", is_data: bool = True):
+    def replacement_for_connection(
+        self, connection: "WorkflowStepConnection", is_data: bool = True, require_ready: bool = False
+    ):
         output_step_id = connection.output_step.id
         output_name = connection.output_name
         if output_step_id not in self.outputs:
@@ -552,11 +560,24 @@ class WorkflowProgress:
 
         if isinstance(replacement, model.DatasetCollection):
             raise NotImplementedError
-        if not is_data and isinstance(
+        # A parameter connection needs the value itself, so it always waits. A data connection
+        # normally does not - the tool framework hands the job a dataset that is still being
+        # produced and the job queue sorts out the ordering. Modules that read or mutate the
+        # data while scheduling opt in with require_ready.
+        if (not is_data or require_ready) and isinstance(
             replacement, (model.HistoryDatasetAssociation, model.HistoryDatasetCollectionAssociation)
         ):
+
+            def not_yet_available(dataset_instance: model.DatasetInstance) -> bool:
+                # Modules waiting on data wait the way DatabaseOperationTool.check_inputs_ready
+                # does - a paused input can still be resumed by the user, so delay rather than
+                # fail the invocation over it.
+                if dataset_instance.is_pending:
+                    return True
+                return require_ready and dataset_instance.state == model.Dataset.states.PAUSED
+
             if isinstance(replacement, model.HistoryDatasetAssociation):
-                if replacement.is_pending:
+                if not_yet_available(replacement):
                     raise modules.DelayedWorkflowEvaluation()
                 if not replacement.is_ok:
                     raise modules.FailWorkflowEvaluation(
@@ -572,7 +593,7 @@ class WorkflowProgress:
                     raise modules.DelayedWorkflowEvaluation()
                 pending = False
                 for dataset_instance in replacement.dataset_instances:
-                    if dataset_instance.is_pending:
+                    if not_yet_available(dataset_instance):
                         pending = True
                     elif not dataset_instance.is_ok:
                         raise modules.FailWorkflowEvaluation(

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -579,7 +579,7 @@ class WorkflowProgress:
             if isinstance(replacement, model.HistoryDatasetAssociation):
                 if not_yet_available(replacement):
                     raise modules.DelayedWorkflowEvaluation()
-                if not replacement.is_ok:
+                if not is_data and not replacement.is_ok:
                     raise modules.FailWorkflowEvaluation(
                         why=InvocationFailureDatasetFailed(
                             reason=FailureReason.dataset_failed,
@@ -595,7 +595,7 @@ class WorkflowProgress:
                 for dataset_instance in replacement.dataset_instances:
                     if not_yet_available(dataset_instance):
                         pending = True
-                    elif not dataset_instance.is_ok:
+                    elif not is_data and not dataset_instance.is_ok:
                         raise modules.FailWorkflowEvaluation(
                             why=InvocationFailureDatasetFailed(
                                 reason=FailureReason.dataset_failed,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3476,14 +3476,25 @@ outputs:
 """)
         with self.dataset_populator.test_history() as history_id:
             invocation_id = self.workflow_populator.invoke_workflow(workflow_id, history_id=history_id).json()["id"]
+
+            def step_output_id(step_label):
+                invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+                invocation_step = next(
+                    (step for step in invocation["steps"] if step["workflow_step_label"] == step_label), None
+                )
+                if invocation_step and (output := invocation_step["outputs"].get("out_file1")):
+                    return output["id"]
+                return None
+
+            failed_dataset_id = wait_on(lambda: step_output_id("job_props"), "job_props output to be created")
+            failed_state = self.dataset_populator.wait_for_dataset(history_id, failed_dataset_id, assert_ok=False)
+            assert failed_state == "error", failed_state
             failed_dataset = self.dataset_populator.get_history_dataset_details(
-                history_id, hid=1, wait=True, assert_ok=False
+                history_id, content_id=failed_dataset_id, wait=False
             )
-            assert failed_dataset["state"] == "error", failed_dataset
-            paused_dataset = self.dataset_populator.get_history_dataset_details(
-                history_id, hid=5, wait=True, assert_ok=False
-            )
-            assert paused_dataset["state"] == "paused", paused_dataset
+            paused_dataset_id = wait_on(lambda: step_output_id("branch"), "branch output to be created")
+            paused_state = self.dataset_populator.wait_for_dataset(history_id, paused_dataset_id, assert_ok=False)
+            assert paused_state == "paused", paused_state
             invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
             pick_step = next(step for step in invocation["steps"] if step["workflow_step_label"] == "pick")
             assert pick_step["state"] == "new", pick_step

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3343,6 +3343,100 @@ input_data:
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
             assert invocation["state"] == "failed"
 
+    @skip_without_tool("exit_code_from_file")
+    def test_pick_value_input_failed(self):
+        # pick_value reads its inputs while scheduling, so it has to wait for the jobs
+        # producing them - scheduling against an unfinished input would pick a dataset
+        # that only later turns out to have failed.
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_code:
+    type: data
+steps:
+  branch:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_code:
+  content: "1"
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["state"] == "failed"
+            assert len(invocation["messages"]) == 1
+            message = invocation["messages"][0]
+            assert message["reason"] == "dataset_failed"
+
+    @skip_without_tool("job_properties")
+    @skip_without_tool("cat1")
+    def test_pick_value_input_paused(self):
+        # A paused input can be resumed by the user, so pick_value waits for it the way
+        # DatabaseOperationTool inputs do rather than failing the invocation over it.
+        workflow_id = self._upload_yaml_workflow("""class: GalaxyWorkflow
+steps:
+  job_props:
+    tool_id: job_properties
+    state:
+      thebool: true
+      failbool: true
+  branch:
+    tool_id: cat1
+    in:
+      input1: job_props/out_file1
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""")
+        with self.dataset_populator.test_history() as history_id:
+            invocation_id = self.workflow_populator.invoke_workflow(workflow_id, history_id=history_id).json()["id"]
+            failed_dataset = self.dataset_populator.get_history_dataset_details(
+                history_id, hid=1, wait=True, assert_ok=False
+            )
+            assert failed_dataset["state"] == "error", failed_dataset
+            paused_dataset = self.dataset_populator.get_history_dataset_details(
+                history_id, hid=5, wait=True, assert_ok=False
+            )
+            assert paused_dataset["state"] == "paused", paused_dataset
+            self.dataset_populator.run_tool(
+                tool_id="job_properties",
+                inputs={
+                    "thebool": "false",
+                    "failbool": "false",
+                    "rerun_remap_job_id": failed_dataset["creating_job"],
+                },
+                history_id=history_id,
+            )
+            self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=False)
+            invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+            assert invocation["state"] == "scheduled", invocation
+            picked = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
+            )
+            assert picked["state"] == "ok", picked
+
     def test_pick_value_first_or_skip(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3343,6 +3343,43 @@ input_data:
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
             assert invocation["state"] == "failed"
 
+    @skip_without_tool("expression_parse_int")
+    @skip_without_tool("expression_forty_two")
+    def test_pick_value_runtime_null(self):
+        # Expression tools run as jobs and can compute null: parseInt produces NaN for
+        # this input, which the expression runtime serializes as null. The picker must
+        # wait for that value before it can reject it and use the fallback.
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+steps:
+  runtime_null:
+    tool_id: expression_parse_int
+    state:
+      input1: not a number
+  fallback:
+    tool_id: expression_forty_two
+    state: {}
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: runtime_null/out1
+      input_1: fallback/out1
+outputs:
+  picked:
+    outputSource: pick/output
+test_data: {}
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked_content = self.dataset_populator.get_history_dataset_content(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert picked_content == "42"
+
     @skip_without_tool("exit_code_from_file")
     def test_pick_value_input_failed(self):
         # pick_value reads its inputs while scheduling, so it has to wait for the jobs
@@ -3431,7 +3468,7 @@ outputs:
             )
             self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=False)
             invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
-            assert invocation["state"] == "scheduled", invocation
+            assert invocation["state"] in ("scheduled", "completed"), invocation
             picked = self.dataset_populator.get_history_dataset_details(
                 history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
             )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3457,6 +3457,10 @@ outputs:
                 history_id, hid=5, wait=True, assert_ok=False
             )
             assert paused_dataset["state"] == "paused", paused_dataset
+            invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+            pick_step = next(step for step in invocation["steps"] if step["workflow_step_label"] == "pick")
+            assert pick_step["state"] == "new", pick_step
+            assert pick_step["outputs"] == {}, pick_step
             self.dataset_populator.run_tool(
                 tool_id="job_properties",
                 inputs={

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3381,10 +3381,11 @@ test_data: {}
             assert picked_content == "42"
 
     @skip_without_tool("exit_code_from_file")
+    @skip_without_tool("__BUILD_LIST__")
+    @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_pick_value_input_failed(self):
-        # pick_value reads its inputs while scheduling, so it has to wait for the jobs
-        # producing them - scheduling against an unfinished input would pick a dataset
-        # that only later turns out to have failed.
+        # Failure is terminal, not null. Preserve the failed dataset as the picked
+        # output so downstream failure filters can handle it without failing scheduling.
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(
                 """class: GalaxyWorkflow
@@ -3402,9 +3403,26 @@ steps:
       mode: first_or_skip
     in:
       input_0: branch/out_file1
+  list:
+    tool_id: __BUILD_LIST__
+    in:
+      datasets_0|input: pick/output
+      datasets_1|input: exit_code
+    state:
+      datasets:
+      - id_cond:
+          id_select: id
+      - id_cond:
+          id_select: id
+  filter_failed:
+    tool_id: __FILTER_FAILED_DATASETS__
+    in:
+      input: list/output
 outputs:
   picked:
     outputSource: pick/output
+  filtered:
+    outputSource: filter_failed/output
 """,
                 test_data="""
 exit_code:
@@ -3416,10 +3434,19 @@ exit_code:
                 wait=True,
             )
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
-            assert invocation["state"] == "failed"
-            assert len(invocation["messages"]) == 1
-            message = invocation["messages"][0]
-            assert message["reason"] == "dataset_failed"
+            assert invocation["state"] in ("scheduled", "completed"), invocation
+            assert invocation["messages"] == [], invocation
+            picked = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
+            )
+            assert picked["state"] == "error", picked
+            filtered = self.dataset_populator.get_history_collection_details(
+                history_id,
+                content_id=invocation["output_collections"]["filtered"]["id"],
+                assert_ok=False,
+            )
+            assert len(filtered["elements"]) == 1, filtered
+            assert filtered["elements"][0]["object"]["state"] == "ok", filtered
 
     @skip_without_tool("job_properties")
     @skip_without_tool("cat1")


### PR DESCRIPTION
Picking values requires dataset contents - not just metadata. Any expression tool can produce null values I believe so we have to wait for tool execution to complete. (Put another way - the input jobs need to be complete not just scheduled.) For this reason I'm pretty sure we always need to wait for all inputs to be realized before we do the picking. These tests kind of suck compared https://github.com/galaxyproject/galaxy/pull/23330.

I was wondering if this is only true if the pick value steps have PJA... this might allow use to optimize this wait - and maybe if we were only picking from skipped whens that would always be available at schedule time and so we could restrict that. But I think the pick value semantics are based on expression values (is it null or not) not whether jobs were skipped or not.

How did the concept of a regular tool that tried to do this value picking never encounter these bugs is a real question that gives me pause. I guess because we didn't put PJA on them and we don't have any common expression tools that produce null outputs?

This PR has some big Opus 5-y comment blobs but I feel like I learned from each. I'd rate their quality as an A for the docstring on _ensure_inputs_ready, B- for docstring on not_yet_available, and B for the blob using require_ready. I can remove these latter two comments if requested.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
