### PR TITLE
Restore styling and behaviour lost in the GButton adoption sweep

### DIFF
--- a/client/packages/ui/src/components/GButtonGroup.vue
+++ b/client/packages/ui/src/components/GButtonGroup.vue
@@ -22,6 +22,9 @@ const styleClasses = computed(() => {
 .g-button-group {
     display: inline-flex;
     gap: 0;
+    // Bootstrap's `.btn-group` set `vertical-align: middle`; without it a group placed
+    // next to standalone `.g-button`s (also `middle`) aligns on the baseline instead.
+    vertical-align: middle;
 
     // Matches Bootstrap's `.btn-group > .btn`, so a group given a width (`w-100`)
     // stretches its buttons instead of collapsing them to content width.

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -416,6 +416,8 @@ function onKeyDown(event: KeyboardEvent) {
                                                     v-g-tooltip.hover
                                                     class="inline-icon-button g-card-rename"
                                                     transparent
+                                                    icon-only
+                                                    color="blue"
                                                     :title="localize(props.renameTitle)"
                                                     @click="emit('rename')">
                                                     <FontAwesomeIcon :icon="faPen" fixed-width />
@@ -467,6 +469,8 @@ function onKeyDown(event: KeyboardEvent) {
                                         v-g-tooltip.hover
                                         class="inline-icon-button"
                                         transparent
+                                        icon-only
+                                        color="blue"
                                         :title="props.bookmarked ? 'Remove bookmark' : 'Add to bookmarks'"
                                         @click="toggleBookmark">
                                         <FontAwesomeIcon :icon="props.bookmarked ? faStar : farStar" fixed-width />
@@ -477,6 +481,8 @@ function onKeyDown(event: KeyboardEvent) {
                                         v-g-tooltip.hover
                                         class="inline-icon-button"
                                         transparent
+                                        icon-only
+                                        color="blue"
                                         :title="localize('Bookmarking...')"
                                         disabled>
                                         <FontAwesomeIcon :icon="faSpinner" spin fixed-width />
@@ -566,7 +572,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-g-tooltip.hover
                                                 class="inline-icon-button"
                                                 :title="localize(indicator.title)"
-                                                v-bind="variantToColor(indicator.variant || 'outline-secondary')"
+                                                v-bind="variantToColor(indicator.variant || 'link')"
                                                 :size="sizeToGSize(indicator.size || 'sm')"
                                                 :to="indicator.to"
                                                 :href="indicator.href"

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -654,7 +654,7 @@ function onKeyDown(event: KeyboardEvent) {
                                 <GButtonGroup
                                     v-if="props.secondaryActions?.length"
                                     :id="getElementId(props.id, 'secondary-actions')"
-                                    class="mt-1">
+                                    class="g-card-secondary-actions mt-1">
                                     <template v-for="sa in props.secondaryActions">
                                         <GButton
                                             v-if="sa.visible ?? true"
@@ -856,6 +856,15 @@ function onKeyDown(event: KeyboardEvent) {
         .g-card-secondary-action-label {
             @container g-card (max-width: #{$breakpoint-sm}) {
                 display: none;
+            }
+        }
+
+        .g-card-secondary-actions .g-button {
+            @container g-card (max-width: #{$breakpoint-sm}) {
+                // With the label hidden only the icon is left in an inline-flex box, which has
+                // no line box and collapses to `1em` tall; keep these as tall as the labelled
+                // primary actions beside them (`1.5em` line box plus padding and border).
+                min-height: calc(1.5em + 2 * var(--spacing-1) + 2px);
             }
         }
     }

--- a/client/src/components/Graph/ZoomControl.vue
+++ b/client/src/components/Graph/ZoomControl.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
 import { getZoomInLevel, getZoomOutLevel, isMaxZoom, isMinZoom } from "@/utils/zoomLevels";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
-import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 
 const props = defineProps({
     zoomLevel: { type: Number, default: 1 },
@@ -31,20 +32,23 @@ function onZoomReset() {
 </script>
 
 <template>
-    <GButtonGroup class="zoom-control float-right">
+    <div class="zoom-control float-right">
         <GButton
             :disabled="isMinZoom(props.zoomLevel)"
-            class="fa fa-minus"
             title="Zoom Out"
             size="small"
+            outline
             icon-only
             aria-label="Zoom Out"
-            @click="onZoomOut" />
+            @click="onZoomOut">
+            <FontAwesomeIcon :icon="faMinus" fixed-width />
+        </GButton>
         <GButton
             tooltip
             class="zoom-reset"
-            transparent
+            outline
             title="Reset Zoom Level"
+            pill
             size="small"
             aria-label="Reset Zoom Level"
             @click="onZoomReset">
@@ -52,17 +56,20 @@ function onZoomReset() {
         </GButton>
         <GButton
             :disabled="isMaxZoom(props.zoomLevel)"
-            class="fa fa-plus"
             title="Zoom In"
             size="small"
+            outline
             icon-only
             aria-label="Zoom In"
-            @click="onZoomIn" />
-    </GButtonGroup>
+            @click="onZoomIn">
+            <FontAwesomeIcon :icon="faPlus" fixed-width />
+        </GButton>
+    </div>
 </template>
 
 <style scoped>
 .zoom-reset {
+    display: block;
     width: 4rem;
 }
 .zoom-control {
@@ -71,5 +78,8 @@ function onZoomReset() {
     bottom: 1rem;
     cursor: pointer;
     z-index: 2000;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
 }
 </style>

--- a/client/src/components/History/CurrentHistory/HistoryCounter.test.ts
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.test.ts
@@ -1,5 +1,5 @@
 import { getLocalVue } from "@tests/vitest/helpers";
-import { shallowMount } from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,6 @@ import { useConfigStore } from "@/stores/configurationStore";
 import { useUserStore } from "@/stores/userStore";
 
 import HistoryCounter from "./HistoryCounter.vue";
-import GButton from "@/components/BaseComponents/GButton.vue";
 
 const sseState = vi.hoisted(() => ({
     onEvent: null as ((event: MessageEvent) => void) | null,
@@ -71,15 +70,21 @@ function setEnableSse(enabled: boolean): void {
     useUserStore().currentUser = { id: "user-1", email: "u@example.com" } as RegisteredUser;
 }
 
-function mountCounter(props: Partial<{ lastChecked: Date; isWatching: boolean }> = {}) {
-    return shallowMount(HistoryCounter as unknown as object, {
+function mountCounter(props: Partial<{ lastChecked: Date; isWatching: boolean }> = {}, deep = false) {
+    const options = {
         propsData: {
             history: baseHistory,
             lastChecked: props.lastChecked ?? new Date(),
             isWatching: props.isWatching ?? true,
         },
         localVue,
-    });
+    };
+    // ``shallowMount`` renders GButton as a stub, which is what the appearance
+    // assertions read their props off. A real ``mount`` is needed whenever a click has
+    // to travel through the template binding into GButton's own click handler.
+    return deep
+        ? mount(HistoryCounter as unknown as object, options)
+        : shallowMount(HistoryCounter as unknown as object, options);
 }
 
 function refreshButton(wrapper: ReturnType<typeof shallowMount>) {
@@ -199,12 +204,10 @@ describe("HistoryCounter — refresh button", () => {
         setSseConnected(sseState, true);
         setSseHasEverConnected(sseState, true);
 
-        const wrapper = mountCounter();
+        const wrapper = mountCounter({}, true);
         await flushPromises();
-        // The shallow-mounted ``<g-button-stub>`` doesn't bind ``@click`` the
-        // way the real GButton does, so emit the GButton's ``click`` event
-        // directly via the component instance.
-        await refreshButton(wrapper).findComponent(GButton).vm.$emit("click");
+
+        await refreshButton(wrapper).trigger("click");
 
         expect(wrapper.emitted("reloadContents")).toBeTruthy();
         expect(wrapper.emitted("reloadContents")?.length).toBe(1);

--- a/client/src/components/JobInformation/JobOutputs.test.js
+++ b/client/src/components/JobInformation/JobOutputs.test.js
@@ -2,6 +2,7 @@ import { shallowMount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 import JobOutputs from "./JobOutputs.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 
 vi.mock("components/providers/DatasetCollectionProvider");
 
@@ -71,8 +72,11 @@ describe("JobInformation/JobOutputs.vue", () => {
             title: "Job Outputs",
             paginate: true,
         };
+        // The paginate button is rendered for real, so the click has to travel through
+        // the template's ``@click`` binding and GButton's own click guard.
         wrapper = shallowMount(JobOutputs, {
             propsData,
+            stubs: { GButton },
         });
         // ---- Before all remaining outputs are paginated: ----
         // heading should exist and include count (due to pagination)
@@ -87,9 +91,7 @@ describe("JobInformation/JobOutputs.vue", () => {
         expect(rows.length).toBe(12);
         // ---- Click button, remaining 5 outputs should be displayed ----
         expect(wrapper.find("#paginate-btn").exists()).toEqual(true);
-        // The shallow-mounted GButton stub doesn't bind @click natively,
-        // so emit the GButton's click event directly via the component instance.
-        await wrapper.find("#paginate-btn").vm.$emit("click");
+        await wrapper.find("#paginate-btn").trigger("click");
         jobOutputsTable = wrapper.find("#job-outputs");
         rows = jobOutputsTable.findAll("tr");
         // should now contain a header and 15 rows (all 15 items and no button)

--- a/client/src/components/Login/NewUserConfirmation.vue
+++ b/client/src/components/Login/NewUserConfirmation.vue
@@ -37,6 +37,13 @@ function login() {
 }
 
 async function submit() {
+    // The confirm button carries no native `disabled` attribute, so it stays keyboard
+    // activatable and eligible as the form's default button. Guard the terms here too,
+    // since an implicit form submission never reaches the button's click handler.
+    if (!termsRead.value) {
+        return;
+    }
+
     if (!provider.value || !token.value) {
         messageVariant.value = "danger";
         messageText.value = "Missing provider and/or token.";

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -18,7 +18,6 @@
                 <GButton
                     v-if="currentUser && currentHistoryId"
                     v-g-tooltip.hover
-                    href="#"
                     transparent
                     title="Import Collection"
                     size="small"

--- a/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
@@ -138,6 +138,9 @@ function dismiss() {
         <GButton
             v-if="multiple"
             class="arrow left inline-icon-button area-l"
+            transparent
+            icon-only
+            color="blue"
             title="Previous"
             @click="currentPage -= 1">
             <FontAwesomeIcon fixed-width :icon="faChevronLeft" />
@@ -174,11 +177,23 @@ function dismiss() {
             </div>
         </section>
 
-        <GButton v-if="multiple" class="arrow right inline-icon-button area-r" title="Next" @click="currentPage += 1">
+        <GButton
+            v-if="multiple"
+            class="arrow right inline-icon-button area-r"
+            transparent
+            icon-only
+            color="blue"
+            title="Next"
+            @click="currentPage += 1">
             <FontAwesomeIcon fixed-width :icon="faChevronRight" />
         </GButton>
 
-        <GButton class="dismiss-button inline-icon-button area-x" title="Dismiss" @click="dismiss">
+        <GButton
+            class="dismiss-button inline-icon-button area-x"
+            transparent
+            icon-only
+            title="Dismiss"
+            @click="dismiss">
             <FontAwesomeIcon fixed-width :icon="faTimes" />
         </GButton>
     </div>
@@ -254,7 +269,10 @@ $margin: 1rem;
         }
     }
 
-    .dismiss-button {
+    // The `.g-button.g-transparent:not(.g-pressed)` part is not decoration: it is what
+    // lets these rules out-rank GButton's own scoped transparent rules, which are more
+    // specific than a plain `.dismiss-button` selector.
+    .dismiss-button.g-button.g-transparent:not(.g-pressed) {
         font-size: 1.5rem;
         color: $border-color;
 

--- a/client/src/components/Sharing/EditableUrl.vue
+++ b/client/src/components/Sharing/EditableUrl.vue
@@ -68,10 +68,26 @@ function onCopyOut() {
                 @keyup.enter="onSubmit" />
         </span>
 
-        <GButton v-if="!editing" v-g-tooltip.hover class="inline-icon-button" title="Edit URL" @click="onEdit">
+        <GButton
+            v-if="!editing"
+            v-g-tooltip.hover
+            class="inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
+            title="Edit URL"
+            @click="onEdit">
             <FontAwesomeIcon :icon="faEdit" fixed-width />
         </GButton>
-        <GButton v-else v-g-tooltip.hover class="inline-icon-button" title="Done" @click="onSubmit">
+        <GButton
+            v-else
+            v-g-tooltip.hover
+            class="inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
+            title="Done"
+            @click="onSubmit">
             <FontAwesomeIcon :icon="faCheck" fixed-width />
         </GButton>
 
@@ -81,6 +97,9 @@ function onCopyOut() {
             v-g-tooltip.hover
             :disabled="editing"
             class="inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
             :title="clipboardTitle"
             @click="onCopy"
             @mouseout="onCopyOut"

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -182,13 +182,19 @@ function onTagClicked(tag: string) {
 
 <style lang="scss" scoped>
 .stateless-tags {
-    .toggle-link {
+    // The `.g-button.g-transparent:not(.g-pressed)` part is what lifts these rules above
+    // GButton's own scoped rules, which are otherwise the more specific of the two: on a
+    // plain `.toggle-link` selector the padding tie is decided by bundle order and the
+    // hover paints a solid blue pill instead of leaving a bare link.
+    .toggle-link.g-button.g-transparent:not(.g-pressed) {
         padding: 0;
         border: none;
 
         &:hover {
             background-color: transparent;
             border: none;
+            color: var(--color-blue-700);
+            text-decoration: underline;
         }
     }
 }

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -53,7 +53,7 @@ function toggleCategory(category: string) {
             </ExternalLink>
         </p>
 
-        <GButton class="ui-link" @click="mainOpen = !mainOpen">
+        <GButton class="ui-link" transparent inline color="blue" @click="mainOpen = !mainOpen">
             <b>
                 Tutorials available in {{ trainingCategories.length }}
                 {{ trainingCategories.length > 1 ? "categories" : "category" }}
@@ -62,7 +62,7 @@ function toggleCategory(category: string) {
         </GButton>
         <GCollapse v-model="mainOpen">
             <div v-for="category in trainingCategories" :key="category">
-                <GButton class="ui-link ml-3" @click="toggleCategory(category)">
+                <GButton class="ui-link ml-3" transparent inline color="blue" @click="toggleCategory(category)">
                     {{ category }} ({{ tutorialsInCategory(category).length }})
                     <FontAwesomeIcon :icon="faCaretDown" />
                 </GButton>
@@ -79,3 +79,17 @@ function toggleCategory(category: string) {
         </GCollapse>
     </div>
 </template>
+
+<style scoped lang="scss">
+// GButton's transparent-blue hover repaints the label near-white, and `.ui-link` keeps
+// the background transparent, so without this the toggles vanish on hover. The extra
+// `.g-*` classes are not decoration: they are what lifts this rule above
+// `.g-button.g-transparent:not(.g-pressed).g-blue:hover`.
+.ui-link.g-button.g-transparent.g-blue:not(.g-pressed) {
+    &:hover,
+    &:focus-visible {
+        color: var(--color-blue-700);
+        text-decoration: underline;
+    }
+}
+</style>

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -29,6 +29,8 @@
                     v-if="credentials.length > 0"
                     v-g-tooltip.hover
                     class="node-credentials py-0 inline-icon-button"
+                    transparent
+                    icon-only
                     color="blue"
                     size="small"
                     aria-label="tool has credentials"

--- a/client/src/components/Workflow/List/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/List/WorkflowIndicators.vue
@@ -158,6 +158,9 @@ function getStepText(steps: number) {
             v-g-tooltip.hover
             size="small"
             class="workflow-published-icon inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
             :title="publishedTitle"
             @click="emit('updateFilter', 'published', true)">
             <FontAwesomeIcon :icon="faGlobe" fixed-width />
@@ -175,6 +178,9 @@ function getStepText(steps: number) {
             v-g-tooltip.hover
             size="small"
             class="workflow-trs-icon inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
             :title="sourceTitle">
             <FontAwesomeIcon :icon="faShieldAlt" fixed-width @click="onCopyLink" />
         </GButton>
@@ -184,6 +190,9 @@ function getStepText(steps: number) {
             v-g-tooltip.hover
             size="small"
             class="workflow-external-link inline-icon-button"
+            transparent
+            icon-only
+            color="blue"
             :title="sourceTitle">
             <FontAwesomeIcon :icon="faFileImport" fixed-width @click="onCopyLink" />
         </GButton>

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -288,7 +288,9 @@ a.btn {
 
 .btn-transparent-background {
     // A wrapper for buttons with transparent background when hovering over it.
-    .btn {
+    // `.g-button` is listed alongside `.btn` for buttons migrated off bootstrap-vue.
+    .btn,
+    .g-button {
         background-color: transparent !important;
         border-color: transparent !important;
     }
@@ -299,6 +301,16 @@ a.btn {
 
     .btn:active {
         color: $brand-dark;
+    }
+
+    // GButton's own scoped variant rules are more specific than a two-class selector,
+    // so the colours have to be forced for it.
+    .g-button:hover {
+        color: $brand-info !important;
+    }
+
+    .g-button:active {
+        color: $brand-dark !important;
     }
 }
 


### PR DESCRIPTION
Follow-up to #22688. That PR converts the last `BButton` call sites to `GButton`. This PR carries the remaining call-site fixes, which are mostly styling regressions the conversion exposed, plus three small behaviour fixes.

The styling regressions all have the same cause. The converted buttons no longer carry `.btn`, and `GButton`'s scoped rules (`.g-button.g-…[data-v-…]`, specificity 0,3,0 and up) outrank the global helper classes those call sites still rely on (0,1,0): `.inline-icon-button` (`client/src/style/scss/ui.scss:427`), `.btn-transparent-background` (`client/src/style/scss/base.scss:289`), `.ui-link` and `.toggle-link`. The visible effect is that brand-blue borderless icons render as grey boxes or bordered chips, and a couple of hover states paint a solid fill where they used to be bare links. Each call site is fixed by passing the props that express what the helper used to do (`transparent`, `icon-only`, `color="blue"`), or by raising the scoped selector so it deterministically outranks `GButton`'s own rule rather than tying on bundle order.

Three behaviour fixes ride along. `HistoryCounter.test.ts` and `JobOutputs.test.js` had been weakened to `.findComponent(GButton).vm.$emit("click")`, which no longer covers the template's `@click` wiring or `GButton`'s disabled guard and would pass with the `@click` deleted; both are back to mounting for real and clicking the button. `NewUserConfirmation` gains an `if (!termsRead.value) return;` guard in `submit()`, because `GButton` renders `aria-disabled` rather than native `disabled`, so an Enter-submit on the form never reaches the button handler and the disabled state alone no longer gates account creation. And `CollectionDisplay`'s import button was `href="#"` with a `@click` that had no `.prevent`; bootstrap-vue's `BLink` special-cased a bare `#` href, `GButton` does not, so importing a collection also pushed a history entry and scrolled the page to the top.

One change is worth calling out because the obvious fix would have been wrong. `GCard`'s indicator buttons needed `transparent color="blue"`, but hard-coding those props on the element would have silently killed `indicator.variant` for callers that set it (`useHistoryCardIndicators.ts:75` passes `variant: "danger"`), because Vue 2's `v-bind="obj"` never overwrites an explicitly declared attribute. Instead the indicator's default variant changed from `outline-secondary` to `link`, which `variantToColor` already maps to exactly `{ transparent: true, color: "blue" }`, so caller-supplied variants keep working.

Three more commits ride on top of the eleven above. Two are component-level alignment fixes: `GButtonGroup`'s inline-flex root had no `vertical-align`, so a group sitting next to standalone `GButton`s (which are `vertical-align: middle`) lined up on the baseline instead, the way Bootstrap's `.btn-group` used to prevent; and `GCard` hides its secondary-action labels below the `sm` container width, which leaves only the icon in `GButton`'s inline-flex root; that box has no line box, so the group collapsed to 22px next to the 28px labelled primary actions, where Bootstrap's `.btn` kept one line box for both. The height fix is scoped to that group rather than to `GButton` itself, because a component-level `min-height` would override every consumer that pins its own button height (the workflow editor comment toolbars, `GModal`'s close button, history item selectors, editor node headers). The third is @ahmedhamidawan's zoom-control change from his review of #22688, cherry-picked here: the workflow editor's zoom control becomes a spaced row of outlined icon buttons with a pill-shaped reset instead of a fused button group.

## Commits

- Restore brand colour on GCard inline icon buttons — rename pencil and bookmark star go back to borderless brand blue.
- Restore brand colour on EditableUrl icon buttons — Edit URL, Done and Copy were rendering as full grey bordered buttons.
- Restore broadcast arrow and dismiss button styling — the banner arrows and the dismiss cross, including the red hover on the cross.
- Restore brand colour on workflow list indicators — published globe, TRS shield and URL-import glyphs.
- Keep the node credentials indicator borderless — the workflow editor node header chip.
- Apply the transparent-background helper to GButton — the tag delete cross in `Tag.vue`.
- Restore the link look of the tutorial category toggles — `ToolTutorialRecommendations`, including the `display: inline` the helper used to set.
- Keep the tag toggles looking like bare links on hover — `StatelessTags` "N more…" and "Fewer tags".
- Click the real button in the counter and outputs tests — restores real click coverage in `HistoryCounter.test.ts` and `JobOutputs.test.js`.
- Guard account creation on the accepted terms — `NewUserConfirmation.submit()`.
- Stop the collection import button navigating to a fragment — `CollectionDisplay`.
- Vertically align GButtonGroup with sibling buttons — adds `vertical-align: middle` to `GButtonGroup`'s root so it lines up with standalone `GButton`s next to it.
- change ZoomControl from being a button group to a div — cherry-picked from @ahmedhamidawan's commit on #22688; the workflow editor zoom control is now three separate outlined buttons with a pill-shaped reset instead of a fused group.
- Keep GCard action buttons level when their labels hide — under the same container query that hides the secondary-action labels, gives that group's buttons the height of a one-line text button so they match the primary actions beside them.

This branch has been rebased onto `dev` now that #22688 has merged.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run `cd client && pnpm vitest run src/components/History/CurrentHistory/HistoryCounter.test.ts src/components/JobInformation/JobOutputs.test.js` and confirm both pass — they now mount the component and click the real button rather than emitting `click` on a stub.
  2. Open `/workflows/list` with at least one published workflow and one imported from a TRS server or a URL. The published globe, TRS shield and URL-import indicators must be borderless brand-blue glyphs, not grey or white bordered chips.
  3. Open a history's sharing page (`/histories/sharing?id=…`). The Edit URL pencil, the Done check and the Copy button must be borderless blue icons, not full grey bordered buttons.
  4. As an admin, create a broadcast with two or more action links (`/admin/notifications/create_new_broadcast`), then view it. The left/right arrows must be borderless, and the dismiss cross must be borderless with a red hover rather than a grey filled square.
  5. On any item with tags, hover the `×` on a tag pill: it must stay bare over the tag's coloured background instead of taking a grey hover box.
  6. Open a tool that has tutorial recommendations and click the category toggles. They must render and hover as brand-blue inline links, not grey inline-flex buttons.
  7. On an item with more tags than fit, hover "N more…" and "Fewer tags": they must stay bare links rather than painting a solid blue pill.
  8. In a workflow report or page, click the import button on a history dataset collection element. The collection must be imported without the page also navigating to `#` (no new history entry, no scroll to top).
  9. On the OIDC new-user confirmation form, press Enter without ticking the terms checkbox. No account may be created.
  10. Open the Workflows list and click a workflow title to open "Workflow Preview". The Download / copy-link button group and the Edit (or Import) and Run buttons must share the same top and bottom edge.
  11. Open `/workflows/list` and `/workflows/list_published` at the default three-column card width, where the secondary-action labels are hidden. The small icon group at the bottom right of each card (copy link / download / share) must be exactly as tall as the Edit/Import and Run buttons next to it; widen the centre panel until the labels reappear and the group must still line up. The workflow editor's comment toolbars and the modal close button must be unchanged.
  12. Open any workflow in the editor. The bottom-left zoom control must show − / 100% / + as three separate outlined buttons with a gap, the reset pill must show the current zoom level, and the − / + buttons must disable at the min/max zoom.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
