### PR TITLE
Move metadata handling into finish_job on the work queue

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -970,9 +970,17 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
         return collect_output_success, stdout, stderr
 
     def finish_job(self, job_state: T) -> None:
+        """Handle external metadata (if needed), then call _finish_job."""
+        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        if external_metadata:
+            self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
+        self._finish_job(job_state)
+
+    def _finish_job(self, job_state: T) -> None:
         """
         Get the output/error for a finished job, pass to `job_wrapper.finish`
         and cleanup all the job's temporary files.
+        Subclasses override this for post-metadata work.
         """
         galaxy_id_tag = job_state.job_wrapper.get_id_tag()
         external_job_id = job_state.job_id

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -470,6 +470,7 @@ class BaseJobRunner:
                 # We're synchronously waiting for a task here. This means we have to have a result backend.
                 # That is bad practice and also means this can never become part of another task.
                 try:
+                    log.debug("Dispatching external metadata execution to celery for job: %d", job_wrapper.job_id)
                     set_job_metadata.delay(
                         tool_job_working_directory=job_wrapper.working_directory,
                         job_id=job_wrapper.job_id,
@@ -862,6 +863,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
 
     monitor_queue: Queue[T]
     watched: list[T]
+    always_handle_metadata_externally = False
 
     def __init__(self, app: "GalaxyManagerApplication", nworkers: int, **kwargs) -> None:
         super().__init__(app, nworkers, **kwargs)
@@ -971,7 +973,9 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
 
     def finish_job(self, job_state: T) -> None:
         """Handle external metadata (if needed), then call _finish_job."""
-        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        external_metadata = self.always_handle_metadata_externally or not asbool(
+            job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
+        )
         if external_metadata:
             self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
         self._finish_job(job_state)

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -252,8 +252,8 @@ class ChronosJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         return None
 
     @handle_exception_call
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         self._chronos_client.delete(job_state.job_id)
 
     def parse_destination_params(self, params):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -200,20 +200,12 @@ class ShellJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 ajs.running = True
             ajs.old_state = state
             if state == model.Job.states.OK or job_state == model.Job.states.STOPPED:
-                external_metadata = not asbool(
-                    ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB)
-                )
-                if external_metadata:
-                    self.work_queue.put((self.handle_metadata_externally, ajs))
                 log.debug(f"({id_tag}/{external_job_id}) job execution finished, running job wrapper finish method")
                 self.work_queue.put((self.finish_job, ajs))
             else:
                 new_watched.append(ajs)
         # Replace the watch list with the updated version
         self.watched = new_watched
