### PR TITLE
Add pkg-resources-backport dependency for fs

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,6 +180,7 @@ paste==3.10.1
 pathable==0.6.0
 pebble==5.2.0
 pillow==12.3.0
+pkg-resources-backport==1.0.1
 platformdirs==4.11.7
 prompt-toolkit==3.0.53
 propcache==0.5.2
@@ -247,7 +248,7 @@ ruamel-yaml==0.19.1
 s3fs==2026.7.0
 schema-salad==8.10.20260825112551
 secretstorage==3.5.0 ; sys_platform == 'linux'
-setuptools==81.0.0
+setuptools==84.0.0
 six==1.17.0
 slowapi==0.1.10
 sniffio==1.3.1

--- a/packages/files/pyproject.toml
+++ b/packages/files/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 dependencies = [
     "galaxy-util[config-template,template]",
     "fs",
-    "setuptools<82",  # TODO: remove once pyfilesystem2 drops pkg_resources (https://github.com/PyFilesystem/pyfilesystem2/issues/597)
+    "pkg-resources-backport",  # needed by fs https://github.com/PyFilesystem/pyfilesystem2/issues/577
     "pydantic>=2.7.4",
     "typing-extensions",
     "fsspec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     # https://github.com/noxdafox/pebble/pull/168
     "pebble!=5.2.1,!=5.2.2",
     "pillow",
+    "pkg-resources-backport",  # needed by fs https://github.com/PyFilesystem/pyfilesystem2/issues/577
     "psutil",
     "pulsar-galaxy-lib>=0.15.15",
     "pycryptodome",
@@ -259,7 +260,6 @@ keep-runtime-typing = true
 constraint-dependencies = [
     "limits>=2.5.0",  # prefer not downgrading this to upgrading packaging
     "mirakuru!=3.0.0",  # https://github.com/dbfixtures/mirakuru/pull/949
-    "setuptools<82",  # https://github.com/PyFilesystem/pyfilesystem2/issues/597
     "scipy>=1.14.1; python_version>='3.10'",  # Python 3.13 support
 ]
 default-groups = []


### PR DESCRIPTION
fs depends at runtime on pkg_resources, which was removed from setuptools in v82, xref: https://github.com/PyFilesystem/pyfilesystem2/issues/577

Until we finish migrating from the unmaintained fs package to fsspec ( https://github.com/galaxyproject/galaxy/issues/21832 ), add dependency on pkg-resources-backport and remove constraint on setuptools.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
