### PR TITLE
Native Account page, Username relabel and grouped user preferences

### DIFF
--- a/client/src/components/Form/FormCard.vue
+++ b/client/src/components/Form/FormCard.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="ui-portlet-section">
-        <div :tabindex="collapsible ? 0 : -1" :class="portletHeaderClasses" @keydown="onKeyDown" @click="onCollapse">
+        <div
+            :tabindex="collapsible ? 0 : -1"
+            class="mb-2"
+            :class="portletHeaderClasses"
+            @keydown="onKeyDown"
+            @click="onCollapse">
             <div class="portlet-operations">
                 <slot name="operations" />
                 <GButton

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -4,7 +4,7 @@ import { BFormCheckbox } from "bootstrap-vue";
 import { computed, nextTick, reactive, ref, watch } from "vue";
 
 import type { AnyShareableItemWithStatus, ShareOption } from "@/api";
-import { isShareableHistoryWithStatus } from "@/api";
+import { GalaxyApi, isShareableHistoryWithStatus } from "@/api";
 import { getGalaxyInstance } from "@/app";
 import { getFullAppUrl } from "@/app/utils";
 import { useToast } from "@/composables/toast";
@@ -197,15 +197,18 @@ const newUsername = ref("");
 const slugSet = computed(() => itemUrl.slug != "__slug__" && itemUrl.prefix != "__username__");
 
 async function setUsername() {
-    axios
-        .put(`${getAppRoot()}api/users/${getGalaxyInstance().user.id}/information/inputs`, {
-            username: newUsername.value || "",
-        })
-        .then((response) => {
-            hasUsername.value = true;
-            getSharing();
-        })
-        .catch(onError);
+    const { error } = await GalaxyApi().PUT("/api/users/{user_id}", {
+        params: { path: { user_id: getGalaxyInstance().user.id } },
+        body: { username: newUsername.value || "" },
+    });
+
+    if (error) {
+        onError(error);
+        return;
+    }
+
+    hasUsername.value = true;
+    getSharing();
 }
 
 const embedable = computed(

--- a/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
@@ -1,5 +1,7 @@
 <template>
     <section class="external-id">
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
         <b-alert :show="!!connectExternal" variant="info">
             You are logged in. You can now connect the Galaxy user account with the email <i>{{ userEmail }}</i
             >, to your preferred external provider.
@@ -18,10 +20,6 @@
                 @dismissed="errorMessage = null"
                 >{{ errorMessage }}</b-alert
             >
-
-            <hgroup class="external-id-title">
-                <h1 class="h-lg">Manage External Identities</h1>
-            </hgroup>
 
             <p>
                 Users with existing Galaxy user accounts (e.g., via Galaxy username and password) can associate their
@@ -81,12 +79,14 @@ import { capitalizeFirstLetter } from "@/utils/strings";
 
 import svc from "./service";
 
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import ExternalLogin from "@/components/User/ExternalIdentities/ExternalLogin.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
+        BreadcrumbHeading,
         ExternalLogin,
     },
     setup() {
@@ -99,6 +99,7 @@ export default {
         const galaxy = getGalaxyInstance();
         return {
             items: [],
+            breadcrumbItems: [{ title: "User Preferences", to: "/user" }, { title: "Manage External Identities" }],
             showHelp: true,
             loading: false,
             doomedItem: null,

--- a/client/src/components/User/UserInformation.test.ts
+++ b/client/src/components/User/UserInformation.test.ts
@@ -1,0 +1,162 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed } from "vue";
+import VueRouter from "vue-router";
+
+import { useServerMock } from "@/api/client/__mocks__";
+import { useConfig } from "@/composables/config";
+import { useUserStore } from "@/stores/userStore";
+
+import UserInformation from "./UserInformation.vue";
+
+vi.mock("@/composables/config", () => ({
+    useConfig: vi.fn(),
+}));
+
+const localVue = getLocalVue();
+localVue.use(VueRouter);
+
+const { server, http } = useServerMock();
+
+const CURRENT_USER = {
+    id: "user-id",
+    email: "ada@example.org",
+    username: "ada-lovelace",
+    display_name: "Ada Lovelace",
+    model_class: "User",
+    preferences: {},
+    total_disk_usage: 0,
+    nice_total_disk_usage: "0 bytes",
+    quota_percent: 0,
+    deleted: false,
+    purged: false,
+    is_admin: false,
+    quota: "unlimited",
+};
+
+const EDITABLE_CONFIG = {
+    enable_account_interface: true,
+    use_remote_user: false,
+    disable_local_accounts: false,
+    user_activation_on: false,
+    enable_oidc: false,
+    fixed_delegated_auth: false,
+};
+
+const STUBS = {
+    BreadcrumbHeading: true,
+    FontAwesomeIcon: true,
+    GLink: true,
+    Heading: true,
+    LoadingSpan: true,
+};
+
+async function mountComponent(configOverrides = {}) {
+    vi.mocked(useConfig).mockReturnValue({
+        config: computed(() => ({ ...EDITABLE_CONFIG, ...configOverrides })),
+        isConfigLoaded: computed(() => true),
+    } as never);
+
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+    const wrapper = mount(UserInformation as object, {
+        localVue,
+        router: new VueRouter(),
+        pinia,
+        stubs: STUBS,
+    });
+
+    const userStore = useUserStore();
+    userStore.currentUser = { ...CURRENT_USER } as never;
+    await flushPromises();
+
+    return wrapper;
+}
+
+function inputValue(wrapper: ReturnType<typeof mount>, selector: string) {
+    return (wrapper.find(selector).element as HTMLInputElement).value;
+}
+
+describe("UserInformation.vue", () => {
+    beforeEach(() => {
+        // The component refreshes the store after a successful save. The PUT
+        // handler is registered per test, so that the failure case is not racing
+        // a success handler registered here.
+        server.use(
+            http.get("/api/users/{user_id}", ({ response }) => {
+                return response(200).json(CURRENT_USER as never);
+            }),
+            http.get("/api/configuration", ({ response }) => {
+                return response(200).json({} as never);
+            }),
+        );
+    });
+
+    it("renders the current values", async () => {
+        const wrapper = await mountComponent();
+
+        expect(inputValue(wrapper, "#email")).toBe("ada@example.org");
+        expect(inputValue(wrapper, "#username")).toBe("ada-lovelace");
+        expect(inputValue(wrapper, "#display_name")).toBe("Ada Lovelace");
+    });
+
+    it("submits only the fields that changed", async () => {
+        let received: Record<string, unknown> | undefined;
+        server.use(
+            http.put("/api/users/{user_id}", async ({ request, response }) => {
+                received = (await request.json()) as Record<string, unknown>;
+                return response(200).json(CURRENT_USER as never);
+            }),
+        );
+
+        const wrapper = await mountComponent();
+
+        await wrapper.find("#display_name").setValue("Ada L");
+        await wrapper.find("form").trigger("submit");
+        await flushPromises();
+
+        // Resending an unchanged email would deactivate the account for no reason.
+        expect(received).toEqual({ display_name: "Ada L" });
+    });
+
+    it("keeps save disabled until something changes", async () => {
+        server.use(http.put("/api/users/{user_id}", ({ response }) => response(200).json(CURRENT_USER as never)));
+        const wrapper = await mountComponent();
+
+        // GButton reflects its disabled state as aria-disabled, which Vue drops
+        // from the DOM entirely once it is false.
+        expect(wrapper.find("#submit").attributes("aria-disabled")).toBe("true");
+
+        await wrapper.find("#display_name").setValue("Ada L");
+        await flushPromises();
+
+        expect(wrapper.find("#submit").attributes("aria-disabled")).toBeUndefined();
+    });
+
+    it("warns that changing the username breaks shared links", async () => {
+        const wrapper = await mountComponent();
+
+        expect(wrapper.text()).not.toContain("breaks links you have already shared");
+
+        await wrapper.find("#username").setValue("ada");
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("breaks links you have already shared");
+    });
+
+    it("is read only when accounts are managed outside Galaxy", async () => {
+        const wrapper = await mountComponent({ use_remote_user: true });
+
+        expect(wrapper.find("#email").attributes("disabled")).toBeTruthy();
+        expect(wrapper.find("#username").attributes("disabled")).toBeTruthy();
+        expect(wrapper.find("#submit").exists()).toBe(false);
+    });
+
+    // NOTE: inline surfacing of a server error is deliberately not covered here.
+    // The mocked 400 reaches the request handler but the error never propagates
+    // back to the component when it is mounted, while the identical call
+    // succeeds outside a component. It is covered by the manual test plan
+    // instead of leaving a test here that passes for the wrong reason.
+});

--- a/client/src/components/User/UserInformation.test.ts
+++ b/client/src/components/User/UserInformation.test.ts
@@ -49,7 +49,6 @@ const EDITABLE_CONFIG = {
 const STUBS = {
     BreadcrumbHeading: true,
     FontAwesomeIcon: true,
-    GLink: true,
     Heading: true,
     LoadingSpan: true,
 };

--- a/client/src/components/User/UserInformation.vue
+++ b/client/src/components/User/UserInformation.vue
@@ -131,162 +131,121 @@ watch(currentUser, resetFromUser, { immediate: true });
                 </span>
             </GAlert>
 
-            <section class="user-information-section">
-                <div class="user-information-intro">
+            <section class="mb-4">
+                <div class="mb-3">
                     <Heading v-localize h2 size="sm">Identity</Heading>
 
-                    <p v-localize class="text-muted">How you are named across Galaxy and in what you share.</p>
+                    <p v-localize class="mb-0 text-muted">How you are named across Galaxy and in what you share.</p>
                 </div>
 
-                <div class="user-information-fields">
-                    <div class="user-information-field">
-                        <GFormLabel :title="localize('Display name')">
-                            <GFormInput
-                                id="display_name"
-                                v-model="displayName"
-                                class="w-100"
-                                :disabled="!canEdit"
-                                :placeholder="username" />
-                        </GFormLabel>
+                <div class="mb-3">
+                    <GFormLabel :title="localize('Display name')">
+                        <GFormInput
+                            id="display_name"
+                            v-model="displayName"
+                            class="w-100"
+                            :disabled="!canEdit"
+                            :placeholder="username" />
+                    </GFormLabel>
 
-                        <small v-localize class="form-text text-muted">
-                            Shown in place of your username across Galaxy. Leave it blank to use your username.
-                        </small>
-                    </div>
+                    <small v-localize class="form-text text-muted">
+                        Shown in place of your username across Galaxy. Leave it blank to use your username.
+                    </small>
                 </div>
             </section>
 
-            <section class="user-information-section">
-                <div class="user-information-intro">
+            <section class="mb-4">
+                <div class="mb-3">
                     <Heading v-localize h2 size="sm">Sign-in</Heading>
 
-                    <p v-localize class="text-muted">How you get into your account, and how you get back in.</p>
+                    <p v-localize class="mb-0 text-muted">How you get into your account, and how you get back in.</p>
                 </div>
 
-                <div class="user-information-fields">
-                    <div class="user-information-field">
-                        <GFormLabel :title="localize('Username')">
-                            <GFormInput id="username" v-model="username" class="w-100" :disabled="!canEdit" />
-                        </GFormLabel>
+                <div class="mb-3">
+                    <GFormLabel :title="localize('Username')">
+                        <GFormInput id="username" v-model="username" class="w-100" :disabled="!canEdit" />
+                    </GFormLabel>
 
-                        <small class="form-text text-muted">
-                            <span v-localize>
-                                Signs you in, and appears in the links you share. Lower-case letters, numbers, '.', '_'
-                                and '-' only.
-                            </span>
+                    <small class="form-text text-muted">
+                        <span v-localize>
+                            Signs you in, and appears in the links you share. Lower-case letters, numbers, '.', '_' and
+                            '-' only.
+                        </span>
 
-                            <br />
+                        <br />
 
-                            <span class="user-information-example">{{ profilePath }}/w/my-workflow</span>
-                        </small>
+                        <span class="text-monospace">{{ profilePath }}/w/my-workflow</span>
+                    </small>
 
-                        <GAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
-                            <span v-localize>
-                                Changing your username breaks links you have already shared - the old addresses stop
-                                resolving.
-                            </span>
-                        </GAlert>
-                    </div>
+                    <GAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
+                        <span v-localize>
+                            Changing your username breaks links you have already shared - the old addresses stop
+                            resolving.
+                        </span>
+                    </GAlert>
+                </div>
 
-                    <div class="user-information-field">
-                        <GFormLabel :title="localize('Email address')">
-                            <GFormInput id="email" v-model="email" class="w-100" type="email" :disabled="!canEdit" />
-                        </GFormLabel>
+                <div class="mb-3">
+                    <GFormLabel :title="localize('Email address')">
+                        <GFormInput id="email" v-model="email" class="w-100" type="email" :disabled="!canEdit" />
+                    </GFormLabel>
 
-                        <small v-localize class="form-text text-muted">
-                            Used to sign in and to recover your account.
-                        </small>
+                    <small v-localize class="form-text text-muted">
+                        Used to sign in and to recover your account.
+                    </small>
 
-                        <GAlert
-                            v-if="config.user_activation_on && email !== currentUser.email"
-                            show
-                            variant="warning"
-                            class="mt-2">
-                            <span v-localize>
-                                Changing your email address deactivates your account until you follow the activation
-                                link sent to the new address.
-                            </span>
-                        </GAlert>
-                    </div>
+                    <GAlert
+                        v-if="config.user_activation_on && email !== currentUser.email"
+                        show
+                        variant="warning"
+                        class="mt-2">
+                        <span v-localize>
+                            Changing your email address deactivates your account until you follow the activation link
+                            sent to the new address.
+                        </span>
+                    </GAlert>
+                </div>
 
-                    <div class="d-flex flex-gapx-1">
-                        <GButton
-                            v-if="canEdit"
-                            outline
-                            tooltip
-                            title="Change your password"
-                            color="blue"
-                            to="/user/password">
-                            <FontAwesomeIcon :icon="faUnlockAlt" />
-                            <span v-localize>Change password</span>
-                        </GButton>
+                <div class="d-flex flex-wrap flex-gapx-1">
+                    <GButton
+                        v-if="canEdit"
+                        outline
+                        tooltip
+                        title="Change your password"
+                        color="blue"
+                        to="/user/password">
+                        <FontAwesomeIcon :icon="faUnlockAlt" />
+                        <span v-localize>Change password</span>
+                    </GButton>
 
-                        <GButton
-                            v-if="showIdentities"
-                            outline
-                            tooltip
-                            title="Manage your third-party identities"
-                            color="blue"
-                            to="/user/external_ids">
-                            <FontAwesomeIcon :icon="faIdCard" />
-                            <span v-localize>Manage third-party identities</span>
-                        </GButton>
-                    </div>
+                    <GButton
+                        v-if="showIdentities"
+                        outline
+                        tooltip
+                        title="Manage your third-party identities"
+                        color="blue"
+                        to="/user/external_ids">
+                        <FontAwesomeIcon :icon="faIdCard" />
+                        <span v-localize>Manage third-party identities</span>
+                    </GButton>
                 </div>
             </section>
 
-            <div v-if="canEdit" class="user-information-section">
-                <div class="user-information-actions">
-                    <GButton id="cancel" :disabled="!dirty || saving" @click="resetFromUser">
-                        <span v-localize>Cancel</span>
-                    </GButton>
+            <div v-if="canEdit" class="d-flex flex-wrap flex-gapx-1">
+                <GButton id="cancel" :disabled="!dirty || saving" @click="resetFromUser">
+                    <span v-localize>Cancel</span>
+                </GButton>
 
-                    <GButton id="submit" color="blue" type="submit" :disabled="!dirty || saving">
-                        <span v-localize>Save</span>
-                    </GButton>
-                </div>
+                <GButton id="submit" color="blue" type="submit" :disabled="!dirty || saving">
+                    <span v-localize>Save</span>
+                </GButton>
             </div>
         </form>
     </div>
 </template>
 
 <style scoped lang="scss">
-@import "@/style/scss/_breakpoints.scss";
-
 .user-information {
-    container-type: inline-size;
-    container-name: user-information;
     max-width: 62rem;
-
-    .user-information-section {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        margin-bottom: 1rem;
-
-        @container user-information (max-width: #{$breakpoint-md}) {
-            gap: 0.5rem;
-        }
-
-        .user-information-intro p {
-            margin-bottom: 0;
-        }
-
-        .user-information-fields {
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-        }
-
-        .user-information-actions {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .user-information-example {
-            font-family: monospace;
-        }
-    }
 }
 </style>

--- a/client/src/components/User/UserInformation.vue
+++ b/client/src/components/User/UserInformation.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BFormGroup, BFormInput } from "bootstrap-vue";
+import { BFormGroup, BFormInput } from "bootstrap-vue";
 import { faIdCard, faUnlockAlt } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
@@ -12,6 +12,7 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import Heading from "@/components/Common/Heading.vue";
@@ -114,20 +115,20 @@ watch(currentUser, resetFromUser, { immediate: true });
     <div>
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <BAlert v-if="!isRegisteredUser(currentUser)" show>
+        <GAlert v-if="!isRegisteredUser(currentUser)" show>
             <LoadingSpan message="Loading your account" />
-        </BAlert>
+        </GAlert>
 
         <form v-else class="user-information" @submit.prevent="onSubmit">
-            <BAlert v-if="errorMessage" show variant="danger">
+            <GAlert v-if="errorMessage" show variant="danger">
                 {{ errorMessage }}
-            </BAlert>
+            </GAlert>
 
-            <BAlert v-if="!canEdit" show variant="info">
+            <GAlert v-if="!canEdit" show variant="info">
                 <span v-localize>
                     Your account details are managed outside Galaxy on this instance, so they cannot be edited here.
                 </span>
-            </BAlert>
+            </GAlert>
 
             <section class="user-information-section">
                 <div class="user-information-intro">
@@ -173,12 +174,12 @@ watch(currentUser, resetFromUser, { immediate: true });
                             <span class="user-information-example">{{ profilePath }}/w/my-workflow</span>
                         </small>
 
-                        <BAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
+                        <GAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
                             <span v-localize>
                                 Changing your username breaks links you have already shared - the old addresses stop
                                 resolving.
                             </span>
-                        </BAlert>
+                        </GAlert>
                     </BFormGroup>
 
                     <BFormGroup label-for="email" :label="localize('Email address')">
@@ -188,7 +189,7 @@ watch(currentUser, resetFromUser, { immediate: true });
                             Used to sign in and to recover your account.
                         </small>
 
-                        <BAlert
+                        <GAlert
                             v-if="config.user_activation_on && email !== currentUser.email"
                             show
                             variant="warning"
@@ -197,7 +198,7 @@ watch(currentUser, resetFromUser, { immediate: true });
                                 Changing your email address deactivates your account until you follow the activation
                                 link sent to the new address.
                             </span>
-                        </BAlert>
+                        </GAlert>
                     </BFormGroup>
 
                     <div class="d-flex flex-gapx-1">

--- a/client/src/components/User/UserInformation.vue
+++ b/client/src/components/User/UserInformation.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BFormGroup, BFormInput } from "bootstrap-vue";
 import { faIdCard, faUnlockAlt } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
@@ -12,6 +11,8 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
+import GFormInput from "@/components/BaseComponents/Form/GFormInput.vue";
+import GFormLabel from "@/components/BaseComponents/Form/GFormLabel.vue";
 import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
@@ -138,17 +139,20 @@ watch(currentUser, resetFromUser, { immediate: true });
                 </div>
 
                 <div class="user-information-fields">
-                    <BFormGroup label-for="display_name" :label="localize('Display name')">
-                        <BFormInput
-                            id="display_name"
-                            v-model="displayName"
-                            :disabled="!canEdit"
-                            :placeholder="username" />
+                    <div class="user-information-field">
+                        <GFormLabel :title="localize('Display name')">
+                            <GFormInput
+                                id="display_name"
+                                v-model="displayName"
+                                class="w-100"
+                                :disabled="!canEdit"
+                                :placeholder="username" />
+                        </GFormLabel>
 
                         <small v-localize class="form-text text-muted">
                             Shown in place of your username across Galaxy. Leave it blank to use your username.
                         </small>
-                    </BFormGroup>
+                    </div>
                 </div>
             </section>
 
@@ -160,8 +164,10 @@ watch(currentUser, resetFromUser, { immediate: true });
                 </div>
 
                 <div class="user-information-fields">
-                    <BFormGroup label-for="username" :label="localize('Username')">
-                        <BFormInput id="username" v-model="username" :disabled="!canEdit" />
+                    <div class="user-information-field">
+                        <GFormLabel :title="localize('Username')">
+                            <GFormInput id="username" v-model="username" class="w-100" :disabled="!canEdit" />
+                        </GFormLabel>
 
                         <small class="form-text text-muted">
                             <span v-localize>
@@ -180,10 +186,12 @@ watch(currentUser, resetFromUser, { immediate: true });
                                 resolving.
                             </span>
                         </GAlert>
-                    </BFormGroup>
+                    </div>
 
-                    <BFormGroup label-for="email" :label="localize('Email address')">
-                        <BFormInput id="email" v-model="email" type="email" :disabled="!canEdit" />
+                    <div class="user-information-field">
+                        <GFormLabel :title="localize('Email address')">
+                            <GFormInput id="email" v-model="email" class="w-100" type="email" :disabled="!canEdit" />
+                        </GFormLabel>
 
                         <small v-localize class="form-text text-muted">
                             Used to sign in and to recover your account.
@@ -199,7 +207,7 @@ watch(currentUser, resetFromUser, { immediate: true });
                                 link sent to the new address.
                             </span>
                         </GAlert>
-                    </BFormGroup>
+                    </div>
 
                     <div class="d-flex flex-gapx-1">
                         <GButton
@@ -262,6 +270,12 @@ watch(currentUser, resetFromUser, { immediate: true });
 
         .user-information-intro p {
             margin-bottom: 0;
+        }
+
+        .user-information-fields {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
         }
 
         .user-information-actions {

--- a/client/src/components/User/UserInformation.vue
+++ b/client/src/components/User/UserInformation.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BFormGroup, BFormInput } from "bootstrap-vue";
+import { faIdCard, faUnlockAlt } from "font-awesome-6";
+import { storeToRefs } from "pinia";
+import { computed, ref, watch } from "vue";
+
+import { GalaxyApi, isRegisteredUser } from "@/api";
+import { useConfig } from "@/composables/config";
+import { useToast } from "@/composables/toast";
+import { useUserStore } from "@/stores/userStore";
+import localize from "@/utils/localization";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import Heading from "@/components/Common/Heading.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+const breadcrumbItems = [{ title: "User Preferences", to: "/user" }, { title: "Account" }];
+
+const { config, isConfigLoaded } = useConfig(true);
+const userStore = useUserStore();
+const { currentUser } = storeToRefs(userStore);
+const Toast = useToast();
+
+const email = ref("");
+const username = ref("");
+const displayName = ref("");
+const saving = ref(false);
+const errorMessage = ref("");
+
+/**
+ * Mirrors the server's own `allow_profile_edit`: instances that delegate
+ * accounts elsewhere must not offer fields the backend will refuse to save.
+ */
+const canEdit = computed(
+    () =>
+        isConfigLoaded.value &&
+        Boolean(config.value.enable_account_interface) &&
+        !config.value.use_remote_user &&
+        !config.value.disable_local_accounts,
+);
+
+const showIdentities = computed(
+    () => isConfigLoaded.value && Boolean(config.value.enable_oidc) && !config.value.fixed_delegated_auth,
+);
+
+const profilePath = computed(() => (username.value ? `/u/${username.value}` : "/u/your-username"));
+
+const dirty = computed(
+    () =>
+        isRegisteredUser(currentUser.value) &&
+        (email.value !== currentUser.value.email ||
+            username.value !== (currentUser.value.username ?? "") ||
+            displayName.value !== (currentUser.value.display_name ?? "")),
+);
+
+function resetFromUser() {
+    if (isRegisteredUser(currentUser.value)) {
+        email.value = currentUser.value.email;
+        username.value = currentUser.value.username ?? "";
+        displayName.value = currentUser.value.display_name ?? "";
+    }
+}
+
+async function onSubmit() {
+    if (!isRegisteredUser(currentUser.value) || saving.value) {
+        return;
+    }
+
+    saving.value = true;
+    errorMessage.value = "";
+
+    // Only changed fields are sent: the server treats an email change as a
+    // re-verification, so resending the current address would deactivate the
+    // account for no reason.
+    const body: Record<string, string> = {};
+    if (email.value !== currentUser.value.email) {
+        body.email = email.value;
+    }
+    if (username.value !== (currentUser.value.username ?? "")) {
+        body.username = username.value;
+    }
+    if (displayName.value !== (currentUser.value.display_name ?? "")) {
+        body.display_name = displayName.value;
+    }
+
+    try {
+        const { error } = await GalaxyApi().PUT("/api/users/{user_id}", {
+            params: { path: { user_id: currentUser.value.id } },
+            body,
+        });
+
+        if (error) {
+            errorMessage.value = errorMessageAsString(error);
+            return;
+        }
+
+        await userStore.refreshUser();
+        resetFromUser();
+        Toast.success(localize("Your account details have been saved."));
+    } catch (error) {
+        errorMessage.value = errorMessageAsString(error);
+    } finally {
+        saving.value = false;
+    }
+}
+
+watch(currentUser, resetFromUser, { immediate: true });
+</script>
+
+<template>
+    <div>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
+        <BAlert v-if="!isRegisteredUser(currentUser)" show>
+            <LoadingSpan message="Loading your account" />
+        </BAlert>
+
+        <form v-else @submit.prevent="onSubmit">
+            <BAlert v-if="errorMessage" show variant="danger">
+                {{ errorMessage }}
+            </BAlert>
+
+            <BAlert v-if="!canEdit" show variant="info">
+                <span v-localize>
+                    Your account details are managed outside Galaxy on this instance, so they cannot be edited here.
+                </span>
+            </BAlert>
+
+            <section class="user-information-section">
+                <Heading v-localize h2 size="sm">Identity</Heading>
+
+                <BFormGroup label-for="display_name" :label="localize('Display name')">
+                    <BFormInput id="display_name" v-model="displayName" :disabled="!canEdit" :placeholder="username" />
+
+                    <small v-localize class="form-text text-muted">
+                        Shown in place of your username across Galaxy. Leave it blank to use your username.
+                    </small>
+                </BFormGroup>
+
+                <BFormGroup label-for="username" :label="localize('Username')">
+                    <BFormInput id="username" v-model="username" :disabled="!canEdit" />
+
+                    <small class="form-text text-muted">
+                        <span v-localize>
+                            Signs you in, and appears in the links you share. Lower-case letters, numbers, '.', '_' and
+                            '-' only.
+                        </span>
+
+                        <br />
+
+                        <span class="user-information-example">{{ profilePath }}/w/my-workflow</span>
+                    </small>
+
+                    <BAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
+                        <span v-localize>
+                            Changing your username breaks links you have already shared - the old addresses stop
+                            resolving.
+                        </span>
+                    </BAlert>
+                </BFormGroup>
+            </section>
+
+            <section class="user-information-section">
+                <Heading v-localize h2 size="sm">Sign-in</Heading>
+
+                <BFormGroup label-for="email" :label="localize('Email address')">
+                    <BFormInput id="email" v-model="email" type="email" :disabled="!canEdit" />
+
+                    <small v-localize class="form-text text-muted">
+                        Used to sign in and to recover your account.
+                    </small>
+
+                    <BAlert
+                        v-if="config.user_activation_on && email !== currentUser.email"
+                        show
+                        variant="warning"
+                        class="mt-2">
+                        <span v-localize>
+                            Changing your email address deactivates your account until you follow the activation link
+                            sent to the new address.
+                        </span>
+                    </BAlert>
+                </BFormGroup>
+
+                <div v-if="canEdit" class="user-information-link">
+                    <GLink to="/user/password">
+                        <FontAwesomeIcon :icon="faUnlockAlt" />
+                        <span v-localize>Change password</span>
+                    </GLink>
+                </div>
+
+                <div v-if="showIdentities" class="user-information-link">
+                    <GLink to="/user/external_ids">
+                        <FontAwesomeIcon :icon="faIdCard" />
+                        <span v-localize>Manage third-party identities</span>
+                    </GLink>
+                </div>
+            </section>
+
+            <div v-if="canEdit" class="d-flex gap-1">
+                <GButton id="submit" color="blue" type="submit" :disabled="!dirty || saving">
+                    <span v-localize>Save</span>
+                </GButton>
+
+                <GButton id="cancel" :disabled="!dirty || saving" @click="resetFromUser">
+                    <span v-localize>Cancel</span>
+                </GButton>
+            </div>
+        </form>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.user-information-section {
+    margin-bottom: 1.5rem;
+    max-width: 40rem;
+}
+
+.user-information-example {
+    font-family: monospace;
+}
+
+.user-information-link {
+    margin-bottom: 0.5rem;
+}
+</style>

--- a/client/src/components/User/UserInformation.vue
+++ b/client/src/components/User/UserInformation.vue
@@ -13,7 +13,6 @@ import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
-import GLink from "@/components/BaseComponents/GLink.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -119,7 +118,7 @@ watch(currentUser, resetFromUser, { immediate: true });
             <LoadingSpan message="Loading your account" />
         </BAlert>
 
-        <form v-else @submit.prevent="onSubmit">
+        <form v-else class="user-information" @submit.prevent="onSubmit">
             <BAlert v-if="errorMessage" show variant="danger">
                 {{ errorMessage }}
             </BAlert>
@@ -131,100 +130,148 @@ watch(currentUser, resetFromUser, { immediate: true });
             </BAlert>
 
             <section class="user-information-section">
-                <Heading v-localize h2 size="sm">Identity</Heading>
+                <div class="user-information-intro">
+                    <Heading v-localize h2 size="sm">Identity</Heading>
 
-                <BFormGroup label-for="display_name" :label="localize('Display name')">
-                    <BFormInput id="display_name" v-model="displayName" :disabled="!canEdit" :placeholder="username" />
+                    <p v-localize class="text-muted">How you are named across Galaxy and in what you share.</p>
+                </div>
 
-                    <small v-localize class="form-text text-muted">
-                        Shown in place of your username across Galaxy. Leave it blank to use your username.
-                    </small>
-                </BFormGroup>
+                <div class="user-information-fields">
+                    <BFormGroup label-for="display_name" :label="localize('Display name')">
+                        <BFormInput
+                            id="display_name"
+                            v-model="displayName"
+                            :disabled="!canEdit"
+                            :placeholder="username" />
 
-                <BFormGroup label-for="username" :label="localize('Username')">
-                    <BFormInput id="username" v-model="username" :disabled="!canEdit" />
-
-                    <small class="form-text text-muted">
-                        <span v-localize>
-                            Signs you in, and appears in the links you share. Lower-case letters, numbers, '.', '_' and
-                            '-' only.
-                        </span>
-
-                        <br />
-
-                        <span class="user-information-example">{{ profilePath }}/w/my-workflow</span>
-                    </small>
-
-                    <BAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
-                        <span v-localize>
-                            Changing your username breaks links you have already shared - the old addresses stop
-                            resolving.
-                        </span>
-                    </BAlert>
-                </BFormGroup>
+                        <small v-localize class="form-text text-muted">
+                            Shown in place of your username across Galaxy. Leave it blank to use your username.
+                        </small>
+                    </BFormGroup>
+                </div>
             </section>
 
             <section class="user-information-section">
-                <Heading v-localize h2 size="sm">Sign-in</Heading>
+                <div class="user-information-intro">
+                    <Heading v-localize h2 size="sm">Sign-in</Heading>
 
-                <BFormGroup label-for="email" :label="localize('Email address')">
-                    <BFormInput id="email" v-model="email" type="email" :disabled="!canEdit" />
-
-                    <small v-localize class="form-text text-muted">
-                        Used to sign in and to recover your account.
-                    </small>
-
-                    <BAlert
-                        v-if="config.user_activation_on && email !== currentUser.email"
-                        show
-                        variant="warning"
-                        class="mt-2">
-                        <span v-localize>
-                            Changing your email address deactivates your account until you follow the activation link
-                            sent to the new address.
-                        </span>
-                    </BAlert>
-                </BFormGroup>
-
-                <div v-if="canEdit" class="user-information-link">
-                    <GLink to="/user/password">
-                        <FontAwesomeIcon :icon="faUnlockAlt" />
-                        <span v-localize>Change password</span>
-                    </GLink>
+                    <p v-localize class="text-muted">How you get into your account, and how you get back in.</p>
                 </div>
 
-                <div v-if="showIdentities" class="user-information-link">
-                    <GLink to="/user/external_ids">
-                        <FontAwesomeIcon :icon="faIdCard" />
-                        <span v-localize>Manage third-party identities</span>
-                    </GLink>
+                <div class="user-information-fields">
+                    <BFormGroup label-for="username" :label="localize('Username')">
+                        <BFormInput id="username" v-model="username" :disabled="!canEdit" />
+
+                        <small class="form-text text-muted">
+                            <span v-localize>
+                                Signs you in, and appears in the links you share. Lower-case letters, numbers, '.', '_'
+                                and '-' only.
+                            </span>
+
+                            <br />
+
+                            <span class="user-information-example">{{ profilePath }}/w/my-workflow</span>
+                        </small>
+
+                        <BAlert v-if="username !== (currentUser.username ?? '')" show variant="warning" class="mt-2">
+                            <span v-localize>
+                                Changing your username breaks links you have already shared - the old addresses stop
+                                resolving.
+                            </span>
+                        </BAlert>
+                    </BFormGroup>
+
+                    <BFormGroup label-for="email" :label="localize('Email address')">
+                        <BFormInput id="email" v-model="email" type="email" :disabled="!canEdit" />
+
+                        <small v-localize class="form-text text-muted">
+                            Used to sign in and to recover your account.
+                        </small>
+
+                        <BAlert
+                            v-if="config.user_activation_on && email !== currentUser.email"
+                            show
+                            variant="warning"
+                            class="mt-2">
+                            <span v-localize>
+                                Changing your email address deactivates your account until you follow the activation
+                                link sent to the new address.
+                            </span>
+                        </BAlert>
+                    </BFormGroup>
+
+                    <div class="d-flex flex-gapx-1">
+                        <GButton
+                            v-if="canEdit"
+                            outline
+                            tooltip
+                            title="Change your password"
+                            color="blue"
+                            to="/user/password">
+                            <FontAwesomeIcon :icon="faUnlockAlt" />
+                            <span v-localize>Change password</span>
+                        </GButton>
+
+                        <GButton
+                            v-if="showIdentities"
+                            outline
+                            tooltip
+                            title="Manage your third-party identities"
+                            color="blue"
+                            to="/user/external_ids">
+                            <FontAwesomeIcon :icon="faIdCard" />
+                            <span v-localize>Manage third-party identities</span>
+                        </GButton>
+                    </div>
                 </div>
             </section>
 
-            <div v-if="canEdit" class="d-flex gap-1">
-                <GButton id="submit" color="blue" type="submit" :disabled="!dirty || saving">
-                    <span v-localize>Save</span>
-                </GButton>
+            <div v-if="canEdit" class="user-information-section">
+                <div class="user-information-actions">
+                    <GButton id="cancel" :disabled="!dirty || saving" @click="resetFromUser">
+                        <span v-localize>Cancel</span>
+                    </GButton>
 
-                <GButton id="cancel" :disabled="!dirty || saving" @click="resetFromUser">
-                    <span v-localize>Cancel</span>
-                </GButton>
+                    <GButton id="submit" color="blue" type="submit" :disabled="!dirty || saving">
+                        <span v-localize>Save</span>
+                    </GButton>
+                </div>
             </div>
         </form>
     </div>
 </template>
 
 <style scoped lang="scss">
-.user-information-section {
-    margin-bottom: 1.5rem;
-    max-width: 40rem;
-}
+@import "@/style/scss/_breakpoints.scss";
 
-.user-information-example {
-    font-family: monospace;
-}
+.user-information {
+    container-type: inline-size;
+    container-name: user-information;
+    max-width: 62rem;
 
-.user-information-link {
-    margin-bottom: 0.5rem;
+    .user-information-section {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        margin-bottom: 1rem;
+
+        @container user-information (max-width: #{$breakpoint-md}) {
+            gap: 0.5rem;
+        }
+
+        .user-information-intro p {
+            margin-bottom: 0;
+        }
+
+        .user-information-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .user-information-example {
+            font-family: monospace;
+        }
+    }
 }
 </style>

--- a/client/src/components/User/UserPreferences.test.ts
+++ b/client/src/components/User/UserPreferences.test.ts
@@ -39,6 +39,18 @@ vi.mock("@/composables/confirmDialog", () => ({
 const localVue = getLocalVue();
 localVue.use(VueRouter);
 
+const STUBS = {
+    BreadcrumbHeading: true,
+    UserDetailsElement: true,
+    UserPreferencesElement: true,
+    Heading: true,
+    BAlert: true,
+    UserPickTheme: true,
+    UserBeaconSettings: true,
+    UserPreferredObjectStore: true,
+    UserDeletion: true,
+};
+
 describe("UserPreferences.vue", () => {
     const mockPreferences = (passwordDisabled: boolean) => {
         // @ts-expect-error - getUserPreferencesModel is mocked
@@ -77,17 +89,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#oidc-profile").exists()).toBe(true);
@@ -110,17 +112,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#oidc-profile").exists()).toBe(false);
@@ -148,20 +140,49 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#edit-preferences-password").exists()).toBe(false);
+    });
+
+    it("always offers the account page", async () => {
+        vi.mocked(useConfig).mockReturnValue({
+            config: computed(() => ({ oidc: {}, themes: {} })),
+            isConfigLoaded: computed(() => true),
+        });
+
+        const wrapper = shallowMount(UserPreferences, {
+            localVue,
+            router: new VueRouter(),
+            pinia: createTestingPinia({ createSpy: vi.fn }),
+            stubs: STUBS,
+        });
+
+        expect(wrapper.find("#edit-preferences-information").exists()).toBe(true);
+    });
+
+    it.each([
+        [true, true],
+        [false, false],
+    ])("shows the extra configurations entry when configured: %s", async (configured, expected) => {
+        vi.mocked(useConfig).mockReturnValue({
+            config: computed(() => ({
+                oidc: {},
+                themes: {},
+                has_user_preferences_extra: configured,
+            })),
+            isConfigLoaded: computed(() => true),
+        });
+
+        const wrapper = shallowMount(UserPreferences, {
+            localVue,
+            router: new VueRouter(),
+            pinia: createTestingPinia({ createSpy: vi.fn }),
+            stubs: STUBS,
+        });
+
+        expect(wrapper.find("#edit-preferences-extra").exists()).toBe(expected);
     });
 
     it("shows password preference when allowed", async () => {
@@ -179,17 +200,7 @@ describe("UserPreferences.vue", () => {
             localVue,
             router: new VueRouter(),
             pinia: createTestingPinia({ createSpy: vi.fn }),
-            stubs: {
-                BreadcrumbHeading: true,
-                UserDetailsElement: true,
-                UserPreferencesElement: true,
-                Heading: true,
-                BAlert: true,
-                UserPickTheme: true,
-                UserBeaconSettings: true,
-                UserPreferredObjectStore: true,
-                UserDeletion: true,
-            },
+            stubs: STUBS,
         });
 
         expect(wrapper.find("#edit-preferences-password").exists()).toBe(true);

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -15,6 +15,7 @@ import {
     faPerson,
     faRadiation,
     faSignOut,
+    faUser,
     faUsers,
 } from "font-awesome-6";
 import { computed, onMounted, ref } from "vue";
@@ -188,6 +189,13 @@ onMounted(async () => {
                     :icon="faPerson"
                     description="Manage my profile information (username, email, password)."
                     to="/user/oidc-profile" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-information"
+                    :icon="faUser"
+                    :title="localize('Account')"
+                    :description="localize('Edit your email address, username and display name.')"
+                    to="/user/information" />
 
                 <UserPreferencesElement
                     v-for="(link, index) in activePreferences"

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -15,6 +15,7 @@ import {
     faPerson,
     faRadiation,
     faSignOut,
+    faSliders,
     faUser,
     faUsers,
 } from "font-awesome-6";
@@ -64,11 +65,20 @@ const showDeleteAccountModal = ref(false);
 const showDataPrivateModal = ref(false);
 const showThemPickerModal = ref(false);
 
+// The remaining generic-form preferences are placed by hand rather than looped
+// over, because they belong in different groups: the password sits with account
+// and sign-in, toolbox filters with data and tools.
 const activePreferences = computed(() => {
     const userPreferencesEntries = getUserPreferencesModel();
     const enabledPreferences = Object.entries(userPreferencesEntries).filter(([, value]) => !value.disabled);
     return Object.fromEntries(enabledPreferences);
 });
+
+const passwordPreference = computed(() => activePreferences.value.password);
+
+const toolboxFiltersPreference = computed(() => activePreferences.value.toolbox_filters);
+
+const hasExtraPreferences = computed(() => isConfigLoaded.value && Boolean(config.value.has_user_preferences_extra));
 // Show the OIDC profile management widget if local account editing is disabled and OIDC profile is configured
 // through a single provider
 const showOidcProfile = computed<boolean>(() => {
@@ -181,6 +191,8 @@ onMounted(async () => {
         <UserDetailsElement />
 
         <div class="d-flex flex-gapy-1 flex-column">
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Account and sign-in</Heading>
+
             <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="showOidcProfile"
@@ -198,14 +210,32 @@ onMounted(async () => {
                     to="/user/information" />
 
                 <UserPreferencesElement
-                    v-for="(link, index) in activePreferences"
-                    :id="link.id"
-                    :key="index"
-                    :icon="link.icon"
-                    :title="link.title"
-                    :description="link.description"
-                    :to="`/user/${index}`" />
+                    v-if="passwordPreference"
+                    :id="passwordPreference.id"
+                    :icon="passwordPreference.icon"
+                    :title="passwordPreference.title"
+                    :description="passwordPreference.description"
+                    to="/user/password" />
 
+                <UserPreferencesElement
+                    v-if="isConfigLoaded && config.enable_oidc && !config.fixed_delegated_auth"
+                    id="manage-third-party-identities"
+                    :icon="faIdCard"
+                    :title="localize('Manage Third-Party Identities')"
+                    :description="localize('Connect or disconnect access to your third-party identities.')"
+                    to="/user/external_ids" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-api-key"
+                    :icon="faKey"
+                    :title="localize('Manage Galaxy API Key')"
+                    :description="localize('Access your current Galaxy API key or create a new one.')"
+                    to="/user/api_key" />
+            </div>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Sharing and privacy</Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="isConfigLoaded && !config.single_user"
                     id="edit-preferences-permissions"
@@ -217,50 +247,6 @@ onMounted(async () => {
                         )
                     "
                     to="/user/permissions" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-api-key"
-                    :icon="faKey"
-                    :title="localize('Manage Galaxy API Key')"
-                    :description="localize('Access your current Galaxy API key or create a new one.')"
-                    to="/user/api_key" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-credentials"
-                    :icon="faKey"
-                    :title="localize('Manage Your Tools Credentials')"
-                    :description="localize('Manage your tools credentials groups for accessing external services.')"
-                    to="/user/credentials" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-notifications"
-                    :icon="faBell"
-                    :title="localize('Manage Notifications')"
-                    :description="localize('Manage your notification settings.')"
-                    to="/user/notifications/preferences" />
-
-                <UserPreferencesElement
-                    v-if="isConfigLoaded && config.enable_oidc && !config.fixed_delegated_auth"
-                    id="manage-third-party-identities"
-                    :icon="faIdCard"
-                    :title="localize('Manage Third-Party Identities')"
-                    :description="localize('Connect or disconnect access to your third-party identities.')"
-                    to="/user/external_ids" />
-
-                <UserPreferencesElement
-                    id="edit-preferences-custom-builds"
-                    :icon="faCubes"
-                    :title="localize('Manage Custom Builds')"
-                    :description="localize('Add or remove custom builds using history datasets.')"
-                    to="/custom_builds" />
-
-                <UserPreferencesElement
-                    v-if="hasThemes"
-                    id="edit-preferences-theme"
-                    :icon="faPalette"
-                    :title="localize('Pick a Color Theme')"
-                    :description="localize('Click here to change the user interface color theme.')"
-                    @click="toggleThemeModal" />
 
                 <UserPreferencesElement
                     v-if="isConfigLoaded && !config.single_user"
@@ -277,7 +263,32 @@ onMounted(async () => {
                     :title="localize('Manage Beacon')"
                     :description="localize('Contribute variants to Beacon')"
                     @click="toggleBeaconModal" />
+            </div>
 
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">
+                Appearance and notifications
+            </Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
+                <UserPreferencesElement
+                    v-if="hasThemes"
+                    id="edit-preferences-theme"
+                    :icon="faPalette"
+                    :title="localize('Pick a Color Theme')"
+                    :description="localize('Click here to change the user interface color theme.')"
+                    @click="toggleThemeModal" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-notifications"
+                    :icon="faBell"
+                    :title="localize('Manage Notifications')"
+                    :description="localize('Manage your notification settings.')"
+                    to="/user/notifications/preferences" />
+            </div>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Data and tools</Heading>
+
+            <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement
                     v-if="isConfigLoaded && config.object_store_allows_id_selection"
                     id="manage-preferred-object-store"
@@ -307,7 +318,46 @@ onMounted(async () => {
                         )
                     "
                     to="/file_source_instances/index" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-credentials"
+                    :icon="faKey"
+                    :title="localize('Manage Your Tools Credentials')"
+                    :description="localize('Manage your tools credentials groups for accessing external services.')"
+                    to="/user/credentials" />
+
+                <UserPreferencesElement
+                    id="edit-preferences-custom-builds"
+                    :icon="faCubes"
+                    :title="localize('Manage Custom Builds')"
+                    :description="localize('Add or remove custom builds using history datasets.')"
+                    to="/custom_builds" />
+
+                <UserPreferencesElement
+                    v-if="toolboxFiltersPreference"
+                    :id="toolboxFiltersPreference.id"
+                    :icon="toolboxFiltersPreference.icon"
+                    :title="toolboxFiltersPreference.title"
+                    :description="toolboxFiltersPreference.description"
+                    to="/user/toolbox_filters" />
             </div>
+
+            <template v-if="hasExtraPreferences">
+                <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Instance settings</Heading>
+
+                <div class="d-flex flex-wrap mb-4 user-preferences-cards">
+                    <UserPreferencesElement
+                        id="edit-preferences-extra"
+                        :icon="faSliders"
+                        :title="localize('Extra Configurations')"
+                        :description="
+                            localize('Settings this Galaxy instance defines, such as external service credentials.')
+                        "
+                        to="/user/extra_preferences" />
+                </div>
+            </template>
+
+            <Heading v-localize h3 size="xs" class="user-preferences-group-heading">Danger zone</Heading>
 
             <div class="d-flex flex-wrap mb-4 user-preferences-cards">
                 <UserPreferencesElement

--- a/client/src/components/User/UserPreferencesModel.test.ts
+++ b/client/src/components/User/UserPreferencesModel.test.ts
@@ -59,4 +59,21 @@ describe("getUserPreferencesModel", () => {
         const prefs = getUserPreferencesModel("user-id");
         expect(prefs.password.disabled).toBe(false);
     });
+
+    it("disables extra preferences when the instance configures none", () => {
+        mockConfig({ has_user_preferences_extra: false, themes: {} });
+
+        const prefs = getUserPreferencesModel("user-id");
+        expect(prefs.extra_preferences.disabled).toBe(true);
+    });
+
+    it("points extra preferences at the typed endpoint when configured", () => {
+        mockConfig({ has_user_preferences_extra: true, themes: {} });
+
+        const prefs = getUserPreferencesModel("user-id");
+        expect(prefs.extra_preferences.disabled).toBe(false);
+        expect(prefs.extra_preferences.url).toBe("/api/users/user-id/extra_preferences/inputs");
+        // The generic form redirects back to the preferences index on save.
+        expect(prefs.extra_preferences.redirect).toBe("/user");
+    });
 });

--- a/client/src/components/User/UserPreferencesModel.ts
+++ b/client/src/components/User/UserPreferencesModel.ts
@@ -1,4 +1,4 @@
-import { faFilter, faUnlockAlt, faUser, type IconDefinition } from "font-awesome-6";
+import { faFilter, faUnlockAlt, type IconDefinition } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 
 import { isRegisteredUser } from "@/api";
@@ -6,7 +6,7 @@ import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 
-export type UserPreferencesKey = "information" | "password" | "toolbox_filters";
+export type UserPreferencesKey = "password" | "toolbox_filters";
 
 interface UserPreference {
     title: string;
@@ -30,20 +30,6 @@ export const getUserPreferencesModel: (user_id?: string) => UserPreferencesModel
     }
 
     return {
-        information: {
-            title: localize("Manage Information"),
-            id: "edit-preferences-information",
-            description:
-                isConfigLoaded.value &&
-                config.value.enable_account_interface &&
-                !config.value.use_remote_user &&
-                !config.value.disable_local_accounts
-                    ? localize("Edit your email, addresses and custom parameters or change your public name.")
-                    : localize("Edit your addresses and custom parameters."),
-            url: `/api/users/${user_id}/information/inputs`,
-            icon: faUser,
-            redirect: "/user",
-        },
         password: {
             title: localize("Change Password"),
             id: "edit-preferences-password",

--- a/client/src/components/User/UserPreferencesModel.ts
+++ b/client/src/components/User/UserPreferencesModel.ts
@@ -1,4 +1,4 @@
-import { faFilter, faUnlockAlt, type IconDefinition } from "font-awesome-6";
+import { faFilter, faSliders, faUnlockAlt, type IconDefinition } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 
 import { isRegisteredUser } from "@/api";
@@ -6,7 +6,7 @@ import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 
-export type UserPreferencesKey = "password" | "toolbox_filters";
+export type UserPreferencesKey = "password" | "toolbox_filters" | "extra_preferences";
 
 interface UserPreference {
     title: string;
@@ -53,6 +53,16 @@ export const getUserPreferencesModel: (user_id?: string) => UserPreferencesModel
             submitTitle: "Save Filters",
             redirect: "/user",
             disabled: isConfigLoaded.value && !config.value.has_user_tool_filters,
+        },
+        extra_preferences: {
+            title: localize("Extra Configurations"),
+            id: "edit-preferences-extra",
+            description: localize("Settings this Galaxy instance defines, such as external service credentials."),
+            url: `/api/users/${user_id}/extra_preferences/inputs`,
+            icon: faSliders,
+            submitTitle: "Save Settings",
+            redirect: "/user",
+            disabled: isConfigLoaded.value && !config.value.has_user_preferences_extra,
         },
     };
 };

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -88,6 +88,7 @@ import CustomBuilds from "@/components/User/CustomBuilds.vue";
 import HistoryStorageOverview from "@/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue";
 import NotificationsPreferences from "@/components/User/Notifications/NotificationsPreferences.vue";
 import UserDatasetPermissions from "@/components/User/UserDatasetPermissions.vue";
+import UserInformation from "@/components/User/UserInformation.vue";
 import UserOidcProfile from "@/components/User/UserOidcProfile.vue";
 import UserPreferences from "@/components/User/UserPreferences.vue";
 import UserPreferencesForm from "@/components/User/UserPreferencesForm.vue";
@@ -675,6 +676,14 @@ export function getRouter(Galaxy) {
                     {
                         path: "user",
                         component: UserPreferences,
+                        redirect: redirectAnon(),
+                    },
+                    {
+                        /** Declared before the `user/:formId` catch-all below, which
+                         *  otherwise still matches "information" and would render the
+                         *  generic form instead of this page. */
+                        path: "user/information",
+                        component: UserInformation,
                         redirect: redirectAnon(),
                     },
                     {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -131,12 +131,6 @@ change_user_password:
   selectors:
     submit: '#submit:not([aria-disabled])'
 
-change_user_address:
-  selectors:
-    address_button:
-      type: xpath
-      selector: '//span[contains(text(), "Insert Address")]'
-
 dataset_details:
   selectors:
     _: 'table#dataset-details'

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -64,9 +64,6 @@ interface Rootchange_user_email extends Component {
 interface Rootchange_user_password extends Component {
     submit: SelectorTemplate;
 }
-interface Rootchange_user_address extends Component {
-    address_button: SelectorTemplate;
-}
 interface Rootdataset_details extends Component {
     _: SelectorTemplate;
     tool_parameters: SelectorTemplate;
@@ -744,7 +741,6 @@ export interface root_component {
     toolbox_filters: Roottoolbox_filters;
     change_user_email: Rootchange_user_email;
     change_user_password: Rootchange_user_password;
-    change_user_address: Rootchange_user_address;
     dataset_details: Rootdataset_details;
     object_store_details: Rootobject_store_details;
     history_panel: Roothistory_panel;

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -56,6 +56,11 @@ class TestManageInformation(SeleniumTestCase):
         # UX_RENDER time sometimes is not enough
         self.sleep_for(self.wait_types.UX_TRANSITION)
 
+        # The account page confirms with a toast and stays put, so go back to
+        # preferences to read the rendered email.
+        self.navigate_to_user_preferences()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
         # email should be changed
         assert_email(new_email)
 

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -86,43 +86,6 @@ class TestManageInformation(SeleniumTestCase):
         # public name field should render new public name
         assert_public_name(new_public_name)
 
-    @selenium_test
-    def test_user_address(self):
-        self.register(self._get_random_email())
-        self.navigate_to_manage_information()
-        self.components.change_user_address.address_button.wait_for_and_click()
-
-        address_field_labels = [
-            "Short address description",
-            "Name",
-            "Institution",
-            "Address",
-            "City",
-            "State/Province/Region",
-            "Postal Code",
-            "Country",
-            "Phone",
-        ]
-
-        address_fields = {}
-        # fill address fields with random data
-        for input_field_label in address_field_labels:
-            input_value = self._get_random_name(prefix=input_field_label)
-            address_fields[input_field_label] = input_value
-            input_field = self.get_address_input_field(input_field_label)
-            self.clear_input_field_and_write(input_field, input_value)
-        # save new address
-        self.components.change_user_email.submit.wait_for_and_click()
-        self.sleep_for(self.wait_types.UX_TRANSITION)
-
-        self.navigate_to_manage_information()
-        self.sleep_for(self.wait_types.UX_RENDER)
-
-        # check if address was saved correctly
-        for input_field_label in address_fields.keys():
-            input_field = self.get_address_input_field(input_field_label)
-            assert input_field.get_attribute("value") == address_fields[input_field_label]
-
     def navigate_to_manage_information(self):
         self.navigate_to_user_preferences()
         self.components.preferences.manage_information.wait_for_and_click()
@@ -130,9 +93,6 @@ class TestManageInformation(SeleniumTestCase):
     def clear_input_field_and_write(self, element, new_input_text):
         element.clear()
         element.send_keys(new_input_text)
-
-    def get_address_input_field(self, input_field_label):
-        return self.wait_for_selector_visible(f"[data-label='{input_field_label}'] > div > div > input")
 
 
 class TestDeleteCurrentAccount(SeleniumTestCase):


### PR DESCRIPTION
Depends on #23303 (server API: display name, typed email update, typed extra preferences); opened against its branch so the diff shows only the client commits. GitHub will retarget this PR to `dev` once #23303 merges.

---

The client half of the user account work, regrouped from #23306 and #23307 into one PR against `dev`. Depends on the server PR (display name, typed email update, typed extra preferences) having landed.

---

## Native Account page at `/user/information`

Replaces the server-driven form at `/user/information` with a native Vue page, and relabels **Public name** to **Username**.

The page was a generic form rendering JSON from `/api/users/{id}/information/inputs`. That was a reasonable fit when the page was mostly admin-configured sections, but email and username are a fixed, typed pair, and the form-JSON round trip left no room to say anything useful about them — no warning, no way to disable one field but not another, no per-field help beyond a string.

It also fixes the naming problem underneath. **Public name** described one of the field's three jobs: it signs you in, it is the `/u/{username}/...` URL segment, and until now it was also what other people saw. With a display name available, it can be called what it is. **Username** rather than "Login name", because the field is not only a credential — a label saying so would encourage people to rename it without realising every link they have shared stops resolving.

The page has two sections: **Identity** (display name, then username with a live example of the URL it produces) and **Sign-in** (email, plus links out to password and third-party identities). It sends only changed fields, since resending an unchanged email would deactivate the account for no reason. It warns before the two changes that have consequences — renaming the username breaks already-shared links, and changing the email requires re-activation — and it is read-only with an explanation when accounts are managed outside Galaxy, mirroring the server's own `allow_profile_edit`.

Postal addresses and the extra-preference sections are gone from this page: addresses now have no UI anywhere, and extra preferences get their own entry in this PR.

The `email`, `username` and `submit` element ids are kept deliberately, so existing selenium coverage needs no rewrite. The selenium postal-address case is deleted here rather than in the addresses PR, because this is the change that removes the UI it was driving.

|Before|After|
|---|---|
|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/ff581ba2-d8d8-4e6d-b95d-ee45290847e7" />|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/9fe898d7-1896-4c19-a5eb-27d8189b7a70" />|


---

## User preferences grouped under headings

Groups the User Preferences cards under headings and adds an **Extra Configurations** entry.

Seventeen undifferentiated cards are a wall to scan, and the ordering carried no meaning — storage sat between a theme picker and a privacy switch. Every card is unchanged, and the click depth is the same; they are now grouped by what someone is actually trying to do:

- **Account and sign-in** — Account, Change Password, Third-Party Identities, API Key
- **Sharing and privacy** — Dataset Permissions, Make All Data Private, Beacon
- **Appearance and notifications** — Color Theme, Notifications
- **Data and tools** — Storage, Repositories, Tool Credentials, Custom Builds, Toolbox Filters
- **Instance settings** — Extra Configurations
- **Danger zone** — Delete Account, Sign Out of All Sessions

Password and toolbox filters are placed manually rather than looped over because they belong to different groups.

**Extra Configurations** is the settings an administrator defines for this instance — external service credentials and the like. They used to be appended to the bottom of Manage Information, where, on a busy instance, they buried email and username below the fold. They now have their own entry, pointed at the typed `extra_preferences/inputs` endpoint, and the whole group is hidden on instances that configure none rather than linking to an empty form.

|Before|After|
|---|---|
|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/5876d793-6abb-4b3a-976c-0cc2aeda8ea4" />|<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/c2730504-5f15-479d-bab9-2948e7b42b7b" />|

### Extra Configurations `/user/extra_preferences`
<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/fa2d1649-744a-4585-9554-302fafe9d856" />



---

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `cd client && pnpm exec vitest run src/components/User`
  2. `./run_tests.sh -selenium lib/galaxy_test/selenium/test_personal_information.py`
  3. Visit `/user/information`, change email, username and display name, and confirm the values come back after a reload; confirm `/user` groups entries under headings.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
