### PR TITLE
Add a failure-tolerant Pick Value mode

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -86,6 +86,16 @@ describe("FormPickValue", () => {
     });
 
     describe("mode changes", () => {
+        it("emits the failure-tolerant selection mode", () => {
+            const wrapper = mountPickValue();
+            const formElement = wrapper.findComponent(FormElement);
+            formElement.vm.$emit("input", "first_ok_or_skip");
+
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("first_ok_or_skip");
+            expect(state.num_inputs).toBe(2);
+        });
+
         it("emits onChange with updated mode", () => {
             const wrapper = mountPickValue();
             const formElement = wrapper.findComponent(FormElement);

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -52,6 +52,7 @@ const emit = defineEmits(["onChange", "onChangePostJobActions"]);
 const modeOptions = [
     ["First non-null (error if all null)", "first_non_null"],
     ["First non-null (skip if all null)", "first_or_skip"],
+    ["First non-null, non-failed (skip if none)", "first_ok_or_skip"],
     ["The only non-null (error if != 1)", "the_only_non_null"],
     ["All non-null (as collection)", "all_non_null"],
 ];
@@ -124,7 +125,7 @@ if (connections) {
             title="Selection Mode"
             type="select"
             :options="modeOptions"
-            help="How to select among the connected inputs."
+            help="How to select among the connected inputs. The non-failed mode ignores failed inputs and skips when none remain."
             @input="onMode" />
         <div v-if="datatypes && step.outputs && step.outputs.length > 0" class="mt-2 mb-4">
             <Heading h2 separator bold size="sm"> Additional Options </Heading>

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2175,19 +2175,21 @@ class PickValueModule(WorkflowModule):
         return state
 
     @staticmethod
-    def _is_null_or_skipped(value) -> bool:
+    def _is_null_or_skipped(value, step: WorkflowStep) -> bool:
         """Check if a replacement value represents a skipped/null output."""
         if value is NO_REPLACEMENT:
             return True
         if isinstance(value, model.HistoryDatasetAssociation):
-            if value.extension == "expression.json" and value.blurb == "skipped":
-                return True
+            if value.extension == "expression.json":
+                if value.blurb == "skipped":
+                    return True
+                return read_expression_json(value, step=step) is None
         return False
 
     def _pick_from_replacements(self, trans: "ProvidesHistoryContext", invocation_step, mode, replacements):
         """Apply pick logic to a list of replacement values. Returns the picked output."""
         step = invocation_step.workflow_step
-        non_null = [r for r in replacements if not self._is_null_or_skipped(r)]
+        non_null = [r for r in replacements if not self._is_null_or_skipped(r, step)]
 
         if mode == "first_non_null":
             if not non_null:
@@ -2389,7 +2391,7 @@ class PickValueModule(WorkflowModule):
         Uses execute_on_mapped_over which operates on step_outputs dict
         rather than requiring a Job object. Skipped outputs are left untouched.
         """
-        if self._is_null_or_skipped(output):
+        if self._is_null_or_skipped(output, step):
             return
         step_outputs = {"output": output}
         step_inputs: dict[str, Any] = {}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2070,13 +2070,13 @@ class PickValueModule(WorkflowModule):
 
     Accepts N inputs from conditional steps and produces a single output
     based on the configured selection mode. Supports first_non_null,
-    first_or_skip, the_only_non_null, and all_non_null modes.
+    first_or_skip, first_ok_or_skip, the_only_non_null, and all_non_null modes.
     """
 
     type = "pick_value"
     name = "Pick Value"
 
-    MODES = ("first_non_null", "first_or_skip", "the_only_non_null", "all_non_null")
+    MODES = ("first_non_null", "first_or_skip", "first_ok_or_skip", "the_only_non_null", "all_non_null")
 
     def __init__(self, trans: "ProvidesHistoryContext", content_id=None, **kwds):
         super().__init__(trans, content_id=content_id, **kwds)
@@ -2190,38 +2190,44 @@ class PickValueModule(WorkflowModule):
                 return read_expression_json(value, step=step) is None
         return False
 
+    @staticmethod
+    def _is_failed(value) -> bool:
+        """Check if a replacement value is settled but invalid as a tool input."""
+        return isinstance(value, model.DatasetInstance) and value.state not in model.Dataset.valid_input_states
+
     def _pick_from_replacements(self, trans: "ProvidesHistoryContext", invocation_step, mode, replacements):
         """Apply pick logic to a list of replacement values. Returns the picked output."""
         step = invocation_step.workflow_step
         non_null = [r for r in replacements if not self._is_null_or_skipped(r, step)]
+        selectable = [r for r in non_null if mode != "first_ok_or_skip" or not self._is_failed(r)]
 
         if mode == "first_non_null":
-            if not non_null:
+            if not selectable:
                 raise FailWorkflowEvaluation(
                     why=InvocationFailureExpressionEvaluationFailed(
                         reason=FailureReason.expression_evaluation_failed,
                         workflow_step_id=step.id,
                     )
                 )
-            return non_null[0]
+            return selectable[0]
 
-        elif mode == "first_or_skip":
-            if not non_null:
+        elif mode in ("first_or_skip", "first_ok_or_skip"):
+            if not selectable:
                 return self._create_skipped_output(trans, invocation_step)
-            return non_null[0]
+            return selectable[0]
 
         elif mode == "the_only_non_null":
-            if len(non_null) != 1:
+            if len(selectable) != 1:
                 raise FailWorkflowEvaluation(
                     why=InvocationFailureExpressionEvaluationFailed(
                         reason=FailureReason.expression_evaluation_failed,
                         workflow_step_id=step.id,
                     )
                 )
-            return non_null[0]
+            return selectable[0]
 
         elif mode == "all_non_null":
-            return self._create_collection_from_list(trans, invocation_step, non_null)
+            return self._create_collection_from_list(trans, invocation_step, selectable)
 
         else:
             raise ValueError(f"Unknown pick_value mode: {mode}")
@@ -2307,7 +2313,7 @@ class PickValueModule(WorkflowModule):
         return self._create_mapped_output_collection(trans, history, mode, per_element_outputs)
 
     def _create_skipped_output(self, trans: "ProvidesHistoryContext", invocation_step):
-        """Create a skipped HDA for first_or_skip when all inputs are null."""
+        """Create a skipped HDA when no input is selectable in a skip-capable mode."""
         invocation = invocation_step.workflow_invocation
         history = invocation.history
         hda = model.HistoryDatasetAssociation(

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2231,6 +2231,8 @@ class PickValueModule(WorkflowModule):
         mode = step.tool_inputs.get("mode", "first_non_null") if step.tool_inputs else "first_non_null"
         all_inputs = self.get_all_inputs()
 
+        self._ensure_inputs_ready(trans, progress, step, all_inputs)
+
         collection_info = self.compute_collection_info(progress, step, all_inputs)
 
         if collection_info:
@@ -2247,6 +2249,17 @@ class PickValueModule(WorkflowModule):
         progress.set_step_outputs(invocation_step, {"output": output})
         self._apply_post_job_actions(trans, step, output, progress.effective_replacement_dict())
         return None
+
+    def _ensure_inputs_ready(self, trans: "WorkRequestContext", progress: "WorkflowProgress", step, all_inputs) -> None:
+        """Delay this step until the inputs it picks from have been produced.
+
+        A tool step can be scheduled against a dataset that is still running - the job queue
+        orders the work. This module cannot. It reads the inputs to decide which one to pick,
+        and the picked output aliases that dataset rather than copying it, so a post job
+        action on this step mutates an upstream job's output. Both need that job finished.
+        """
+        for input_dict in all_inputs:
+            progress.replacement_for_input(trans, step, input_dict, require_ready=True)
 
     def _execute_mapped(self, trans: "ProvidesHistoryContext", invocation_step, mode, all_inputs, collection_info):
         """Execute pick_value mapped over collection inputs."""

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2183,6 +2183,10 @@ class PickValueModule(WorkflowModule):
             if value.extension == "expression.json":
                 if value.blurb == "skipped":
                     return True
+                if not value.is_ok:
+                    # A failed expression output has no readable value, but failure is
+                    # not null. Preserve it so downstream failure filters can handle it.
+                    return False
                 return read_expression_json(value, step=step) is None
         return False
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2192,7 +2192,7 @@ class PickValueModule(WorkflowModule):
 
     @staticmethod
     def _is_failed(value) -> bool:
-        """Check if a replacement value is settled but invalid as a tool input."""
+        """Check whether a replacement value has an invalid tool-input state."""
         return isinstance(value, model.DatasetInstance) and value.state not in model.Dataset.valid_input_states
 
     def _pick_from_replacements(self, trans: "ProvidesHistoryContext", invocation_step, mode, replacements):

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -460,7 +460,11 @@ class WorkflowProgress:
         return remaining_steps
 
     def replacement_for_input(
-        self, trans: "ProvidesHistoryContext", step: "WorkflowStep", input_dict: dict[str, Any]
+        self,
+        trans: "ProvidesHistoryContext",
+        step: "WorkflowStep",
+        input_dict: dict[str, Any],
+        require_ready: bool = False,
     ) -> modules.StepInputReplacement:
         replacement: modules.StepInputReplacement = NO_REPLACEMENT
         prefixed_name = input_dict["name"]
@@ -469,7 +473,7 @@ class WorkflowProgress:
         if prefixed_name in step.input_connections_by_name:
             connection = step.input_connections_by_name[prefixed_name]
             if input_dict["input_type"] == "dataset" and multiple:
-                temp = [self.replacement_for_connection(c) for c in connection]
+                temp = [self.replacement_for_connection(c, require_ready=require_ready) for c in connection]
                 # If replacement is just one dataset collection, replace tool
                 # input_dict with dataset collection - tool framework will extract
                 # datasets properly.
@@ -481,7 +485,9 @@ class WorkflowProgress:
                 else:
                     replacement = temp
             else:
-                replacement = self.replacement_for_connection(connection[0], is_data=is_data)
+                replacement = self.replacement_for_connection(
+                    connection[0], is_data=is_data, require_ready=require_ready
+                )
         elif (
             step.state
             and (state_input := get_path(step.state.inputs, nested_key_to_path(prefixed_name), None))
@@ -497,7 +503,9 @@ class WorkflowProgress:
                 replacement = raw_to_galaxy(trans.app, trans.history, step_input.default_value)
         return replacement
 
-    def replacement_for_connection(self, connection: "WorkflowStepConnection", is_data: bool = True):
+    def replacement_for_connection(
+        self, connection: "WorkflowStepConnection", is_data: bool = True, require_ready: bool = False
+    ):
         output_step_id = connection.output_step.id
         output_name = connection.output_name
         if output_step_id not in self.outputs:
@@ -552,11 +560,24 @@ class WorkflowProgress:
 
         if isinstance(replacement, model.DatasetCollection):
             raise NotImplementedError
-        if not is_data and isinstance(
+        # A parameter connection needs the value itself, so it always waits. A data connection
+        # normally does not - the tool framework hands the job a dataset that is still being
+        # produced and the job queue sorts out the ordering. Modules that read or mutate the
+        # data while scheduling opt in with require_ready.
+        if (not is_data or require_ready) and isinstance(
             replacement, (model.HistoryDatasetAssociation, model.HistoryDatasetCollectionAssociation)
         ):
+
+            def not_yet_available(dataset_instance: model.DatasetInstance) -> bool:
+                # Modules waiting on data wait the way DatabaseOperationTool.check_inputs_ready
+                # does - a paused input can still be resumed by the user, so delay rather than
+                # fail the invocation over it.
+                if dataset_instance.is_pending:
+                    return True
+                return require_ready and dataset_instance.state == model.Dataset.states.PAUSED
+
             if isinstance(replacement, model.HistoryDatasetAssociation):
-                if replacement.is_pending:
+                if not_yet_available(replacement):
                     raise modules.DelayedWorkflowEvaluation()
                 if not replacement.is_ok:
                     raise modules.FailWorkflowEvaluation(
@@ -572,7 +593,7 @@ class WorkflowProgress:
                     raise modules.DelayedWorkflowEvaluation()
                 pending = False
                 for dataset_instance in replacement.dataset_instances:
-                    if dataset_instance.is_pending:
+                    if not_yet_available(dataset_instance):
                         pending = True
                     elif not dataset_instance.is_ok:
                         raise modules.FailWorkflowEvaluation(

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -579,7 +579,7 @@ class WorkflowProgress:
             if isinstance(replacement, model.HistoryDatasetAssociation):
                 if not_yet_available(replacement):
                     raise modules.DelayedWorkflowEvaluation()
-                if not replacement.is_ok:
+                if not is_data and not replacement.is_ok:
                     raise modules.FailWorkflowEvaluation(
                         why=InvocationFailureDatasetFailed(
                             reason=FailureReason.dataset_failed,
@@ -595,7 +595,7 @@ class WorkflowProgress:
                 for dataset_instance in replacement.dataset_instances:
                     if not_yet_available(dataset_instance):
                         pending = True
-                    elif not dataset_instance.is_ok:
+                    elif not is_data and not dataset_instance.is_ok:
                         raise modules.FailWorkflowEvaluation(
                             why=InvocationFailureDatasetFailed(
                                 reason=FailureReason.dataset_failed,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3476,14 +3476,25 @@ outputs:
 """)
         with self.dataset_populator.test_history() as history_id:
             invocation_id = self.workflow_populator.invoke_workflow(workflow_id, history_id=history_id).json()["id"]
+
+            def step_output_id(step_label):
+                invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+                invocation_step = next(
+                    (step for step in invocation["steps"] if step["workflow_step_label"] == step_label), None
+                )
+                if invocation_step and (output := invocation_step["outputs"].get("out_file1")):
+                    return output["id"]
+                return None
+
+            failed_dataset_id = wait_on(lambda: step_output_id("job_props"), "job_props output to be created")
+            failed_state = self.dataset_populator.wait_for_dataset(history_id, failed_dataset_id, assert_ok=False)
+            assert failed_state == "error", failed_state
             failed_dataset = self.dataset_populator.get_history_dataset_details(
-                history_id, hid=1, wait=True, assert_ok=False
+                history_id, content_id=failed_dataset_id, wait=False
             )
-            assert failed_dataset["state"] == "error", failed_dataset
-            paused_dataset = self.dataset_populator.get_history_dataset_details(
-                history_id, hid=5, wait=True, assert_ok=False
-            )
-            assert paused_dataset["state"] == "paused", paused_dataset
+            paused_dataset_id = wait_on(lambda: step_output_id("branch"), "branch output to be created")
+            paused_state = self.dataset_populator.wait_for_dataset(history_id, paused_dataset_id, assert_ok=False)
+            assert paused_state == "paused", paused_state
             invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
             pick_step = next(step for step in invocation["steps"] if step["workflow_step_label"] == "pick")
             assert pick_step["state"] == "new", pick_step

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3448,6 +3448,191 @@ exit_code:
             assert len(filtered["elements"]) == 1, filtered
             assert filtered["elements"][0]["object"]["state"] == "ok", filtered
 
+    @skip_without_tool("exit_code_from_file")
+    def test_pick_value_first_ok_or_skip_selects_ok_after_failed(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_code:
+    type: data
+steps:
+  failed:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  pick:
+    type: pick_value
+    state:
+      mode: first_ok_or_skip
+    in:
+      input_0: failed/out_file1
+      input_1: exit_code
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_code:
+  content: "1"
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["messages"] == [], invocation
+            picked = invocation["outputs"]["picked"]
+            input_dataset = next(iter(invocation["inputs"].values()))
+            assert picked["id"] == input_dataset["id"]
+            picked_details = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=picked["id"], assert_ok=False
+            )
+            assert picked_details["state"] == "ok", picked_details
+
+    @skip_without_tool("exit_code_from_file")
+    def test_pick_value_first_ok_or_skip_all_failed(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_code:
+    type: data
+steps:
+  failed_a:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  failed_b:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  pick:
+    type: pick_value
+    state:
+      mode: first_ok_or_skip
+    in:
+      input_0: failed_a/out_file1
+      input_1: failed_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_code:
+  content: "1"
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["messages"] == [], invocation
+            picked = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
+            )
+            assert picked["extension"] == "expression.json", picked
+            assert picked["misc_blurb"] == "skipped", picked
+
+    @skip_without_tool("expression_parse_int")
+    @skip_without_tool("exit_code_from_file")
+    @skip_without_tool("expression_forty_two")
+    def test_pick_value_first_ok_or_skip_runtime_null_and_failed(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_code:
+    type: data
+steps:
+  runtime_null:
+    tool_id: expression_parse_int
+    state:
+      input1: not a number
+  failed:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  fallback:
+    tool_id: expression_forty_two
+    state: {}
+  pick:
+    type: pick_value
+    state:
+      mode: first_ok_or_skip
+    in:
+      input_0: runtime_null/out1
+      input_1: failed/out_file1
+      input_2: fallback/out1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_code:
+  content: "1"
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked_content = self.dataset_populator.get_history_dataset_content(
+                history_id,
+                content_id=invocation["outputs"]["picked"]["id"],
+                assert_ok=False,
+            )
+            assert picked_content == "42"
+
+    @skip_without_tool("exit_code_from_file")
+    def test_pick_value_first_ok_or_skip_mapped(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_codes:
+    type: collection
+steps:
+  results:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_codes
+  pick:
+    type: pick_value
+    state:
+      mode: first_ok_or_skip
+    in:
+      input_0: results/out_file1
+      input_1: exit_codes
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_codes:
+  collection_type: list
+  elements:
+    - identifier: failed
+      content: "1"
+    - identifier: ok
+      content: "0"
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked = self.dataset_populator.get_history_collection_details(
+                history_id,
+                content_id=invocation["output_collections"]["picked"]["id"],
+                assert_ok=False,
+            )
+            assert [element["element_identifier"] for element in picked["elements"]] == ["failed", "ok"]
+            assert all(element["object"]["state"] == "ok" for element in picked["elements"]), picked
+
     @skip_without_tool("job_properties")
     @skip_without_tool("cat1")
     def test_pick_value_input_paused(self):
@@ -3558,10 +3743,11 @@ input_data:
             )
             assert output_details["state"] == "ok"
 
-    def test_pick_value_first_or_skip_all_null(self):
+    @pytest.mark.parametrize("mode", ["first_or_skip", "first_ok_or_skip"])
+    def test_pick_value_first_or_skip_all_null(self, mode):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(
-                """class: GalaxyWorkflow
+                f"""class: GalaxyWorkflow
 inputs:
   input_data:
     type: data
@@ -3579,7 +3765,7 @@ steps:
   pick:
     type: pick_value
     state:
-      mode: first_or_skip
+      mode: {mode}
     in:
       input_0: branch_a/out_file1
       input_1: branch_b/out_file1

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3343,6 +3343,100 @@ input_data:
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
             assert invocation["state"] == "failed"
 
+    @skip_without_tool("exit_code_from_file")
+    def test_pick_value_input_failed(self):
+        # pick_value reads its inputs while scheduling, so it has to wait for the jobs
+        # producing them - scheduling against an unfinished input would pick a dataset
+        # that only later turns out to have failed.
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  exit_code:
+    type: data
+steps:
+  branch:
+    tool_id: exit_code_from_file
+    in:
+      input: exit_code
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+exit_code:
+  content: "1"
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["state"] == "failed"
+            assert len(invocation["messages"]) == 1
+            message = invocation["messages"][0]
+            assert message["reason"] == "dataset_failed"
+
+    @skip_without_tool("job_properties")
+    @skip_without_tool("cat1")
+    def test_pick_value_input_paused(self):
+        # A paused input can be resumed by the user, so pick_value waits for it the way
+        # DatabaseOperationTool inputs do rather than failing the invocation over it.
+        workflow_id = self._upload_yaml_workflow("""class: GalaxyWorkflow
+steps:
+  job_props:
+    tool_id: job_properties
+    state:
+      thebool: true
+      failbool: true
+  branch:
+    tool_id: cat1
+    in:
+      input1: job_props/out_file1
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""")
+        with self.dataset_populator.test_history() as history_id:
+            invocation_id = self.workflow_populator.invoke_workflow(workflow_id, history_id=history_id).json()["id"]
+            failed_dataset = self.dataset_populator.get_history_dataset_details(
+                history_id, hid=1, wait=True, assert_ok=False
+            )
+            assert failed_dataset["state"] == "error", failed_dataset
+            paused_dataset = self.dataset_populator.get_history_dataset_details(
+                history_id, hid=5, wait=True, assert_ok=False
+            )
+            assert paused_dataset["state"] == "paused", paused_dataset
+            self.dataset_populator.run_tool(
+                tool_id="job_properties",
+                inputs={
+                    "thebool": "false",
+                    "failbool": "false",
+                    "rerun_remap_job_id": failed_dataset["creating_job"],
+                },
+                history_id=history_id,
+            )
+            self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=False)
+            invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+            assert invocation["state"] == "scheduled", invocation
+            picked = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
+            )
+            assert picked["state"] == "ok", picked
+
     def test_pick_value_first_or_skip(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3343,6 +3343,43 @@ input_data:
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
             assert invocation["state"] == "failed"
 
+    @skip_without_tool("expression_parse_int")
+    @skip_without_tool("expression_forty_two")
+    def test_pick_value_runtime_null(self):
+        # Expression tools run as jobs and can compute null: parseInt produces NaN for
+        # this input, which the expression runtime serializes as null. The picker must
+        # wait for that value before it can reject it and use the fallback.
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+steps:
+  runtime_null:
+    tool_id: expression_parse_int
+    state:
+      input1: not a number
+  fallback:
+    tool_id: expression_forty_two
+    state: {}
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: runtime_null/out1
+      input_1: fallback/out1
+outputs:
+  picked:
+    outputSource: pick/output
+test_data: {}
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked_content = self.dataset_populator.get_history_dataset_content(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert picked_content == "42"
+
     @skip_without_tool("exit_code_from_file")
     def test_pick_value_input_failed(self):
         # pick_value reads its inputs while scheduling, so it has to wait for the jobs
@@ -3431,7 +3468,7 @@ outputs:
             )
             self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=False)
             invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
-            assert invocation["state"] == "scheduled", invocation
+            assert invocation["state"] in ("scheduled", "completed"), invocation
             picked = self.dataset_populator.get_history_dataset_details(
                 history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
             )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3457,6 +3457,10 @@ outputs:
                 history_id, hid=5, wait=True, assert_ok=False
             )
             assert paused_dataset["state"] == "paused", paused_dataset
+            invocation = self.workflow_populator.get_invocation(invocation_id, step_details=True)
+            pick_step = next(step for step in invocation["steps"] if step["workflow_step_label"] == "pick")
+            assert pick_step["state"] == "new", pick_step
+            assert pick_step["outputs"] == {}, pick_step
             self.dataset_populator.run_tool(
                 tool_id="job_properties",
                 inputs={

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3381,10 +3381,11 @@ test_data: {}
             assert picked_content == "42"
 
     @skip_without_tool("exit_code_from_file")
+    @skip_without_tool("__BUILD_LIST__")
+    @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_pick_value_input_failed(self):
-        # pick_value reads its inputs while scheduling, so it has to wait for the jobs
-        # producing them - scheduling against an unfinished input would pick a dataset
-        # that only later turns out to have failed.
+        # Failure is terminal, not null. Preserve the failed dataset as the picked
+        # output so downstream failure filters can handle it without failing scheduling.
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(
                 """class: GalaxyWorkflow
@@ -3402,9 +3403,26 @@ steps:
       mode: first_or_skip
     in:
       input_0: branch/out_file1
+  list:
+    tool_id: __BUILD_LIST__
+    in:
+      datasets_0|input: pick/output
+      datasets_1|input: exit_code
+    state:
+      datasets:
+      - id_cond:
+          id_select: id
+      - id_cond:
+          id_select: id
+  filter_failed:
+    tool_id: __FILTER_FAILED_DATASETS__
+    in:
+      input: list/output
 outputs:
   picked:
     outputSource: pick/output
+  filtered:
+    outputSource: filter_failed/output
 """,
                 test_data="""
 exit_code:
@@ -3416,10 +3434,19 @@ exit_code:
                 wait=True,
             )
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
-            assert invocation["state"] == "failed"
-            assert len(invocation["messages"]) == 1
-            message = invocation["messages"][0]
-            assert message["reason"] == "dataset_failed"
+            assert invocation["state"] in ("scheduled", "completed"), invocation
+            assert invocation["messages"] == [], invocation
+            picked = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"], assert_ok=False
+            )
+            assert picked["state"] == "error", picked
+            filtered = self.dataset_populator.get_history_collection_details(
+                history_id,
+                content_id=invocation["output_collections"]["filtered"]["id"],
+                assert_ok=False,
+            )
+            assert len(filtered["elements"]) == 1, filtered
+            assert filtered["elements"][0]["object"]["state"] == "ok", filtered
 
     @skip_without_tool("job_properties")
     @skip_without_tool("cat1")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3625,6 +3625,11 @@ exit_codes:
                 wait=True,
             )
             invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            input_collection = self.dataset_populator.get_history_collection_details(
+                history_id,
+                content_id=next(iter(invocation["inputs"].values()))["id"],
+                assert_ok=False,
+            )
             picked = self.dataset_populator.get_history_collection_details(
                 history_id,
                 content_id=invocation["output_collections"]["picked"]["id"],
@@ -3632,6 +3637,11 @@ exit_codes:
             )
             assert [element["element_identifier"] for element in picked["elements"]] == ["failed", "ok"]
             assert all(element["object"]["state"] == "ok" for element in picked["elements"]), picked
+            input_failed = next(
+                element for element in input_collection["elements"] if element["element_identifier"] == "failed"
+            )
+            picked_failed = next(element for element in picked["elements"] if element["element_identifier"] == "failed")
+            assert picked_failed["object"]["id"] == input_failed["object"]["id"]
 
     @skip_without_tool("job_properties")
     @skip_without_tool("cat1")
@@ -3744,7 +3754,7 @@ input_data:
             assert output_details["state"] == "ok"
 
     @pytest.mark.parametrize("mode", ["first_or_skip", "first_ok_or_skip"])
-    def test_pick_value_first_or_skip_all_null(self, mode):
+    def test_pick_value_skip_modes_all_null(self, mode):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(
                 f"""class: GalaxyWorkflow

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -430,7 +430,7 @@ def test_replace_expression_json_dataset_leaves_other_replacements_unchanged():
 )
 def test_pick_value_failed_state_classification(state, is_failed):
     hda = model.HistoryDatasetAssociation(create_dataset=True, flush=False)
-    hda.dataset.state = state
+    hda.state = state
     assert modules.PickValueModule._is_failed(hda) is is_failed
 
 

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -417,6 +417,23 @@ def test_replace_expression_json_dataset_leaves_other_replacements_unchanged():
     assert modules.replace_expression_json_dataset("a string", _workflow_step()) == "a string"
 
 
+@pytest.mark.parametrize(
+    ("state", "is_failed"),
+    [
+        (model.Dataset.states.OK, False),
+        (model.Dataset.states.DEFERRED, False),
+        (model.Dataset.states.EMPTY, False),
+        (model.Dataset.states.ERROR, True),
+        (model.Dataset.states.FAILED_METADATA, True),
+        (model.Dataset.states.DISCARDED, True),
+    ],
+)
+def test_pick_value_failed_state_classification(state, is_failed):
+    hda = model.HistoryDatasetAssociation(create_dataset=True, flush=False)
+    hda.dataset.state = state
+    assert modules.PickValueModule._is_failed(hda) is is_failed
+
+
 class MapOverTestCase(NamedTuple):
     data_input: str
     step_input_def: str | list[str]


### PR DESCRIPTION
# Add a failure-tolerant Pick Value mode

Stacked on #23433. That prerequisite makes `pick_value` wait for runtime inputs and
preserve terminal failed datasets without turning them into scheduling failures.

## Summary

This adds a Galaxy-specific `first_ok_or_skip` mode to the native Pick Value workflow
step. It selects the first non-null input whose dataset state is usable. Failed inputs are
ignored, and the step produces a skipped output when no usable input remains.

Existing modes are unchanged: failure remains distinct from null, so `first_or_skip` and
the CWL-derived modes continue to propagate a failed dataset as a non-null value. Users
must opt into the new mode when failure should behave like an unavailable branch.

## Details

- Add `first_ok_or_skip` to the backend mode validation and workflow-editor selection.
- Wait for all inputs using the readiness behavior introduced by #23433, then apply the
  failure policy during candidate selection rather than scheduling.
- Ignore `ERROR`, `FAILED_METADATA`, and `DISCARDED` datasets in the new mode.
- Keep `OK`, `DEFERRED`, and `EMPTY` datasets selectable; checking `not is_ok` would
  incorrectly discard the latter two states.
- Apply the same selection policy per element when Pick Value is mapped over collections.
- Reuse the existing skipped placeholder when every input is null, skipped, or failed.

## Why a separate mode?

Null/skipped and failed are different workflow outcomes. CWL PickValue methods operate on
null values and do not receive failed step outputs, while Galaxy can preserve failed HDAs
for downstream failure-aware operations such as `__FILTER_FAILED_DATASETS__`.

Changing `first_or_skip` to silently ignore failures would conflate those outcomes. An explicit mode makes failure tolerance intentional.

## Tests

Coverage uses real framework jobs rather than synthetic runtime values:

- a failed first input falls through to an OK second input;
- all failed inputs produce a skipped output;
- runtime JSON `null` and a failed input are both ignored before selecting an OK fallback;
- mapped selection proves the failed element aliases its corresponding fallback input;
- both skip-capable modes produce skipped outputs when every input is null/skipped;
- unit coverage classifies OK, DEFERRED, EMPTY, ERROR, FAILED_METADATA, and DISCARDED;
- the workflow-editor component preserves and emits the new mode.

Local validation:

- 20 Pick Value API tests passed.
- 86 workflow-module unit tests passed.
- 11 `FormPickValue` component tests passed.
