### PR TITLE
Test that job cache is not used for composite datasets with different extra files

### DIFF
--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -7,7 +7,9 @@ keep things like testing other tool APIs in ./test_tools.py (index, search, tool
 files, etc..).
 """
 
+import copy
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
@@ -716,6 +718,34 @@ def test_map_over_data_param_with_list_of_lists(target_history: TargetHistory, r
     execute = required_tool.execute().with_inputs({"parameter": {"batch": True, "values": [hdca.src_dict]}})
     execute.assert_has_n_jobs(3).assert_creates_n_implicit_collections(1)
     execute.assert_creates_implicit_collection(0)
+
+
+@requires_tool_id("gx_data")
+def test_job_cache_not_used_for_datasets_with_different_extra_files(
+    target_history: TargetHistory, required_tool: RequiredTool
+) -> None:
+    velvet_upload_request: dict[str, Any] = {
+        "src": "composite",
+        "ext": "velvet",
+        "composite": {
+            "items": [
+                {"src": "pasted", "paste_content": "sequences content"},
+                {"src": "pasted", "paste_content": "roadmaps content"},
+                {"src": "pasted", "paste_content": "log content"},
+            ]
+        },
+    }
+    velvet1_hda = target_history._dataset_populator.fetch_hda(target_history.id, velvet_upload_request, wait=True)
+    velvet1 = {"src": "hda", "id": velvet1_hda["id"]}
+    _ = required_tool.execute().with_inputs({"parameter": velvet1}).assert_has_single_job
+
+    # Same primary file ("sequences"), but a different extra file ("roadmaps").
+    velvet_modified_request = copy.deepcopy(velvet_upload_request)
+    velvet_modified_request["composite"]["items"][1]["paste_content"] = "roadmaps content MODIFIED"
+    velvet2_hda = target_history._dataset_populator.fetch_hda(target_history.id, velvet_modified_request, wait=True)
+    velvet2 = {"src": "hda", "id": velvet2_hda["id"]}
+    job = required_tool.execute(use_cached_job=True).with_inputs({"parameter": velvet2}).assert_has_single_job
+    assert not job.final_details["copied_from_job_id"]
 
 
 @requires_tool_id("gx_repeat_boolean_min")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4651,10 +4651,10 @@ class DescribeJob:
         self._job_id = job_id
         self._final_details: dict[str, Any] | None = None
 
-    def _wait_for(self):
+    def _wait_for(self) -> None:
         if self._final_details is None:
             self._dataset_populator.wait_for_job(self._job_id, assert_ok=False)
-            self._final_details = self._dataset_populator.get_job_details(self._job_id).json()
+            self._final_details = self._dataset_populator.get_job_details(self._job_id, full=True).json()
 
     @property
     def final_details(self) -> dict[str, Any]:


### PR DESCRIPTION
Two composite datasets with the same primary file but different extra files must never be treated as cache-equivalent, regardless of how (or whether) hash-based job matching handles composite datasets: on current dev, with no hash-based matching at all, this holds trivially (job cache only ever matches on identical `dataset_id`); it must continue to hold under any future implementation, including one that computes a composite hash covering extra files (see the discussion on https://github.com/galaxyproject/galaxy/issues/21676), since a correct composite hash would itself distinguish the differing extra file content. This makes the test a durable regression guard independent of which design for hash-based job matching on composite datasets is eventually implemented.

Also extends `DescribeJob._wait_for()` to request full job details, needed for `copied_from_job_id` to be present in the response at all.

Extracted from the (unmerged, not yet pushed further) PR #23429.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
