### PR TITLE
Allow setting metadata via `PUT /api/datasets/{id}`

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -25413,6 +25413,13 @@ export interface components {
              */
             deleted?: boolean | null;
             /**
+             * Metadata
+             * @description A dictionary of metadata key/value pairs to update for this dataset. Readonly and unknown metadata keys are silently ignored.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Name
              * @description The new name of the item.
              */

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -879,37 +879,27 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
         self.deserializable_keyset.update(self.deserializers.keys())
 
     def deserialize_metadata(self, item, key, val, **context):
-        """Deserialize a dictionary of metadata key/value pairs for a dataset association.
-
-        Mirrors the legacy controller's ``set_edit`` (operation="attributes")
-        behavior: guards against editing while the dataset is in use, sets
-        all writable metadata fields, calls ``after_setting_metadata`` for
-        datatype-specific post-processing, and resets FAILED_METADATA state
-        when all required metadata is now present.
-        """
+        """Deserialize a dictionary of metadata key/value pairs for a dataset association."""
         self.validate.matches_type(key, val, dict)
         if not item.ok_to_edit_metadata():
             raise exceptions.RequestParameterInvalidException(
                 "Dataset metadata could not be updated because it is used as input or output of a running job."
             )
         returned = {}
+        applied = False
         for metadata_key, metadata_val in val.items():
-            returned[metadata_key] = self.deserialize_metadatum(item, metadata_key, metadata_val, **context)
-        item.datatype.after_setting_metadata(item)
-        if item.state == Dataset.states.FAILED_METADATA and not item.missing_meta():
-            item.set_metadata_success_state()
+            spec = item.datatype.metadata_spec.get(metadata_key)
+            if spec is None or spec.get("readonly"):
+                continue
+            unwrapped_val = spec.unwrap(metadata_val)
+            setattr(item.metadata, metadata_key, unwrapped_val)
+            applied = True
+            returned[metadata_key] = unwrapped_val
+        if applied:
+            item.datatype.after_setting_metadata(item)
+            if item.state == Dataset.states.FAILED_METADATA and not item.missing_meta():
+                item.set_metadata_success_state()
         return returned
-
-    def deserialize_metadatum(self, item, key, val, **context):
-        """Set a single metadata field, silently skipping unknown or readonly keys."""
-        if key not in item.datatype.metadata_spec:
-            return
-        metadata_specification = item.datatype.metadata_spec[key]
-        if metadata_specification.get("readonly"):
-            return
-        unwrapped_val = metadata_specification.unwrap(val)
-        setattr(item.metadata, key, unwrapped_val)
-        return unwrapped_val
 
     def deserialize_datatype(self, item, key, val, **context):
         if not item.datatype.is_datatype_change_allowed():

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -873,29 +873,42 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
                 "name": self.deserialize_basestring,
                 "info": self.deserialize_basestring,
                 "datatype": self.deserialize_datatype,
+                "metadata": self.deserialize_metadata,
             }
         )
         self.deserializable_keyset.update(self.deserializers.keys())
 
-    # TODO: untested
-    def deserialize_metadata(self, dataset_assoc, metadata_key, metadata_dict, **context):
-        """ """
-        self.validate.matches_type(metadata_key, metadata_dict, dict)
+    def deserialize_metadata(self, item, key, val, **context):
+        """Deserialize a dictionary of metadata key/value pairs for a dataset association.
+
+        Mirrors the legacy controller's ``set_edit`` (operation="attributes")
+        behavior: guards against editing while the dataset is in use, sets
+        all writable metadata fields, calls ``after_setting_metadata`` for
+        datatype-specific post-processing, and resets FAILED_METADATA state
+        when all required metadata is now present.
+        """
+        self.validate.matches_type(key, val, dict)
+        if not item.ok_to_edit_metadata():
+            raise exceptions.RequestParameterInvalidException(
+                "Dataset metadata could not be updated because it is used as input or output of a running job."
+            )
         returned = {}
-        for key, val in metadata_dict.items():
-            returned[key] = self.deserialize_metadatum(dataset_assoc, key, val, **context)
+        for metadata_key, metadata_val in val.items():
+            returned[metadata_key] = self.deserialize_metadatum(item, metadata_key, metadata_val, **context)
+        item.datatype.after_setting_metadata(item)
+        if item.state == Dataset.states.FAILED_METADATA and not item.missing_meta():
+            item.set_metadata_success_state()
         return returned
 
-    def deserialize_metadatum(self, dataset_assoc, key, val, **context):
-        """ """
-        if key not in dataset_assoc.datatype.metadata_spec:
+    def deserialize_metadatum(self, item, key, val, **context):
+        """Set a single metadata field, silently skipping unknown or readonly keys."""
+        if key not in item.datatype.metadata_spec:
             return
