### PR TITLE
[26.1] Fix flaky datatype selection in workflow editor selenium tests

### DIFF
--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -180,6 +180,32 @@ const currentValue = computed({
 });
 
 /**
+ * Stable identifier for an option, so an option can be addressed by what it selects
+ * rather than by its position in the list or its rendered label.
+ */
+function optionIdentifier(option: SelectOption): string {
+    if (option.key !== undefined) {
+        return option.key;
+    }
+    if (typeof option.value === "string" || typeof option.value === "number") {
+        return String(option.value);
+    }
+    return option.label;
+}
+
+/**
+ * Identifier of the selected option, exposed on the root element. Only meaningful
+ * for single selects, where exactly one option can be selected.
+ */
+const selectedValueIdentifier = computed(() => {
+    if (props.multiple) {
+        return undefined;
+    }
+    const selected = currentValue.value[0];
+    return selected ? optionIdentifier(selected) : undefined;
+});
+
+/**
  * Ensures that an initial value is selected for non-optional inputs
  */
 function setInitialValue(): void {
@@ -236,7 +262,7 @@ function isSelected(item: SelectValue): boolean {
 </script>
 
 <template>
-    <div>
+    <div :data-selected-value="selectedValueIdentifier">
         <Multiselect
             v-if="hasOptions"
             :id="id"
@@ -258,7 +284,9 @@ function isSelected(item: SelectValue): boolean {
             @open="onOpen"
             @close="onClose">
             <template v-slot:option="{ option }">
-                <div class="d-flex align-items-center justify-content-between">
+                <div
+                    class="d-flex align-items-center justify-content-between"
+                    :data-option-value="optionIdentifier(option)">
                     <div>
                         <span>{{ option.label }}</span>
                         <StatelessTags

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1111,15 +1111,11 @@ workflow_editor:
       type: xpath
       selector: >
         //div[@data-label='Rename dataset']//input
-    change_datatype:
-      type: xpath
-      selector: >
-        //div[@data-label='Change datatype']//div[contains(@class, 'multiselect')]
-    select_datatype_text_search: "div[data-label='Change datatype'] .multiselect__input"
-    select_datatype:
-      type: xpath
-      selector: >
-        //div[@data-label='Change datatype']//li[contains(@class,"multiselect__element")]//span[normalize-space()="${datatype}"]
+    change_datatype: "#pja__${output}__ChangeDatatypeAction__newtype [role='combobox']"
+    select_datatype_text_search: "#pja__${output}__ChangeDatatypeAction__newtype [role='combobox'] input"
+    select_datatype: "#pja__${output}__ChangeDatatypeAction__newtype [data-option-value='${datatype}']"
+    select_datatype_option_not_matching: "#pja__${output}__ChangeDatatypeAction__newtype [data-option-value]:not([data-option-value*='${text}' i])"
+    selected_datatype: "#pja__${output}__ChangeDatatypeAction__newtype [data-selected-value]"
     add_tags_button:
       type: xpath
       selector: >

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -461,6 +461,8 @@ interface Rootworkflow_editor extends Component {
     change_datatype: SelectorTemplate;
     select_datatype_text_search: SelectorTemplate;
     select_datatype: SelectorTemplate;
+    select_datatype_option_not_matching: SelectorTemplate;
+    selected_datatype: SelectorTemplate;
     add_tags: SelectorTemplate;
     remove_tags: SelectorTemplate;
     tool_version_button: SelectorTemplate;

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -50,7 +50,10 @@ from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     requests,
 )
-from galaxy.util.wait import wait_on
+from galaxy.util.wait import (
+    TimeoutAssertionError,
+    wait_on,
+)
 from .has_driver import (
     exception_indicates_click_intercepted,
     exception_indicates_not_clickable,
@@ -1496,6 +1499,35 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
 
         license_selector_option = self.components.workflow_editor.license_selector_option
         license_selector_option.wait_for_and_click()
+
+    def workflow_editor_change_output_datatype(self, output: str, datatype: str) -> None:
+        """Pick ``datatype`` in the "Change datatype" multiselect of the output card for ``output``.
+
+        Typing into the search box re-filters the option list asynchronously and vue-multiselect
+        keys its option elements by index, so an option located before the filtered list is
+        rendered stays attached but ends up bound to whichever datatype occupies that index
+        afterwards. Only click once every option that does not match the search text is gone, then
+        check what the control reports as selected.
+        """
+        editor = self.components.workflow_editor
+        editor.change_datatype(output=output).wait_for_and_click()
+        editor.select_datatype_text_search(output=output).wait_for_and_send_keys(datatype)
+        editor.select_datatype_option_not_matching(output=output, text=datatype).wait_for_absent()
+        editor.select_datatype(output=output, datatype=datatype).wait_for_and_click()
+
+        selected = editor.selected_datatype(output=output)
+        selected.wait_for_present()
+        try:
+            self._wait_on(
+                lambda: selected.data_value("selected-value") == datatype or None,
+                f"'Change datatype' selection for output [{output}] to be [{datatype}]",
+                wait_type=WAIT_TYPES.UX_TRANSITION,
+            )
+        except TimeoutAssertionError as e:
+            raise AssertionError(
+                f"Selected [{selected.data_value('selected-value')}] in 'Change datatype' for "
+                f"output [{output}] instead of [{datatype}]"
+            ) from e
 
     def workflow_editor_license_text(self) -> str:
         editor = self.components.workflow_editor

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -753,9 +753,7 @@ steps:
         node = editor.node._(label="create_2")
         node.wait_for_and_click()
         editor.configure_output(output="out_file1").wait_for_and_click()
-        editor.change_datatype.wait_for_and_click()
-        editor.select_datatype_text_search.wait_for_and_send_keys("bam")
-        editor.select_datatype(datatype="bam").wait_for_and_click()
+        self.workflow_editor_change_output_datatype("out_file1", "bam")
         editor.node.output_data_row(output_name="out_file1", extension="bam").wait_for_visible()
         self.assert_connection_invalid("create_2#out_file1", "checksum#input")
         # Assert save button
@@ -766,9 +764,7 @@ steps:
         self.components.confirm_dialog._.wait_for_absent_or_hidden()
         # Make connection valid again
         editor.configure_output(output="out_file1").wait_for_and_click()
-        editor.change_datatype.wait_for_and_click()
-        editor.select_datatype_text_search.wait_for_and_send_keys("tabular")
-        editor.select_datatype(datatype="tabular").wait_for_and_click()
+        self.workflow_editor_change_output_datatype("out_file1", "tabular")
         # Assert connection is valid
         self.assert_connected("create_2#out_file1", "checksum#input")
 
@@ -865,9 +861,7 @@ steps:
         output_label = editor.label_output(output="out_file1")
         self.set_text_element(output_label, "workflow output label")
         self.set_text_element(editor.rename_output, "renamed_output")
-        editor.change_datatype.wait_for_and_click()
-        editor.select_datatype_text_search.wait_for_and_send_keys("bam")
-        editor.select_datatype(datatype="bam").wait_for_and_click()
+        self.workflow_editor_change_output_datatype("out_file1", "bam")
         editor.add_tags_button.wait_for_and_click()
         editor.add_tags_input.wait_for_and_send_keys("#crazynewtag" + Keys.ENTER + Keys.ESCAPE)
         editor.remove_tags_button.wait_for_and_click()
@@ -1140,9 +1134,7 @@ steps:
         pick_node.wait_for_and_click()
         # Expand the output card — PJA controls are inside a collapsed FormCard
         editor.configure_output(output="output").wait_for_and_click()
-        editor.change_datatype.wait_for_and_click()
-        editor.select_datatype_text_search.wait_for_and_send_keys("bam")
-        editor.select_datatype(datatype="bam").wait_for_and_click()
+        self.workflow_editor_change_output_datatype("output", "bam")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
         workflow = self._download_current_workflow()


### PR DESCRIPTION
Fixes the intermittent failure of `test_pick_value_change_datatype_pja`, which saved a `ChangeDatatypeAction` of `unsorted.bam` instead of `bam`:

```
FAILED lib/galaxy_test/selenium/test_workflow_editor.py::TestWorkflowEditor::test_pick_value_change_datatype_pja
  AssertionError: assert 'unsorted.bam' == 'bam'
```

Seen in [this run](https://github.com/galaxyproject/galaxy/actions/runs/33631217566/job/100252170263?pr=23430), where it also failed on the flaky-retry.

### What was going wrong

Several tests shared this three-line sequence: click the multiselect open, type the search text, click the option whose text matches exactly.

Filtering runs in a web worker, so the list is still unfiltered when the option is located, and vue-multiselect keys its option elements by index. `bam` sits at index 3 of the unfiltered list, behind `Leave unchanged`, `Roadmaps` and `Sequences`. Index 3 of the filtered list is `unsorted.bam`. The located element is reused for the new option and the click lands on the wrong datatype.

A probe confirms the mechanism directly. Resolving the exact-text `bam` option against the unfiltered list, then reading the same element handle once the filter lands:

```
before='bam' after='unsorted.bam'
```

The sibling test `test_change_datatype` waits on the node's output row afterwards, so it catches a wrong pick early. The pick_value test had no such check, so a mis-click only surfaced in the downloaded workflow.

### Changes

**DOM hooks instead of library internals.** The selectors reached into vue-multiselect's private class names and matched options by rendered text. `FormSelect` now exposes `data-option-value` on each option, and a single select exposes its current selection as `data-selected-value`, so an option can be addressed by what it selects rather than by its position or its label. Every xpath in this area is gone.

**A shared helper.** `workflow_editor_change_output_datatype` waits for every option that does not match the search text to disappear before clicking, then checks `data-selected-value`. A wrong pick now fails at the selection step with a clear message instead of at the downloaded workflow. Used by `test_change_datatype`, `test_change_datatype_in_subworkflow` and `test_pick_value_change_datatype_pja`.

**Scoped selectors.** The old locators matched every "Change datatype" control on the page, including those in collapsed output cards, which render their full option lists. In a two-output workflow the option selector resolved to 45 elements. They are now scoped to the post-job-action element id of the output being configured.

Note that keying by index happens inside the vendored library, so no selector alone can fix this. The wait for non-matching options to disappear is the actual fix; the new attribute just lets it be expressed as readable CSS.

### Verification

The four affected tests pass under both the Selenium and the Playwright driver locally. `vue-tsc`, eslint and prettier are clean on the client change; ruff, black, flake8 and mypy are clean on the Python.

I did not reproduce the flake through timing alone; eight iterations under 8x CPU throttling all passed. The probe above demonstrates the mechanism instead.

Targeting `release_26.1`, the oldest supported release containing this test.
