### PR TITLE
Reject output-only format_source references in the XML linter

### DIFF
--- a/lib/galaxy/tool_util/linters/output.py
+++ b/lib/galaxy/tool_util/linters/output.py
@@ -279,17 +279,10 @@ class OutputsFormatSourceReference(Linter):
         if not tool_xml:
             return
         param_qualified_paths = _collect_param_qualified_paths(tool_xml)
-        output_names = {
-            o.attrib["name"]
-            for o in tool_xml.findall("./outputs/data[@name]") + tool_xml.findall("./outputs/collection[@name]")
-        }
         for output in tool_xml.findall("./outputs/data[@format_source]") + tool_xml.findall(
             "./outputs/collection[@format_source]"
         ):
             format_source = output.attrib["format_source"]
-            # format_source can reference other outputs, skip if it matches an output name
-            if format_source in output_names:
-                continue
             _check_unqualified_reference(
                 lint_ctx, cls.name(), output, format_source, "format_source", param_qualified_paths
             )

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -849,31 +849,6 @@ OUTPUTS_FORMAT_SOURCE_QUALIFIED = """
 </tool>
 """
 
-OUTPUTS_FORMAT_SOURCE_OUTPUT_ONLY = """
-<tool id="id" name="name">
-    <inputs>
-        <param name="input1" type="data" format="data" />
-    </inputs>
-    <outputs>
-        <data name="source" format="bam" />
-        <data name="derived_data" format_source="source" />
-        <collection name="derived_collection" type="list" format_source="source" />
-    </outputs>
-</tool>
-"""
-
-OUTPUTS_FORMAT_SOURCE_INPUT_OUTPUT_SAME_NAME = """
-<tool id="id" name="name">
-    <inputs>
-        <param name="source" type="data" format="data" />
-    </inputs>
-    <outputs>
-        <data name="source" format="bam" />
-        <data name="derived" format_source="source" />
-    </outputs>
-</tool>
-"""
-
 # tool xml for repeats linter
 REPEATS = """
 <tool id="id" name="name">
@@ -2124,20 +2099,6 @@ def test_outputs_format_source_unqualified(lint_ctx):
 
 def test_outputs_format_source_qualified(lint_ctx):
     tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_QUALIFIED)
-    run_lint_module(lint_ctx, output, tool_source)
-    assert "format_source" not in lint_ctx.warn_messages
-    assert "format_source" not in lint_ctx.error_messages
-
-
-def test_outputs_format_source_rejects_output_only_reference(lint_ctx):
-    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_OUTPUT_ONLY)
-    run_lint_module(lint_ctx, output, tool_source)
-    assert "Output 'derived_data' references format_source='source'" in lint_ctx.error_messages
-    assert "Output 'derived_collection' references format_source='source'" in lint_ctx.error_messages
-
-
-def test_outputs_format_source_accepts_input_output_name_collision(lint_ctx):
-    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_INPUT_OUTPUT_SAME_NAME)
     run_lint_module(lint_ctx, output, tool_source)
     assert "format_source" not in lint_ctx.warn_messages
     assert "format_source" not in lint_ctx.error_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -849,6 +849,31 @@ OUTPUTS_FORMAT_SOURCE_QUALIFIED = """
 </tool>
 """
 
+OUTPUTS_FORMAT_SOURCE_OUTPUT_ONLY = """
+<tool id="id" name="name">
+    <inputs>
+        <param name="input1" type="data" format="data" />
+    </inputs>
+    <outputs>
+        <data name="source" format="bam" />
+        <data name="derived_data" format_source="source" />
+        <collection name="derived_collection" type="list" format_source="source" />
+    </outputs>
+</tool>
+"""
+
+OUTPUTS_FORMAT_SOURCE_INPUT_OUTPUT_SAME_NAME = """
+<tool id="id" name="name">
+    <inputs>
+        <param name="source" type="data" format="data" />
+    </inputs>
+    <outputs>
+        <data name="source" format="bam" />
+        <data name="derived" format_source="source" />
+    </outputs>
+</tool>
+"""
+
 # tool xml for repeats linter
 REPEATS = """
 <tool id="id" name="name">
@@ -2099,6 +2124,20 @@ def test_outputs_format_source_unqualified(lint_ctx):
 
 def test_outputs_format_source_qualified(lint_ctx):
     tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_QUALIFIED)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "format_source" not in lint_ctx.warn_messages
+    assert "format_source" not in lint_ctx.error_messages
+
+
+def test_outputs_format_source_rejects_output_only_reference(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_OUTPUT_ONLY)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "Output 'derived_data' references format_source='source'" in lint_ctx.error_messages
+    assert "Output 'derived_collection' references format_source='source'" in lint_ctx.error_messages
+
+
+def test_outputs_format_source_accepts_input_output_name_collision(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_INPUT_OUTPUT_SAME_NAME)
     run_lint_module(lint_ctx, output, tool_source)
     assert "format_source" not in lint_ctx.warn_messages
     assert "format_source" not in lint_ctx.error_messages


### PR DESCRIPTION
Remove the XML linter exemption that treated an output name as a valid `format_source` reference.

At runtime, output formats can be derived from tool inputs and input collections, but not from another output. The schema likewise documents `format_source` as an input reference. Restricting the linter to collected input parameter paths makes linting consistent with those semantics.

Fixes #23449.

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Lint a tool whose output uses another output's name as its `format_source`.
  2. Confirm that the linter reports the reference as an unknown parameter.

Existing linter suite: `pytest test/unit/tool_util/test_tool_linters.py` (104 passed).

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
