### PR TITLE
Move metadata handling into finish_job on the work queue (redo)

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -970,9 +970,17 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
         return collect_output_success, stdout, stderr
 
     def finish_job(self, job_state: T) -> None:
+        """Handle external metadata (if needed), then call _finish_job."""
+        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        if external_metadata:
+            self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
+        self._finish_job(job_state)
+
+    def _finish_job(self, job_state: T) -> None:
         """
         Get the output/error for a finished job, pass to `job_wrapper.finish`
         and cleanup all the job's temporary files.
+        Subclasses override this for post-metadata work.
         """
         galaxy_id_tag = job_state.job_wrapper.get_id_tag()
         external_job_id = job_state.job_id

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -470,6 +470,7 @@ class BaseJobRunner:
                 # We're synchronously waiting for a task here. This means we have to have a result backend.
                 # That is bad practice and also means this can never become part of another task.
                 try:
+                    log.debug("Dispatching external metadata execution to celery for job: %d", job_wrapper.job_id)
                     set_job_metadata.delay(
                         tool_job_working_directory=job_wrapper.working_directory,
                         job_id=job_wrapper.job_id,
@@ -862,6 +863,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
 
     monitor_queue: Queue[T]
     watched: list[T]
+    always_handle_metadata_externally = False
 
     def __init__(self, app: "GalaxyManagerApplication", nworkers: int, **kwargs) -> None:
         super().__init__(app, nworkers, **kwargs)
@@ -971,7 +973,9 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
 
     def finish_job(self, job_state: T) -> None:
         """Handle external metadata (if needed), then call _finish_job."""
-        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        external_metadata = self.always_handle_metadata_externally or not asbool(
+            job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
+        )
         if external_metadata:
             self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
         self._finish_job(job_state)

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -252,8 +252,8 @@ class ChronosJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         return None
 
     @handle_exception_call
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         self._chronos_client.delete(job_state.job_id)
 
     def parse_destination_params(self, params):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -200,20 +200,12 @@ class ShellJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 ajs.running = True
             ajs.old_state = state
             if state == model.Job.states.OK or job_state == model.Job.states.STOPPED:
-                external_metadata = not asbool(
-                    ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB)
-                )
-                if external_metadata:
-                    self.work_queue.put((self.handle_metadata_externally, ajs))
                 log.debug(f"({id_tag}/{external_job_id}) job execution finished, running job wrapper finish method")
                 self.work_queue.put((self.finish_job, ajs))
             else:
                 new_watched.append(ajs)
         # Replace the watch list with the updated version
         self.watched = new_watched