-
-    def handle_metadata_externally(self, ajs):
-        self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
 
     def __handle_job_failure_reasons(self, ajs, external_job_id):
         shell_params, job_params = self.parse_destination_params(ajs.job_destination.params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -233,11 +233,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
             job_state = cjs.job_wrapper.get_state()
             if job_complete or job_state == model.Job.states.STOPPED:
                 if job_state != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
                 continue
@@ -271,11 +266,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
                 self._stop_container(job_wrapper)
                 # self.watched.append(cjs)
                 if cjs.job_wrapper.get_state() != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{external_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
             except Exception as e:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -270,10 +270,6 @@ class DRMAAJobRunner(AsynchronousJobRunner[DRMAAJobState]):
                 ajs.fail_message = "The cluster DRM system terminated this job"
                 self.work_queue.put((self.fail_job, ajs))
         elif drmaa_state == drmaa.JobState.DONE or job_state == model.Job.states.STOPPED:
-            # External metadata processing for external runjobs
-            external_metadata = not asbool(ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
-            if external_metadata:
-                self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
             if job_state != model.Job.states.DELETED:
                 self.work_queue.put((self.finish_job, ajs))
         return None

--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -99,6 +99,7 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
     """
 
     runner_name = "GoogleCloudBatchJobRunner"
+    always_handle_metadata_externally = True
 
     def __init__(self, app, nworkers, **kwargs):
         """Initialize the Google Cloud Batch job runner."""
@@ -791,16 +792,6 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             log.error("Error checking status of Batch job %s: %s", batch_job_name, e)
             # Return job_state to continue monitoring - might be temporary error
             return job_state
-
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        # The Batch task's job script is built with include_metadata=False
-        # (queue_job above), so the remote task never runs the metadata
-        # command and never writes the metadata/metadata_results_* files
-        # the default (directory) metadata strategy expects at finish.
-        # Run the external set_meta script handler-side instead, as the
-        # Kubernetes and Pulsar runners do.
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
 
     def stop_job(self, job_wrapper):
         """Stop a job running on Google Cloud Batch."""

--- a/lib/galaxy/jobs/runners/htcondor.py
+++ b/lib/galaxy/jobs/runners/htcondor.py
@@ -696,11 +696,6 @@ class HTCondorJobRunner(AsynchronousJobRunner[HTCondorJobState]):
                         cjs.close_event_log()
                         self.work_queue.put((self.fail_job, cjs))
                         continue
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     cjs.close_event_log()
                     self.work_queue.put((self.finish_job, cjs))

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -88,6 +88,7 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
     """
 
     runner_name = "KubernetesRunner"
+    always_handle_metadata_externally = True
 
     LABEL_START = re.compile("^[A-Za-z0-9]")
     LABEL_END = re.compile("[A-Za-z0-9]$")

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -1145,9 +1145,8 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         # run super method
         super().fail_job(job_state, exception, message, full_status)
 
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         jobs = find_job_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
         if len(jobs.response["items"]) > 1:
             log.warning(

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -249,12 +249,12 @@ PARAMETER_SPECIFICATION_IGNORED = object()
 
 @dataclass
 class PulsarFinishJobResult:
-    tool_stdout: Optional[str]
-    tool_stderr: Optional[str]
-    exit_code: Optional[int]
-    job_stdout: Optional[str]
-    job_stderr: Optional[str]
-    remote_metadata_directory: Optional[str]
+    tool_stdout: str | None
+    tool_stderr: str | None
+    exit_code: int | None
+    job_stdout: str | None
+    job_stderr: str | None
+    remote_metadata_directory: str | None
     job_metrics_directory: str
 
 

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from time import sleep
 from typing import (
     Any,
@@ -244,6 +245,17 @@ PULSAR_PARAM_SPECS = dict(
 
 PARAMETER_SPECIFICATION_REQUIRED = object()
 PARAMETER_SPECIFICATION_IGNORED = object()
+
+
+@dataclass
+class PulsarFinishJobResult:
+    tool_stdout: Optional[str]
+    tool_stderr: Optional[str]
+    exit_code: Optional[int]
+    job_stdout: Optional[str]
+    job_stderr: Optional[str]
+    remote_metadata_directory: Optional[str]
+    job_metrics_directory: str
 
 
 class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
@@ -811,6 +823,15 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             self.fail_job(job_state, message=GENERIC_REMOTE_ERROR, exception=True)
             log.exception("failure finishing job %d", job_wrapper.job_id)
             return
+        result = PulsarFinishJobResult(
+            tool_stdout=tool_stdout,
+            tool_stderr=tool_stderr,
+            exit_code=exit_code,
+            job_stdout=job_stdout,
+            job_stderr=job_stderr,
+            remote_metadata_directory=remote_metadata_directory,
+            job_metrics_directory=os.path.join(job_wrapper.working_directory, "metadata"),
+        )
         if not PulsarJobRunner.__remote_metadata(client):
             # we need an actual exit code file in the job working directory to detect job errors in the metadata script
             with open(
@@ -818,21 +839,22 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             ) as exit_code_file:
                 exit_code_file.write(str(exit_code))
             self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
-        job_metrics_directory = os.path.join(job_wrapper.working_directory, "metadata")
-        # Finish the job
+        self._finish_pulsar_job(job_wrapper, result)
+
+    def _finish_pulsar_job(self, job_wrapper, result: PulsarFinishJobResult):
         try:
             job_wrapper.finish(
-                tool_stdout,
-                tool_stderr,
-                exit_code,
-                job_stdout=job_stdout,
-                job_stderr=job_stderr,
-                remote_metadata_directory=remote_metadata_directory,
-                job_metrics_directory=job_metrics_directory,
+                result.tool_stdout,
+                result.tool_stderr,
+                result.exit_code,
+                job_stdout=result.job_stdout,
+                job_stderr=result.job_stderr,
+                remote_metadata_directory=result.remote_metadata_directory,
+                job_metrics_directory=result.job_metrics_directory,
             )
         except Exception:
             log.exception("Job wrapper finish method failed")
-            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=job_metrics_directory)
+            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=result.job_metrics_directory)
 
     def check_pid(self, pid):
         try:

--- a/test/integration/embedded_pulsar_job_conf.yml
+++ b/test/integration/embedded_pulsar_job_conf.yml
@@ -16,6 +16,9 @@ execution:
     pulsar_embed:
       runner: pulsar_embed
       remote_metadata: true
+    pulsar_embed_handler_metadata:
+      runner: pulsar_embed
+      remote_metadata: false
     user_defined:
       runner: pulsar_embed
       remote_metadata: true
@@ -24,6 +27,8 @@ execution:
       docker_net: "none"
 
 tools:
+- id: metadata_columns
+  environment: pulsar_embed_handler_metadata
 - class: local
   environment: local
 - class: user_defined

--- a/test/integration/test_htcondor_runner.py
+++ b/test/integration/test_htcondor_runner.py
@@ -43,6 +43,7 @@ execution:
   environments:
     htcondor_environment:
       runner: htcondor
+      embed_metadata_in_job: false
     local_environment:
       runner: local
 tools:
@@ -651,9 +652,9 @@ class FakeHTCondorJobIntegrationInstance(FakeHTCondorIntegrationInstance):
 fake_job_instance = integration_util.integration_module_instance(FakeHTCondorJobIntegrationInstance)
 
 
-def test_fake_end_to_end_job(fake_job_instance):
-    """Full Galaxy job lifecycle via the htcondor runner backed by the fake module."""
-    fake_job_instance._run_tool_test("simple_constructs")
+def test_fake_end_to_end_job_with_external_metadata(fake_job_instance):
+    """Run a real job and external metadata lifecycle through the HTCondor runner."""
+    fake_job_instance._run_tool_test("metadata_columns")
 
 
 class FakeHTCondorCancelIntegrationInstance(FakeHTCondorIntegrationInstance):
@@ -1337,6 +1338,10 @@ def test_finish_handles_external_metadata(fake_instance, fake_htcondor, runner_f
     method, job_state_record = runner.work_queue.get_nowait()
     assert method == runner.finish_job
     assert job_state_record.job_id == cjs.job_id
+    assert metadata_calls == []
+
+    method(job_state_record)
+
     assert metadata_calls == [(job_wrapper, True)]
     assert runner.watched == []
 

--- a/test/integration/test_metadata_strategy.py
+++ b/test/integration/test_metadata_strategy.py
@@ -1,3 +1,5 @@
+import logging
+
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
@@ -25,3 +27,12 @@ class TestDiskUsageCeleryExtended(TestDiskUsageUpdateDefault):
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
         config["metadata_strategy"] = "celery_extended"
+
+    def test_external_metadata_dispatch_is_logged(self, history_id, caplog):
+        with caplog.at_level(logging.DEBUG, logger="galaxy.jobs.runners"):
+            response = self.dataset_populator.run_tool("from_work_dir_glob", {}, history_id, assert_ok=True)
+            encoded_job_id = response["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(job_id=encoded_job_id)
+
+        job_id = self._decode_id(encoded_job_id)
+        assert f"Dispatching external metadata execution to celery for job: {job_id}" in caplog.messages

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -29,6 +29,7 @@ class TestEmbeddedPulsarIntegrationInstance(integration_util.IntegrationTestCase
         config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
         config["enable_celery_tasks"] = False
         config["metadata_strategy"] = "directory"
+        config["retry_metadata_internally"] = False
         config["cleanup_job"] = "never"
 
     def test_tool_eval_failure(self):
@@ -80,6 +81,10 @@ class TestEmbeddedPulsarIntegrationInstance(integration_util.IntegrationTestCase
                 "but it exists in Galaxy's job working directory"
             )
 
+    def test_handler_metadata_runs_after_output_staging(self):
+        """Exercise Pulsar output staging followed by handler-side metadata."""
+        self._run_tool_test("metadata_columns")
+
 
 instance = integration_util.integration_module_instance(TestEmbeddedPulsarIntegrationInstance)
 
@@ -104,7 +109,6 @@ test_tools = integration_util.integration_tool_runner(
         "composite_output_tests",
         "detect_errors",
         "tool_directory_copy",
-        "metadata_columns",
         "create_directory_index",
         "collection_split_on_column",
     ]


### PR DESCRIPTION
This rescues #22086 on current `dev`, preserving Nate's original commit and authorship.

The original intent remains intact: asynchronous runners perform external metadata handling from `finish_job` on a worker thread, while `_finish_job` remains the subclass hook for output finalization and post-metadata cleanup.

Updates made while rebasing and reviewing against current `dev`:

- Move the newer HTCondor runner's external metadata handling off its monitor thread.
- Preserve mandatory handler-side metadata for Kubernetes and GCP Batch, whose job scripts deliberately omit metadata. A shared runner capability avoids both skipped metadata and GCP Batch double execution.
- Preserve Pulsar's required order: stage remote outputs, run handler-side metadata, then finalize the job.
- Restore the requested pre-Celery-dispatch log message from #22083 and the discussion on #23436, so logs identify when a job enters the Celery metadata wait.
- Replace mock-heavy regression tests with integration coverage of the shared asynchronous runner path, Pulsar staging and handler-side metadata, and the real Celery dispatch log.

## How to test the changes?

- [x] I've included appropriate automated tests.
- [x] This is a refactoring of components with existing test coverage.

Local verification:

- Metadata-strategy integration module: 3 passed, including the exact Celery dispatch log assertion.
- HTCondor end-to-end external-metadata lifecycle: passed.
- Embedded Pulsar handler-side metadata after output staging: passed with internal metadata retry disabled.
- Full embedded Pulsar integration module: 23 passed; the sole Docker-dependent test could not run because the local Docker daemon was unavailable.
- Pulsar unit tests: 10 passed.
- Black, Ruff, flake8, isort, Prettier, and pre-commit checks pass.

## License

- [x] I agree to license these and all my past contributions to the core Galaxy codebase under the MIT license.
