### PR TITLE
[26.1] Wait for upload rows to be submitted before closing the upload dialog

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1096,7 +1096,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
                 setting.click()
 
         self.upload_start()
-
+        self.upload_wait_for_submission()
         self.components.upload.close_button.wait_for_and_click()
 
     def perform_upload_of_composite_dataset_pasted_data(self, ext, paste_content):
@@ -1198,6 +1198,19 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
 
     def upload_start(self, tab_id="regular"):
         self.wait_for_and_click_selector(f"div#{tab_id} button#btn-start")
+
+    def upload_wait_for_submission(self, tab_id="regular"):
+        """Wait until every started upload row has been sent to the server.
+
+        The client submits rows one request at a time and only sends the next row once
+        the previous request has returned. Rows are ``upload-init`` until the Start click
+        handler runs and ``upload-queued`` until their request completes, so leaving the
+        page while either is present drops the unsent rows.
+        """
+        self.wait_for_selector_absent(
+            f"div#{tab_id} .upload-row.upload-init, div#{tab_id} .upload-row.upload-queued",
+            wait_type=WAIT_TYPES.JOB_COMPLETION,
+        )
 
     @retry_during_transitions
     def upload_build(self, tab="collection"):


### PR DESCRIPTION
Fixes the flaky `TestHistoryStorage::test_delete_dataset_from_storage_view` seen in https://github.com/galaxyproject/galaxy/actions/runs/33653553913/job/100337800831 (Playwright shard 1 on #23434):

```
playwright._impl._errors.TimeoutError: Timeout waiting on CSS selector
[[data-description='chart history top datasets by size'] [aria-roledescription='bar'][aria-label*='big']]
to become clickable.
```

## Cause

The client upload queue (`UploadQueue._process`) sends one row per `/api/tools/fetch` request and only sends the next row from the previous request's callback. `_perform_upload` clicked Start and closed the dialog immediately. The test then called `wait_for_history()`, which passes as soon as the first 1-byte upload is `ok`, and `home()`, which reloads the page and drops the still-unsent rows. In the failing run the server log shows a single `__DATA_FETCH__` job with only the `small` element and the failure screenshot shows a history with one dataset. Any test that queues several rows through `perform_upload_of_pasted_content` has the same race.

## Fix

`_perform_upload` now waits for the absence of `upload-init` / `upload-queued` rows before clicking Close, using the existing `upload-<status>` row classes that `test_uploads.py` already relies on. Closing the dialog while requests are in flight is still allowed; the helper just no longer returns before every row has been submitted.

## Reproduction

With the helper unchanged and the fetch endpoint patched to delay the *response* for the `small` row by 30 s (job still created immediately), the test fails locally with exactly the CI error and only `small` reaches the server. With this change all three rows are submitted and the test passes. `test_history_storage.py` passes under both the Playwright and Selenium drivers, as does a sample of `test_uploads.py` tests that go through the same helper.

## How to test the changes?

- [x] This is a refactoring of components with existing test coverage.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
