### PR TITLE
Return handler and job_runner_name to admins from the job show endpoint

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2384,10 +2384,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             rval["external_id"] = self.job_runner_external_id
             rval["command_line"] = self.command_line
             rval["traceback"] = self.traceback
-        if view == "admin_job_list":
-            rval["user_email"] = self.user.email if self.user else None
             rval["handler"] = self.handler
             rval["job_runner_name"] = self.job_runner_name
+        if view == "admin_job_list":
+            rval["user_email"] = self.user.email if self.user else None
             rval["info"] = self.info
             rval["session_id"] = self.session_id
             if self.galaxy_session and self.galaxy_session.remote_host:

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -53,6 +53,21 @@ class TestJobsApi(ApiTestCase, TestsTools):
         assert job["external_id"]
 
     @requires_new_history
+    def test_show_system_details_admin_only(self, history_id):
+        # handler and job_runner_name were only set for the admin_job_list
+        # view, so an admin reading a single job always got null for both.
+        self.__history_with_new_dataset(history_id)
+        job_id = self.__jobs_index(admin=True)[0]["id"]
+
+        job = self._get(f"jobs/{job_id}", admin=False).json()
+        assert job["handler"] is None
+        assert job["job_runner_name"] is None
+
+        job = self._get(f"jobs/{job_id}", admin=True).json()
+        assert job["handler"] is not None
+        assert job["job_runner_name"] is not None
+
+    @requires_new_history
     def test_admin_job_list(self, history_id):
         self.__history_with_new_dataset(history_id)
         jobs_response = self._get("jobs?view=admin_job_list", admin=False)


### PR DESCRIPTION
`JobSummary` documents `handler` and `job_runner_name` as "Only
administrator can see this value", but `GET /api/jobs/{id}` never returns
them — an admin always gets `null` for both, while `external_id` and
`command_line` on the same response are populated.

### Cause

`Job.to_dict` gates the two groups differently:

```python
if system_details or view == "admin_job_list":
    rval["external_id"] = self.job_runner_external_id
    rval["command_line"] = self.command_line
    rval["traceback"] = self.traceback
if view == "admin_job_list":
    rval["handler"] = self.handler
    rval["job_runner_name"] = self.job_runner_name
```

`GET /api/jobs/{id}` goes through `view_show_job`, which calls
`to_dict("element", system_details=is_admin)`. That reaches the first
branch but never the second, so the two fields are simply absent from the
dict. Because the pydantic models declare them `Optional[str] = None`,
they serialize as `null` rather than being omitted, which makes it look
like the values are missing rather than never populated.

### Fix

Move `handler` and `job_runner_name` into the `system_details` branch.
The `admin_job_list` view is unaffected — its condition already includes
`system_details`, so it keeps returning both.

### Why this matters

Anything that reads jobs one at a time loses the runner. The AnVIL tool
test harness records the full job object for every test it runs, so every
report it publishes carries a `job_runner_name` column that is `null` on
every row, and which runner a failing job used cannot be recovered after
the instance is gone.

### Testing

Adds `test_show_system_details_admin_only`, asserting both fields are
`None` for a non-admin and non-`None` for an admin on the show endpoint.
It uses `__history_with_new_dataset`, which waits for job completion, so
the values are reliably set by then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
