### PR TITLE
[26.1] fix: filter webhooks by type and activation in Webhook.vue

### DIFF
--- a/client/src/components/Common/Webhook.test.ts
+++ b/client/src/components/Common/Webhook.test.ts
@@ -5,29 +5,74 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Webhook from "./Webhook.vue";
 
-const { WEBHOOK, targetExistsAtInjection } = vi.hoisted(() => ({
-    WEBHOOK: { id: "phdcomics", type: ["tool"], weight: 1, script: "/* noop */", styles: "" },
+interface WebhookData {
+    id: string;
+    type: string[];
+    weight: number;
+    activate: boolean;
+    script: string;
+    styles: string;
+}
+
+const { fixtures, loadWebhooks, pickWebhook, appendScriptStyle, targetExistsAtInjection } = vi.hoisted(() => {
+    const activeTool = {
+        id: "phdcomics",
+        type: ["tool"],
+        weight: 1,
+        activate: true,
+        script: "/* noop */",
+        styles: "",
+    };
+    const inactiveTool = {
+        id: "inactive_tool_webhook",
+        type: ["tool"],
+        weight: 1,
+        activate: false,
+        script: "/* noop */",
+        styles: "",
+    };
+    const activeMasthead = {
+        id: "searchover",
+        type: ["masthead"],
+        weight: 1,
+        activate: true,
+        script: "/* uses Backbone */",
+        styles: "",
+    };
+    const all = [activeTool, inactiveTool, activeMasthead];
+
     // Records whether the target mount point existed in the document at the
     // moment the webhook script would have been injected.
-    targetExistsAtInjection: vi.fn(),
-}));
+    const targetExistsAtInjection = vi.fn();
+
+    return {
+        fixtures: { activeTool, inactiveTool, activeMasthead, all },
+        // Mirrors the real `loadWebhooks` type filter: everything when no type is given.
+        loadWebhooks: vi.fn(async (type?: string) =>
+            type ? all.filter((webhook) => webhook.type.includes(type)) : all,
+        ),
+        pickWebhook: vi.fn((webhooks: WebhookData[]) => webhooks[0]),
+        appendScriptStyle: vi.fn((data: { id?: string }) => {
+            targetExistsAtInjection(Boolean(data.id && document.getElementById(data.id)));
+        }),
+        targetExistsAtInjection,
+    };
+});
 
 vi.mock("@/utils/webhooks", () => ({
-    loadWebhooks: vi.fn().mockResolvedValue([WEBHOOK]),
-    pickWebhook: vi.fn().mockReturnValue(WEBHOOK),
+    loadWebhooks,
+    pickWebhook,
 }));
 
 vi.mock("@/utils/utils", () => ({
-    appendScriptStyle: (data: { id?: string }) => {
-        targetExistsAtInjection(Boolean(data.id && document.getElementById(data.id)));
-    },
+    appendScriptStyle,
 }));
 
 const localVue = getLocalVue();
 
 describe("Webhook.vue", () => {
     beforeEach(() => {
-        targetExistsAtInjection.mockClear();
+        vi.clearAllMocks();
     });
 
     it("renders the webhook mount point before injecting its script", async () => {
@@ -42,5 +87,26 @@ describe("Webhook.vue", () => {
         expect(targetExistsAtInjection).toHaveBeenCalledTimes(1);
         // Injected script queries `#<webhookId>`; that div must exist when it runs.
         expect(targetExistsAtInjection).toHaveBeenCalledWith(true);
+    });
+
+    it("only considers active webhooks matching its type", async () => {
+        mount(Webhook as object, {
+            localVue,
+            propsData: { type: "tool", toolId: "cat1", toolVersion: "1.0" },
+            attachTo: document.body,
+        });
+
+        await flushPromises();
+
+        expect(loadWebhooks).toHaveBeenCalledWith("tool");
+
+        expect(pickWebhook).toHaveBeenCalledTimes(1);
+        const candidates = pickWebhook.mock.calls[0]?.[0];
+        expect(candidates).toEqual([fixtures.activeTool]);
+        expect(candidates).not.toContain(fixtures.inactiveTool);
+        expect(candidates).not.toContain(fixtures.activeMasthead);
+
+        expect(appendScriptStyle).toHaveBeenCalledTimes(1);
+        expect(appendScriptStyle).toHaveBeenCalledWith(fixtures.activeTool);
     });
 });

--- a/client/src/components/Common/Webhook.vue
+++ b/client/src/components/Common/Webhook.vue
@@ -15,6 +15,15 @@ const props = withDefaults(defineProps<Props>(), {
     toolVersion: "",
 });
 
+interface WebhookModel {
+    id: string;
+    type?: string[];
+    weight?: number;
+    activate?: boolean;
+    script?: string;
+    styles?: string;
+}
+
 const container = ref<HTMLElement | null>(null);
 const webhookId = ref<string | null>(null);
 
@@ -24,7 +33,9 @@ onMounted(async () => {
         container.value.setAttribute("tool_version", props.toolVersion);
     }
 
-    const webhooks = await loadWebhooks();
+    const webhooks = (await loadWebhooks(props.type)).filter(
+        (webhook: WebhookModel) => webhook.activate && webhook.script,
+    );
     if (webhooks.length > 0) {
         const model = pickWebhook(webhooks);
         webhookId.value = model.id;


### PR DESCRIPTION
Fixes #23451 (Sentry [USEGALAXY-EU-MAIN-61HFG00001WJ2](https://sentry.galaxyproject.org/organizations/galaxy/issues/309990/), ~2.3K events / ~970 users on usegalaxy.eu since 2026-08-18).

```
ReferenceError: Backbone is not defined
  at HTMLDocument.<anonymous> (<anonymous>:5:29)
  at c (/static/dist/jquery-core-DuHCnOMY.js:1:26984)
  at Object.add [as done] (/static/dist/jquery-core-DuHCnOMY.js:1:27289)
  at p.fn.ready (/static/dist/jquery-core-DuHCnOMY.js:1:29337)
  ...
  at Vy [appendScriptStyle] (/static/dist/galaxy-app-xIh_ws7p.js)
  at o.<anonymous> [Webhook.vue onMounted] (/static/dist/analysis.bundled.js)
```

### What
`Webhook.vue` (used on the tool and workflow submission success pages) called `loadWebhooks()` without its `type` prop and never checked `webhook.activate`. It therefore did a weighted-random pick over *every* webhook returned by `GET /api/webhooks`, which includes inactive ones and ones of other types (`masthead`, `onload`, `tool-menu`). The component now requests only webhooks of its own type and keeps only active ones that ship a script, mirroring what `app/addons/webhooks.js`, `Masthead/_webhooks.js` and `ToolOptionsButton.vue` already do.

### Why it surfaced now
The type filter was lost in 02f096e651 (2024, composition API refactor of `Webhook.vue`), so the bug has been on every release since 24.0. It stayed silent because the wrongly injected scripts ran without error while Backbone/underscore were globals. usegalaxy.eu updated to 26.1 (where those globals are gone) on 2026-08-18, and its registry contains an *inactive* masthead webhook (`searchover`) whose `script.js` starts with `$(document).ready(function() { ... var OverlaySearchView = Backbone.View.extend({` at line 4, column 29. `appendScriptStyle` wraps scripts in a one-line IIFE prefix, which yields exactly the `<anonymous>:5:29` frame in the Sentry event. The second error in the same trace ("API authentication required for this request") is most likely another wrong-type pick and should disappear with this change.

Verified against the live usegalaxy.eu `/api/webhooks` response: all active `tool` webhooks there are already vanilla JS; only the inactive/other-type entries still use Backbone.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Point the client at usegalaxy.eu (`GALAXY_URL=https://usegalaxy.eu make client-dev-server`) or any instance whose webhooks dir contains an active `masthead`/`onload` webhook plus at least one inactive one.
  2. Run any tool and land on `/jobs/submission/success` a dozen times.
  3. Before: the console intermittently shows `ReferenceError: Backbone is not defined` and non-tool webhooks (or nothing) render under the success message. After: only active `tool` webhooks (e.g. citation_needed / iframe / phdcomics) render, no errors.

Unit test: `cd client && pnpm vitest run src/components/Common/Webhook.test.ts` (the new test fails on `release_26.1` without the fix).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

