### PR TITLE
[26.1] Retry GETs answered with foreign HTML while bypassing the browser cache

### DIFF
--- a/client/src/api/client/index.ts
+++ b/client/src/api/client/index.ts
@@ -2,6 +2,7 @@ import createClient from "openapi-fetch";
 
 import { pendingRequestsMiddleware } from "@/api/client/pendingRequestsMiddleware";
 import { createRateLimiterMiddleware } from "@/api/client/rateLimiter";
+import { staleCacheRetryMiddleware } from "@/api/client/staleCacheRetryMiddleware";
 import type { GalaxyApiPaths } from "@/api/schema";
 import { getAppRoot } from "@/onload/loadConfig";
 
@@ -25,6 +26,8 @@ function apiClientFactory() {
             maxRetries: 3,
         }),
     );
+
+    client.use(staleCacheRetryMiddleware);
 
     return client;
 }

--- a/client/src/api/client/staleCacheRetryMiddleware.test.ts
+++ b/client/src/api/client/staleCacheRetryMiddleware.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GalaxyApi } from "@/api/client";
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
+import { REQUEST_ID_HEADER } from "@/api/staleCacheRetry";
+
+const { server, http } = useServerMock();
+
+const HTML = "<!doctype html><html><body>failover</body></html>";
+const HISTORY = { id: "abc", name: "recovered" };
+const GALAXY_HEADERS = { [REQUEST_ID_HEADER]: "3f2c0d1e9a8b4c7d8e6f5a4b3c2d1e0f" };
+
+/** Answers foreign HTML for the first `htmlCount` requests and Galaxy JSON afterwards. */
+function serveHtmlThenJson(htmlCount: number, htmlHeaders = {}) {
+    const cacheControlHeaders: (string | null)[] = [];
+    server.use(
+        http.get("/api/histories/{history_id}", ({ request, response }) => {
+            cacheControlHeaders.push(request.headers.get("Cache-Control"));
+            if (cacheControlHeaders.length <= htmlCount) {
+                return response.untyped(
+                    new HttpResponse(HTML, { headers: { "Content-Type": "text/html", ...htmlHeaders } }),
+                );
+            }
+            return response(200).json(HISTORY as never, { headers: GALAXY_HEADERS });
+        }),
+    );
+    return cacheControlHeaders;
+}
+
+const HISTORY_PARAMS = { params: { path: { history_id: "abc" } } };
+
+describe("staleCacheRetryMiddleware", () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+        consoleWarnSpy.mockRestore();
+    });
+
+    it("retries a foreign HTML GET response with the cache bypassed", async () => {
+        const cacheControlHeaders = serveHtmlThenJson(1);
+
+        const { data, response } = await GalaxyApi().GET("/api/histories/{history_id}", HISTORY_PARAMS);
+
+        expect(response.status).toBe(200);
+        expect(data).toMatchObject(HISTORY);
+        // happy-dom's Request has no `cache` property, so only the header is observable.
+        expect(cacheControlHeaders).toEqual([null, "no-cache"]);
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry JSON responses", async () => {
+        const cacheControlHeaders = serveHtmlThenJson(0);
+
+        const { data } = await GalaxyApi().GET("/api/histories/{history_id}", HISTORY_PARAMS);
+
+        expect(data).toMatchObject(HISTORY);
+        expect(cacheControlHeaders).toEqual([null]);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not retry HTML produced by Galaxy", async () => {
+        const cacheControlHeaders = serveHtmlThenJson(Infinity, GALAXY_HEADERS);
+
+        const { data } = await GalaxyApi().GET("/api/histories/{history_id}", { ...HISTORY_PARAMS, parseAs: "text" });
+
+        expect(data).toBe(HTML);
+        expect(cacheControlHeaders).toEqual([null]);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not retry when the caller asked for HTML", async () => {
+        const cacheControlHeaders = serveHtmlThenJson(Infinity);
+
+        const { data } = await GalaxyApi().GET("/api/histories/{history_id}", {
+            ...HISTORY_PARAMS,
+            headers: { Accept: "text/html" },
+            parseAs: "text",
+        });
+
+        expect(data).toBe(HTML);
+        expect(cacheControlHeaders).toEqual([null]);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/api/client/staleCacheRetryMiddleware.ts
+++ b/client/src/api/client/staleCacheRetryMiddleware.ts
@@ -1,0 +1,28 @@
+import type { Middleware } from "openapi-fetch";
+
+import { isForeignHtmlResponse, NO_CACHE_HEADERS, REQUEST_ID_HEADER } from "@/api/staleCacheRetry";
+
+/** ``openapi-fetch`` counterpart of ``installStaleCacheRetryInterceptor``, see ``@/api/staleCacheRetry``. */
+export const staleCacheRetryMiddleware: Middleware = {
+    async onResponse({ request, response }) {
+        if (request.cache === "no-cache" || request.headers.get("Accept")?.includes("text/html")) {
+            return response;
+        }
+        const isPoisoned = isForeignHtmlResponse({
+            method: request.method,
+            status: response.status,
+            contentType: response.headers.get("content-type"),
+            requestId: response.headers.get(REQUEST_ID_HEADER),
+        });
+        if (!isPoisoned) {
+            return response;
+        }
+        console.warn(`Received foreign HTML for ${request.url}; retrying with the browser cache bypassed.`);
+        const headers = new Headers(request.headers);
+        for (const [name, value] of Object.entries(NO_CACHE_HEADERS)) {
+            headers.set(name, value);
+        }
+        // Bypasses the rest of the middleware chain, like the rate limiter's retry.
+        return fetch(new Request(request, { cache: "no-cache", headers }));
+    },
+};

--- a/client/src/api/staleCacheRetry.test.ts
+++ b/client/src/api/staleCacheRetry.test.ts
@@ -1,0 +1,119 @@
+import axios, { type AxiosAdapter, type InternalAxiosRequestConfig } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installStaleCacheRetryInterceptor, isForeignHtmlResponse } from "./staleCacheRetry";
+
+const HTML = "<!doctype html><html><body>failover</body></html>";
+const JSON_BODY = { stats: { total_matches: 1 }, contents: [] };
+const GALAXY_HEADERS = { "x-request-id": "3f2c0d1e9a8b4c7d8e6f5a4b3c2d1e0f" };
+const MAX_REQUESTS_PER_CALL = 3;
+
+function answer(config: InternalAxiosRequestConfig, data: unknown, contentType: string, extraHeaders = {}) {
+    return { data, status: 200, statusText: "OK", headers: { "content-type": contentType, ...extraHeaders }, config };
+}
+
+/** Answers foreign HTML for the first `htmlCount` calls and Galaxy JSON afterwards. */
+function createClient(htmlCount: number, htmlHeaders = {}) {
+    const requests: InternalAxiosRequestConfig[] = [];
+    const adapter: AxiosAdapter = async (config) => {
+        requests.push(config);
+        if (requests.length > MAX_REQUESTS_PER_CALL) {
+            throw new Error(`runaway retry loop: ${requests.length} requests`);
+        }
+        return requests.length <= htmlCount
+            ? answer(config, HTML, "text/html", htmlHeaders)
+            : answer(config, JSON_BODY, "application/json", GALAXY_HEADERS);
+    };
+    const client = axios.create({ adapter });
+    installStaleCacheRetryInterceptor(client);
+    return { client, requests };
+}
+
+describe("isForeignHtmlResponse", () => {
+    const poisoned = {
+        method: "get",
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        requestId: null,
+    };
+
+    it.each(["get", "GET", "head", "HEAD", undefined])(
+        "matches a successful HTML %s without a request id",
+        (method) => {
+            expect(isForeignHtmlResponse({ ...poisoned, method })).toBe(true);
+        },
+    );
+
+    it.each([
+        ["a POST", { method: "post" }],
+        ["a PUT", { method: "put" }],
+        ["a DELETE", { method: "delete" }],
+        ["a non-2xx status", { status: 503 }],
+        ["a JSON body", { contentType: "application/json" }],
+        ["a missing content type", { contentType: null }],
+        ["HTML produced by Galaxy", { requestId: GALAXY_HEADERS["x-request-id"] }],
+    ])("ignores %s", (_label, override) => {
+        expect(isForeignHtmlResponse({ ...poisoned, ...override })).toBe(false);
+    });
+});
+
+describe("installStaleCacheRetryInterceptor", () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+        consoleWarnSpy.mockRestore();
+    });
+
+    it.each(["get", "head"] as const)(
+        "retries a foreign HTML %s response with the cache bypassed and returns the retry",
+        async (method) => {
+            const { client, requests } = createClient(1);
+            const { data } = await client[method]("/api/histories/abc/contents?v=dev&offset=0");
+            expect(data).toEqual(JSON_BODY);
+            expect(requests).toHaveLength(2);
+            expect(requests[0]!.headers.get("Cache-Control")).toBeUndefined();
+            expect(requests[1]!.headers.get("Cache-Control")).toBe("no-cache");
+            expect(requests[1]!.headers.get("Pragma")).toBe("no-cache");
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it("gives up after one retry", async () => {
+        const { client, requests } = createClient(Infinity);
+        const { data } = await client.get("/api/histories/abc/contents");
+        expect(data).toBe(HTML);
+        expect(requests).toHaveLength(2);
+    });
+
+    it("passes JSON responses through untouched", async () => {
+        const { client, requests } = createClient(0);
+        const { data } = await client.get("/api/histories/abc/contents");
+        expect(data).toEqual(JSON_BODY);
+        expect(requests).toHaveLength(1);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("passes HTML produced by Galaxy through untouched", async () => {
+        const { client, requests } = createClient(Infinity, GALAXY_HEADERS);
+        const { data } = await client.get("/api/histories/h/contents/abc/display");
+        expect(data).toBe(HTML);
+        expect(requests).toHaveLength(1);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["a POST", (client) => client.post("/api/histories", {})],
+        ["a non-JSON responseType", (client) => client.get("/api/histories/abc/contents", { responseType: "text" })],
+    ] as [string, (client: ReturnType<typeof createClient>["client"]) => Promise<unknown>][])(
+        "does not retry %s",
+        async (_label, call) => {
+            const { client, requests } = createClient(Infinity);
+            await call(client);
+            expect(requests).toHaveLength(1);
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        },
+    );
+});

--- a/client/src/api/staleCacheRetry.ts
+++ b/client/src/api/staleCacheRetry.ts
@@ -1,0 +1,80 @@
+/**
+ * Retries GET/HEAD responses that the browser served from a cache entry
+ * poisoned by a failover page.
+ *
+ * A failover page answering every path with a cacheable ``200 text/html``
+ * (nginx ``try_files ... /index.html`` without ``Cache-Control``) gets cached
+ * under whatever URL the client requested during the outage. Stable URLs such
+ * as the history panel's initial contents fetch then keep returning that HTML
+ * for as long as heuristic freshness lasts, which can be weeks.
+ *
+ * Galaxy stamps ``X-Request-ID`` on every response and the cache keeps
+ * response headers, so HTML without it did not come from Galaxy. Such a
+ * response is re-requested with ``Cache-Control: no-cache``: Galaxy ignores
+ * the failover page's validators and answers 200, replacing the cached body.
+ * Genuine HTML served by a file server or object store (no request id) only
+ * costs a conditional request answered with 304.
+ */
+import axios, { AxiosHeaders, type AxiosInstance, type AxiosResponse } from "axios";
+
+export const NO_CACHE_HEADERS: Readonly<Record<string, string>> = {
+    "Cache-Control": "no-cache",
+    Pragma: "no-cache",
+};
+
+export const REQUEST_ID_HEADER = "X-Request-ID";
+
+const CACHEABLE_METHODS = ["get", "head"];
+
+interface ResponseDescription {
+    method: string | undefined;
+    status: number;
+    contentType: string | null | undefined;
+    requestId: string | null | undefined;
+}
+
+/** True for a successful ``GET``/``HEAD`` answered with an HTML page that Galaxy did not produce. */
+export function isForeignHtmlResponse({ method, status, contentType, requestId }: ResponseDescription): boolean {
+    if (!CACHEABLE_METHODS.includes((method ?? "get").toLowerCase())) {
+        return false;
+    }
+    if (status < 200 || status >= 300) {
+        return false;
+    }
+    if (!contentType || !contentType.toLowerCase().startsWith("text/html")) {
+        return false;
+    }
+    return !requestId;
+}
+
+/**
+ * Registers a response interceptor on ``instance`` (the global axios by
+ * default) that retries foreign HTML answers with the cache bypassed. Call
+ * once at app boot.
+ */
+export function installStaleCacheRetryInterceptor(instance: AxiosInstance = axios) {
+    instance.interceptors.response.use(async (response: AxiosResponse) => {
+        const config = response.config;
+        const responseType = config.responseType ?? "json";
+        if (responseType !== "json") {
+            return response;
+        }
+        const alreadyRetried = config.headers.get("Cache-Control") === NO_CACHE_HEADERS["Cache-Control"];
+        if (alreadyRetried) {
+            return response;
+        }
+        const isPoisoned = isForeignHtmlResponse({
+            method: config.method,
+            status: response.status,
+            contentType: String(response.headers["content-type"] ?? ""),
+            requestId: String(response.headers[REQUEST_ID_HEADER.toLowerCase()] ?? ""),
+        });
+        if (!isPoisoned) {
+            return response;
+        }
+        const url = instance.getUri(config);
+        console.warn(`Received foreign HTML for ${url}; retrying with the browser cache bypassed.`);
+        const headers = new AxiosHeaders(config.headers).set(NO_CACHE_HEADERS);
+        return instance.request({ ...config, headers });
+    });
+}

--- a/client/src/entry/analysis/index.ts
+++ b/client/src/entry/analysis/index.ts
@@ -3,6 +3,7 @@ import { createPinia, PiniaVuePlugin } from "pinia";
 import Vue from "vue";
 
 import { installPendingRequestsInterceptor } from "@/api/pendingRequests";
+import { installStaleCacheRetryInterceptor } from "@/api/staleCacheRetry";
 import { initGalaxyInstance } from "@/app";
 import { initSentry } from "@/app/addons/sentry";
 import { initWebhooks } from "@/app/addons/webhooks";
@@ -19,6 +20,7 @@ const pinia = createPinia();
 // navigates — otherwise their late ``Set-Cookie: galaxysession=<anon>`` can
 // clobber the authenticated cookie.
 installPendingRequestsInterceptor();
+installStaleCacheRetryInterceptor();
 
 window.addEventListener("load", async () => {
     // Create Galaxy object


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/23382

During Galaxy Australia's outage the failover nginx served `index.html` with a `200 text/html` for every path, including API GETs, without a `Cache-Control` header. Browsers cached those responses heuristically (static files carry `Last-Modified`, so the freshness window is roughly 10% of the file's age, weeks for an old failover page). Stable URLs such as the history panel's initial `/api/histories/<id>/contents?...&offset=0` fetch then kept returning HTML after the outage. The panel swallowed the parse error, so items created before the outage never appeared while the timestamped change poller still delivered new ones. Only clearing the browser cache helped.

Galaxy stamps `X-Request-ID` on every response it produces and the browser cache stores response headers with the entry, so a `text/html` answer to a GET or HEAD without that header did not come from Galaxy. This PR treats such a response as a poisoned cache entry and re-issues the request once with `Cache-Control: no-cache`. That revalidates rather than refetches: Galaxy ignores the failover page's validators and answers 200, replacing the cached body, while genuine HTML content served by a file server or object store (which carries no request id, e.g. an `html` dataset via `X-Accel-Redirect`) only costs a 304. Both HTTP layers are covered: an axios response interceptor for the path the history panel uses, and an `openapi-fetch` middleware for `GalaxyApi()`.

Affected users self-heal on their next page load after deploying this. The failover page itself should still answer `503` with `Cache-Control: no-store`; that recommendation is in the issue.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Put nginx in front of Galaxy with `location / { try_files $uri $uri/ /index.html; }` pointing at a static `index.html` with an old mtime, load a history, then switch nginx back to proxying Galaxy.
  2. Without this PR the history panel stays partially empty and DevTools shows the contents request served `text/html` from disk cache. With it, the console warns once and the panel loads.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

---
*Description written by Claude Code (Fable 5.1, default effort) on behalf of @mvdbeek.*