-
-    def handle_metadata_externally(self, ajs):
-        self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
 
     def __handle_job_failure_reasons(self, ajs, external_job_id):
         shell_params, job_params = self.parse_destination_params(ajs.job_destination.params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -233,11 +233,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
             job_state = cjs.job_wrapper.get_state()
             if job_complete or job_state == model.Job.states.STOPPED:
                 if job_state != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
                 continue
@@ -271,11 +266,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
                 self._stop_container(job_wrapper)
                 # self.watched.append(cjs)
                 if cjs.job_wrapper.get_state() != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{external_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
             except Exception as e:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -270,10 +270,6 @@ class DRMAAJobRunner(AsynchronousJobRunner[DRMAAJobState]):
                 ajs.fail_message = "The cluster DRM system terminated this job"
                 self.work_queue.put((self.fail_job, ajs))
         elif drmaa_state == drmaa.JobState.DONE or job_state == model.Job.states.STOPPED:
-            # External metadata processing for external runjobs
-            external_metadata = not asbool(ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
-            if external_metadata:
-                self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
             if job_state != model.Job.states.DELETED:
                 self.work_queue.put((self.finish_job, ajs))
         return None

--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -99,6 +99,7 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
     """
 
     runner_name = "GoogleCloudBatchJobRunner"
+    always_handle_metadata_externally = True
 
     def __init__(self, app, nworkers, **kwargs):
         """Initialize the Google Cloud Batch job runner."""
@@ -791,16 +792,6 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             log.error("Error checking status of Batch job %s: %s", batch_job_name, e)
             # Return job_state to continue monitoring - might be temporary error
             return job_state
-
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        # The Batch task's job script is built with include_metadata=False
-        # (queue_job above), so the remote task never runs the metadata
-        # command and never writes the metadata/metadata_results_* files
-        # the default (directory) metadata strategy expects at finish.
-        # Run the external set_meta script handler-side instead, as the
-        # Kubernetes and Pulsar runners do.
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
 
     def stop_job(self, job_wrapper):
         """Stop a job running on Google Cloud Batch."""

--- a/lib/galaxy/jobs/runners/htcondor.py
+++ b/lib/galaxy/jobs/runners/htcondor.py
@@ -696,11 +696,6 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
                         continue
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     cjs.close_event_log()
                     self.work_queue.put((self.finish_job, cjs))

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -88,6 +88,7 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
     """
 
     runner_name = "KubernetesRunner"
+    always_handle_metadata_externally = True
 
     LABEL_START = re.compile("^[A-Za-z0-9]")
     LABEL_END = re.compile("[A-Za-z0-9]$")

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -1145,9 +1145,8 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         # run super method
         super().fail_job(job_state, exception, message, full_status)
 
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         jobs = find_job_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
         if len(jobs.response["items"]) > 1:
             log.warning(

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from time import sleep
 from typing import (
     Any,
@@ -244,6 +245,17 @@ PULSAR_PARAM_SPECS = dict(
 
 PARAMETER_SPECIFICATION_REQUIRED = object()
 PARAMETER_SPECIFICATION_IGNORED = object()
+
+
+@dataclass
+class PulsarFinishJobResult:
+    tool_stdout: Optional[str]
+    tool_stderr: Optional[str]
+    exit_code: Optional[int]
+    job_stdout: Optional[str]
+    job_stderr: Optional[str]
+    remote_metadata_directory: Optional[str]
+    job_metrics_directory: str
 
 
 class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
@@ -811,6 +823,15 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             self.fail_job(job_state, message=GENERIC_REMOTE_ERROR, exception=True)
             log.exception("failure finishing job %d", job_wrapper.job_id)
             return
+        result = PulsarFinishJobResult(
+            tool_stdout=tool_stdout,
+            tool_stderr=tool_stderr,
+            exit_code=exit_code,
+            job_stdout=job_stdout,
+            job_stderr=job_stderr,
+            remote_metadata_directory=remote_metadata_directory,
+            job_metrics_directory=os.path.join(job_wrapper.working_directory, "metadata"),
+        )
         if not PulsarJobRunner.__remote_metadata(client):
             # we need an actual exit code file in the job working directory to detect job errors in the metadata script
             with open(
@@ -818,21 +839,22 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             ) as exit_code_file:
                 exit_code_file.write(str(exit_code))
             self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
-        job_metrics_directory = os.path.join(job_wrapper.working_directory, "metadata")
-        # Finish the job
+        self._finish_pulsar_job(job_wrapper, result)
+
+    def _finish_pulsar_job(self, job_wrapper, result: PulsarFinishJobResult):
         try:
             job_wrapper.finish(
-                tool_stdout,
-                tool_stderr,
-                exit_code,
-                job_stdout=job_stdout,
-                job_stderr=job_stderr,
-                remote_metadata_directory=remote_metadata_directory,
-                job_metrics_directory=job_metrics_directory,
+                result.tool_stdout,
+                result.tool_stderr,
+                result.exit_code,
+                job_stdout=result.job_stdout,
+                job_stderr=result.job_stderr,
+                remote_metadata_directory=result.remote_metadata_directory,
+                job_metrics_directory=result.job_metrics_directory,
             )
         except Exception:
             log.exception("Job wrapper finish method failed")
-            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=job_metrics_directory)
+            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=result.job_metrics_directory)
 
     def check_pid(self, pid):
         try:

--- a/test/integration/test_htcondor_runner.py
+++ b/test/integration/test_htcondor_runner.py
@@ -1337,6 +1337,10 @@ def test_finish_handles_external_metadata(fake_instance, fake_htcondor, runner_f
     method, job_state_record = runner.work_queue.get_nowait()
     assert method == runner.finish_job
     assert job_state_record.job_id == cjs.job_id
+    assert metadata_calls == []
+
+    method(job_state_record)
+
     assert metadata_calls == [(job_wrapper, True)]
     assert runner.watched == []
 

--- a/test/unit/app/jobs/test_pulsar_runner.py
+++ b/test/unit/app/jobs/test_pulsar_runner.py
@@ -6,6 +6,10 @@ from typing import (
     cast,
 )
 
+from galaxy.jobs.runners import (
+    AsynchronousJobState,
+    pulsar as pulsar_module,
+)
 from galaxy.jobs.runners.pulsar import PulsarJobRunner
 
 
@@ -161,3 +165,62 @@ def test_stop_job_supplies_recorded_external_id_to_kill_client():
     _destination_params, kill_kwargs = runner.client_manager.calls[-1]
     assert kill_kwargs["external_id"] == external_id
     assert runner.client_manager.clients[-1].killed
+
+
+def test_finish_job_stages_outputs_before_external_metadata(monkeypatch, tmp_path):
+    events: list[Any] = []
+    client = SimpleNamespace(
+        destination_params={"remote_metadata": False},
+        full_status=lambda: {
+            "stdout": "tool stdout",
+            "stderr": "tool stderr",
+            "job_stdout": "job stdout",
+            "job_stderr": "job stderr",
+            "returncode": 0,
+        },
+    )
+    job_wrapper = SimpleNamespace(
+        working_directory=str(tmp_path),
+        job_id=42,
+        cleanup_job="always",
+        get_state=lambda: "running",
+    )
+    job_state = object.__new__(AsynchronousJobState)
+    job_state.job_wrapper = job_wrapper
+    job_state.job_id = "remote-42"
+    runner = cast(Any, object.__new__(PulsarJobRunner))
+    runner.get_client_from_state = lambda _: client
+    runner._PulsarJobRunner__client_outputs = lambda *args: "client outputs"
+    runner._handle_metadata_externally = lambda *args, **kwargs: events.append("metadata")
+    runner._finish_pulsar_job = lambda wrapper, result: events.append(("finish", result))
+    monkeypatch.setattr(
+        pulsar_module.PulsarOutputs,
+        "from_status_response",
+        lambda _: "pulsar outputs",
+    )
+
+    def stage_outputs(**kwargs):
+        events.append(("stage", kwargs))
+        return False
+
+    monkeypatch.setattr(pulsar_module, "pulsar_finish_job", stage_outputs)
+
+    runner.finish_job(job_state)
+
+    assert [event[0] if isinstance(event, tuple) else event for event in events] == ["stage", "metadata", "finish"]
+    _, stage_kwargs = events[0]
+    assert stage_kwargs == {
+        "client": client,
+        "job_completed_normally": True,
+        "cleanup_job": "always",
+        "client_outputs": "client outputs",
+        "pulsar_outputs": "pulsar outputs",
+    }
+    _, result = events[2]
+    assert result.tool_stdout == "tool stdout"
+    assert result.tool_stderr == "tool stderr"
+    assert result.exit_code == 0
+    assert result.job_stdout == "job stdout"
+    assert result.job_stderr == "job stderr"
+    assert result.job_metrics_directory == str(tmp_path / "metadata")
+    assert (tmp_path / "galaxy_42.ec").read_text() == "0"

--- a/test/unit/app/jobs/test_runner.py
+++ b/test/unit/app/jobs/test_runner.py
@@ -1,0 +1,72 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from galaxy import model
+from galaxy.celery import tasks
+from galaxy.jobs.runners import (
+    AsynchronousJobRunner,
+    BaseJobRunner,
+)
+
+
+class RecordingAsynchronousJobRunner(AsynchronousJobRunner):
+    def _handle_metadata_externally(self, job_wrapper, resolve_requirements=False):
+        self.calls.append(("metadata", job_wrapper, resolve_requirements))
+
+    def _finish_job(self, job_state):
+        self.calls.append(("finish", job_state))
+
+
+@pytest.mark.parametrize(
+    ("always_external", "embed_metadata", "expected_call_names"),
+    [
+        (False, True, ["finish"]),
+        (False, False, ["metadata", "finish"]),
+        (True, True, ["metadata", "finish"]),
+    ],
+)
+def test_asynchronous_finish_job_metadata_handling(always_external, embed_metadata, expected_call_names):
+    runner = object.__new__(RecordingAsynchronousJobRunner)
+    runner.always_handle_metadata_externally = always_external
+    runner.calls = []
+    job_wrapper = SimpleNamespace(job_destination=SimpleNamespace(params={"embed_metadata_in_job": embed_metadata}))
+    job_state = SimpleNamespace(job_wrapper=job_wrapper)
+
+    runner.finish_job(job_state)
+
+    assert [call[0] for call in runner.calls] == expected_call_names
+    if "metadata" in expected_call_names:
+        assert runner.calls[0] == ("metadata", job_wrapper, True)
+
+
+def test_celery_metadata_dispatch_is_logged(caplog, monkeypatch, tmp_path):
+    runner = object.__new__(BaseJobRunner)
+    monkeypatch.setattr(runner, "_verify_celery_config", lambda: None)
+    async_result = Mock()
+
+    def delay(**kwargs):
+        assert "Dispatching external metadata execution to celery for job: 42" in caplog.messages
+        assert kwargs == {
+            "tool_job_working_directory": str(tmp_path),
+            "job_id": 42,
+            "extended_metadata_collection": True,
+        }
+        return async_result
+
+    monkeypatch.setattr(tasks.set_job_metadata, "delay", delay)
+    job_wrapper = SimpleNamespace(
+        get_state=lambda: model.Job.states.RUNNING,
+        setup_external_metadata=lambda **kwargs: "set-metadata",
+        job_io=SimpleNamespace(get_output_fnames=lambda: []),
+        metadata_strategy="celery_extended",
+        working_directory=str(tmp_path),
+        job_id=42,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="galaxy.jobs.runners"):
+        runner._handle_metadata_externally(job_wrapper)
+
+    async_result.get.assert_called_once_with()


### PR DESCRIPTION
This rescues #22086 on current `dev`, preserving Nate’s original commit and authorship.

The original intent remains intact: asynchronous runners perform external metadata handling from `finish_job` on a worker thread, while `_finish_job` remains the subclass hook for output finalization and post-metadata cleanup.

Updates made while rebasing/reviewing against current `dev`:

- Move the newer HTCondor runner’s external metadata handling off its monitor thread.
- Preserve mandatory handler-side metadata for Kubernetes and GCP Batch, whose job scripts deliberately omit metadata. A shared runner capability avoids both skipped metadata and GCP Batch double execution.
- Preserve Pulsar’s required order: stage remote outputs, run handler-side metadata, then finalize the job.
- Restore the requested pre-Celery-dispatch log message from #22083 / the discussion on #23436, so logs identify when a job enters the Celery metadata wait.
- Add regression coverage for shared metadata orchestration, the dispatch log, HTCondor worker-thread handoff, and Pulsar staging/finalization order.

## How to test the changes?

- [x] I’ve included appropriate automated tests.
- [x] This is a refactoring of components with existing test coverage.

Local verification:

- `test/unit/app/jobs`: 374 passed
- `test/integration/test_htcondor_runner.py`: 93 passed; 4 Docker-backed tests could not run because the local Docker daemon is unavailable
- Black, Ruff, flake8, isort, Prettier, and pre-commit checks pass
- Focused mypy check for the new unit tests passes

## License

- [x] I agree to license these and all my past contributions to the core Galaxy codebase under the MIT license.