### PR TITLE
[25.1] Two Continuous Integration workflow fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
-# Python CircleCI 2.0 configuration file
-version: 2
+version: 2.1
 variables:
   restore_repo_cache: &restore_repo_cache
     restore_cache:
@@ -82,7 +81,6 @@ jobs:
       - *install_tox
       - run: tox -e validate_test_tools
 workflows:
-  version: 2
   get_code_and_test:
     jobs:
       - get_code

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           driver: none
+          container-runtime: docker
           kubernetes-version: '1.28.0'
       - name: Check pods
         run: kubectl get pods -A


### PR DESCRIPTION
- Backport of fix for setup-minikube action from https://github.com/galaxyproject/galaxy/pull/23438
- Update CircleCI pipeline to version 2.1, as CircleCI is removing support for `version: 2.0` configs

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