-        metadata_specification = dataset_assoc.datatype.metadata_spec[key]
+        metadata_specification = item.datatype.metadata_spec[key]
         if metadata_specification.get("readonly"):
             return
         unwrapped_val = metadata_specification.unwrap(val)
-        setattr(dataset_assoc.metadata, key, unwrapped_val)
-        # ...?
+        setattr(item.metadata, key, unwrapped_val)
         return unwrapped_val
 
     def deserialize_datatype(self, item, key, val, **context):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1429,6 +1429,12 @@ class UpdateHistoryContentsPayload(Model):
         title="Tags",
         description="A list of tags to add to this item.",
     )
+    metadata: dict[str, Any] | None = Field(
+        None,
+        title="Metadata",
+        description="A dictionary of metadata key/value pairs to update for this dataset. "
+        "Readonly and unknown metadata keys are silently ignored.",
+    )
     model_config = ConfigDict(
         extra="allow",
         json_schema_extra={

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -729,6 +729,32 @@ class TestDatasetsApi(ApiTestCase):
         )
         self._assert_status_code_is(invalidly_updated_hda_response, 400)
 
+    def test_update_metadata(self, history_id):
+        hda_id = self.dataset_populator.new_dataset(history_id, wait=True)["id"]
+        original_hda = self._get(f"histories/{history_id}/contents/{hda_id}").json()
+        assert original_hda["metadata_dbkey"] == "?"
+
+        updated_response = self._put(
+            f"histories/{history_id}/contents/{hda_id}", data={"metadata": {"dbkey": "hg38"}}, json=True
+        )
+        self._assert_status_code_is(updated_response, 200)
+        updated_hda = updated_response.json()
+        assert updated_hda["metadata_dbkey"] == "hg38"
+
+        # readonly metadata keys should be silently ignored
+        readonly_response = self._put(
+            f"histories/{history_id}/contents/{hda_id}", data={"metadata": {"data_lines": 999}}, json=True
+        )
+        self._assert_status_code_is(readonly_response, 200)
+        assert readonly_response.json().get("metadata_data_lines") != 999
+
+        # unknown metadata keys should be silently ignored
+        unknown_response = self._put(
+            f"histories/{history_id}/contents/{hda_id}", data={"metadata": {"nonexistent_key": "value"}}, json=True
+        )
+        self._assert_status_code_is(unknown_response, 200)
+        assert "metadata_nonexistent_key" not in unknown_response.json()
+
     @skip_without_tool("cat_data_and_sleep")
     def test_delete_cancels_job(self, history_id):
         self._run_cancel_job(history_id, use_query_params=False)

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -674,6 +674,47 @@ class TestHDADeserializer(HDATestCase):
         assert hda.missing_meta()
         assert hda.state == model.Dataset.states.FAILED_METADATA
 
+    def test_deserialize_metadata_no_op_preserves_associated_files(self):
+        """No-op metadata updates must not invoke after_setting_metadata
+        (which clears implicit conversions). A real writable key must."""
+        hda = self._create_vanilla_hda()
+
+        # Attach an implicit conversion with metadata_safe=False — exactly what
+        # clear_associated_files(metadata_safe=True) would delete.
+        converted_hda = self.hda_manager.create(
+            history=hda.history, dataset=self.dataset_manager.create(), hid=hda.hid + 1
+        )
+        assoc = model.ImplicitlyConvertedDatasetAssociation(
+            parent=hda, file_type="txt", dataset=converted_hda, metadata_safe=False
+        )
+        self.trans.sa_session.add(assoc)
+        self.trans.sa_session.flush()
+        assert not assoc.deleted
+
+        # Spy on after_setting_metadata to detect whether it was called
+        with mock.patch.object(type(hda.datatype), "after_setting_metadata", return_value=None) as mock_after:
+            self.log("empty metadata dict should not invoke after_setting_metadata")
+            self.hda_deserializer.deserialize(hda, {"metadata": {}})
+            assert not mock_after.called, "after_setting_metadata was called for empty metadata dict"
+            assert not assoc.deleted, "Implicit conversion was deleted by a no-op metadata update"
+
+            mock_after.reset_mock()
+            self.log("unknown-only keys should not invoke after_setting_metadata")
+            self.hda_deserializer.deserialize(hda, {"metadata": {"nonexistent_key": "value"}})
+            assert not mock_after.called, "after_setting_metadata was called for unknown-only keys"
+            assert not assoc.deleted, "Implicit conversion was deleted by unknown-only keys"
+
+            mock_after.reset_mock()
+            self.log("readonly-only keys should not invoke after_setting_metadata")
+            self.hda_deserializer.deserialize(hda, {"metadata": {"data_lines": 42}})
+            assert not mock_after.called, "after_setting_metadata was called for readonly-only keys"
+            assert not assoc.deleted, "Implicit conversion was deleted by readonly-only keys"
+
+            mock_after.reset_mock()
+            self.log("a real writable key SHOULD invoke after_setting_metadata")
+            self.hda_deserializer.deserialize(hda, {"metadata": {"dbkey": "hg38"}})
+            assert mock_after.called, "after_setting_metadata was not called for a real writable key"
+
 
 # =============================================================================
 class TestHDAFilterParser(HDATestCase):

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -27,12 +27,13 @@ class HDATestCase(BaseTestCase):
         self.history_manager = self.app[HistoryManager]
         self.dataset_manager = self.app[DatasetManager]
 
-    def _create_vanilla_hda(self, user_data=None):
+    def _create_vanilla_hda(self, user_data=None, extension=None):
         user_data = user_data or user2_data
         owner = self.user_manager.create(**user_data)
         history1 = self.history_manager.create(name="history1", user=owner)
         dataset1 = self.dataset_manager.create()
-        return self.hda_manager.create(history=history1, dataset=dataset1)
+        kwargs = {"extension": extension} if extension else {}
+        return self.hda_manager.create(history=history1, dataset=dataset1, **kwargs)
 
 
 # =============================================================================
@@ -623,6 +624,55 @@ class TestHDADeserializer(HDATestCase):
         self.log("should be deserializable from empty string")
         self.hda_deserializer.deserialize(hda, {"info": ""})
         assert hda.info == ""
+
+    def test_deserialize_metadata(self):
+        hda = self._create_vanilla_hda()
+
+        self.log("should be able to deserialize writable metadata (dbkey)")
+        assert hda.dbkey == "?"
+        self.hda_deserializer.deserialize(hda, {"metadata": {"dbkey": "hg38"}})
+        assert hda.dbkey == "hg38"
+
+        self.log("should silently skip readonly metadata keys")
+        self.hda_deserializer.deserialize(hda, {"metadata": {"data_lines": 42}})
+        assert hda.metadata.data_lines != 42
+
+        self.log("should silently skip unknown metadata keys")
+        self.hda_deserializer.deserialize(hda, {"metadata": {"nonexistent_key": "value"}})
+
+        self.log("should raise when deserializing metadata from non-dict")
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.hda_deserializer.deserialize(hda, {"metadata": "not a dict"})
+
+    def test_deserialize_metadata_guard(self):
+        hda = self._create_vanilla_hda()
+
+        self.log("should raise when dataset is in use as input/output of a running job")
+        with mock.patch.object(type(hda), "ok_to_edit_metadata", return_value=False):
+            with self.assertRaises(exceptions.RequestParameterInvalidException):
+                self.hda_deserializer.deserialize(hda, {"metadata": {"dbkey": "hg38"}})
+
+    def test_deserialize_metadata_failed_state_reset(self):
+        hda = self._create_vanilla_hda(extension="bed")
+
+        self.log("should reset FAILED_METADATA state when required metadata is now present")
+        # Clear a required field so missing_meta() genuinely returns truthy
+        hda._state = model.Dataset.states.FAILED_METADATA
+        hda.metadata.chromCol = None
+        assert hda.missing_meta()
+        # Now set the required field via the deserializer — missing_meta() should be falsy
+        self.hda_deserializer.deserialize(hda, {"metadata": {"chromCol": 1}})
+        assert not hda.missing_meta()
+        assert hda.state != model.Dataset.states.FAILED_METADATA
+
+        self.log("should NOT reset FAILED_METADATA state when required metadata is still missing")
+        hda._state = model.Dataset.states.FAILED_METADATA
+        hda.metadata.chromCol = None
+        assert hda.missing_meta()
+        # Update only dbkey (optional) — chromCol is still missing
+        self.hda_deserializer.deserialize(hda, {"metadata": {"dbkey": "hg38"}})
+        assert hda.missing_meta()
+        assert hda.state == model.Dataset.states.FAILED_METADATA
 
 
 # =============================================================================


### PR DESCRIPTION
`DatasetAssociationDeserializer` had `deserialize_metadata`/`deserialize_metadatum` methods since 2015 (marked `# TODO: untested`), but `"metadata"` was never registered in the `deserializers` dict, so `PUT /api/datasets/{id}` with `{"metadata": {...}}` was silently dropped. This PR registers it, adds the three safeguards from the legacy `set_edit` controller, and adds tests.

Extracted from #23277 and improved as a standalone PR per @jmchilton's request in https://github.com/galaxyproject/galaxy/pull/23277#issuecomment-5295384904

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
