### PR TITLE
[26.1] Handle unknown upload methods gracefully

### DIFF
--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -122,7 +122,8 @@ function handleReadyStateChange(ready: boolean) {
             </div>
         </div>
         <div v-else class="flex-grow-1 text-center text-muted py-5">
-            <p>Loading...</p>
+            <p>Unknown import method.</p>
+            <GButton color="blue" @click="handleCancel">Back to import methods</GButton>
         </div>
 
         <!-- Fixed Footer -->

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -74,6 +74,10 @@ function handleCancel() {
     router.push("/upload");
 }
 
+function handleUnknownMethod() {
+    router.replace("/upload");
+}
+
 function handleStart() {
     if (!canStartUpload.value) {
         return;
@@ -123,7 +127,7 @@ function handleReadyStateChange(ready: boolean) {
         </div>
         <div v-else class="flex-grow-1 text-center text-muted py-5">
             <p>Unknown import method.</p>
-            <GButton color="blue" @click="handleCancel">Back to import methods</GButton>
+            <GButton color="blue" @click="handleUnknownMethod">Back to import methods</GButton>
         </div>
 
         <!-- Fixed Footer -->

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -56,7 +56,12 @@ export async function requireAuthForUploadMethod(to: Route, _from: Route, next: 
     const methodId = to.params.methodId as UploadMethod;
     const method = getUploadMethod(methodId);
 
-    if (method?.requiresLogin && (await redirectIfAnonymous(to, next))) {
+    if (!method) {
+        next("/upload");
+        return;
+    }
+
+    if (method.requiresLogin && (await redirectIfAnonymous(to, next))) {
         return;
     }
     next();

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -57,7 +57,7 @@ export async function requireAuthForUploadMethod(to: Route, _from: Route, next: 
     const method = getUploadMethod(methodId);
 
     if (!method) {
-        next("/upload");
+        next({ path: "/upload", replace: true });
         return;
     }
 


### PR DESCRIPTION
Prevents users from being stranded on an invalid import method route by redirecting to the upload method list and showing a clear recovery state in the view.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://localhost:5173/upload/wrong and observe that you are redirected to the upload method list instead of getting an infinite "Loading" message.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
