### PR TITLE
CI Bugfix - exclude Pebble 5.2.2

### DIFF
--- a/packages/app/pyproject.toml
+++ b/packages/app/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "nodejs-wheel>=22,<23",
     "packaging",
     "paramiko!=2.9.0,!=2.9.1",
-    "pebble!=5.2.1",
+    "pebble!=5.2.1,!=5.2.2",
     "pulsar-galaxy-lib>=0.15.15",
     "pydantic>=2.7.4",
     "pydantic-ai>=1.99.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ dependencies = [
     "paramiko!=2.9.0,!=2.9.1",  # https://github.com/paramiko/paramiko/issues/1961
     "Parsley",
     "Paste",
-    "pebble!=5.2.1",  # https://github.com/noxdafox/pebble/issues/164
+    # https://github.com/noxdafox/pebble/issues/164
+    # https://github.com/noxdafox/pebble/pull/168
+    "pebble!=5.2.1,!=5.2.2",
     "pillow",
     "psutil",
     "pulsar-galaxy-lib>=0.15.15",


### PR DESCRIPTION
Until @nsoranzo's fixes are released. 

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
