### PR TITLE
[26.1] Don't set job state to OK before finish_job runs in the GCP Batch runner

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -752,7 +752,6 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             if job_status == batch_v1.JobStatus.State.SUCCEEDED:
                 log.info("Batch job %s completed successfully", batch_job_name)
                 job_state.running = False
-                job_state.job_wrapper.change_state(model.Job.states.OK)
                 self.mark_as_finished(job_state)
                 log.debug("Finished check_watched_item for job %s (completed successfully)", job_state.job_id)
                 return None  # Remove from monitoring


### PR DESCRIPTION
`GoogleCloudBatchJobRunner.check_watched_item` commits `OK` the instant GCP
Batch reports `SUCCEEDED`:

```python
if job_status == batch_v1.JobStatus.State.SUCCEEDED:
    job_state.running = False
    job_state.job_wrapper.change_state(model.Job.states.OK)  # flush=True → commits now
    self.mark_as_finished(job_state)                         # only *queues* finish_job
```

`mark_as_finished` just puts `finish_job` on the runner work queue.
Everything an API client would expect a finished job to have is produced
later, inside `finish_job`:

1. `_handle_metadata_externally(..., resolve_requirements=True)`, which can
   be slow when dependencies or containers have to resolve;
2. `JobWrapper.finish()`, which reads `outputs/tool_stdout` and commits it
   via `set_streams`, collects job metrics, and — when
   `outputs_to_working_directory` is enabled — **moves the output files from
   the job working directory to their final dataset paths**. It then sets
   the final state, which is a no-op because the job is already terminal
   ("Ignoring state change ... already terminal").

So between the watch loop and the work queue there is a window where the
API reports `state: ok` while `tool_stdout` is NULL, `job_metrics` is `[]`,
and each output dataset still points at an empty placeholder file. A client
that trusts the state — the documented contract — reads HTTP 200 with zero
bytes.

The Kubernetes runner does not have this window: its success path calls
`mark_as_finished` without touching job state (`kubernetes.py:746`), so the
job stays `running` until `finish()` has committed streams and outputs. The
local runner behaves the same way. This change makes the Batch runner match.

### How this was found

The AnVIL nightly tool-test harness runs ~200 tools against a Galaxy
deployed on GCE with GCP Batch as the job runner. Roughly 220 tests per run
across ~45 tools failed reporting an empty output, stable across four runs.

`galaxy-tool-test` polls `GET jobs/{id}` every 0.25s with no backoff, and
the moment it sees `ok` it snapshots `jobs/{id}?full=true` and downloads
every output it compares (`verify_output` still carries
`# TODO: Twill version verifies dataset is 'ok' in here.`). That lands
inside the window, which produces all three observed surface forms from one
cause: `in output ('')` for text assertions, a unified diff whose actual
side is `+0,0`, and h5py's `file signature not found` on binary outputs.

Evidence from one run (401 empty-output problems over 239 tests, 48 tools):

| bucket | problems | evidence |
|---|---|---|
| `assert_stdout` / `assert_stderr` seeing `''` | 39 | **39/39 pass when re-run against the same job's stdout after the fact** — the data existed, just not when the client looked |
| dataset problems on tools with **no** zero-byte outputs server-side | 248 | the output had bytes by end of run, so it was read before `finish()` |
| dataset problems on mixed tools | 71 | ≥52 attributable by count |
| dataset problems on tools whose outputs really are empty | 43 | genuinely empty; unrelated to this |

Delivery was ruled out first, so this is not a serving problem: 60/60
byte-exact in-cluster, 45/45 from outside the VM including an 838 KB
`.h5ad`, and 240/240 under 24-way concurrency including a 4.3 MB file.

Independent corroboration: a script that backfills missing job metrics for
Batch jobs measured metrics arriving 14 ms to 12 s after `state=ok`.
Metrics commit in the same `finish()` path as the streams, so that lag is a
direct measurement of the window.

### Note on the FAILED branch

The `FAILED` branch has the same shape — `change_state(ERROR)` before
`mark_as_failed` queues `fail_job` — and would expose an equivalent window
to tests using `expect_failure`. It looks safe to remove too (`fail_job`
only consults state at `job.state != model.Job.states.NEW`, which still
holds when the state is `running`), but I've left it out to keep this
change to the path with measured evidence behind it. Happy to include it if
you'd prefer them fixed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
