### PR TITLE
Extract list API helpers and add entity list caches to the client stores

### DIFF
--- a/client/src/api/histories.test.ts
+++ b/client/src/api/histories.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+
+import {
+    getArchivedHistories,
+    getHistories,
+    getMyHistories,
+    getPublishedHistories,
+    getSharedHistories,
+    type MyHistory,
+} from "./histories";
+
+const { server, http } = useServerMock();
+
+function mockHistory(id: string, name: string): MyHistory {
+    return {
+        id,
+        name,
+        model_class: "History",
+        annotation: null,
+        archived: false,
+        count: 0,
+        deleted: false,
+        published: false,
+        purged: false,
+        tags: [],
+        update_time: "2026-01-02T00:00:00",
+        username: "test-user",
+    } as unknown as MyHistory;
+}
+
+/** Captures the query parameters of the intercepted history index requests. */
+function interceptIndex(path: "/api/histories" | "/api/histories/archived", histories: unknown[], totalMatches = "0") {
+    const queries: Record<string, string>[] = [];
+
+    server.use(
+        http.get(path, ({ request, response }) => {
+            const url = new URL(request.url);
+            queries.push(Object.fromEntries(url.searchParams.entries()));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return response(200).json(histories as any, { headers: { total_matches: totalMatches } });
+        }),
+    );
+
+    return queries;
+}
+
+describe("getMyHistories", () => {
+    it("returns the histories and the total matches header", async () => {
+        const expected = [mockHistory("h1", "First"), mockHistory("h2", "Second")];
+        interceptIndex("/api/histories", expected, "42");
+
+        const result = await getMyHistories();
+
+        expect(result.data).toEqual(expected);
+        expect(result.total).toBe(42);
+    });
+
+    it("never requests published histories, so a user listing cannot leak public ones", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getMyHistories();
+
+        expect(queries[0]).toMatchObject({
+            view: "summary",
+            keys: "username",
+            limit: "24",
+            offset: "0",
+            search: "",
+            sort_by: "update_time",
+            sort_desc: "false",
+            show_own: "true",
+            show_published: "false",
+            show_shared: "false",
+            show_archived: "false",
+        });
+    });
+
+    it("forwards pagination, search and sorting options", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getMyHistories({ limit: 5, offset: 10, search: "rna", sortBy: "name", sortDesc: true });
+
+        expect(queries[0]).toMatchObject({
+            limit: "5",
+            offset: "10",
+            search: "rna",
+            sort_by: "name",
+            sort_desc: "true",
+            show_own: "true",
+            show_published: "false",
+        });
+    });
+});
+
+describe("getSharedHistories", () => {
+    it("requests only histories shared with the current user", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getSharedHistories({ search: "shared" });
+
+        expect(queries[0]).toMatchObject({
+            keys: "username,owner",
+            search: "shared",
+            show_own: "false",
+            show_published: "false",
+            show_shared: "true",
+            show_archived: "false",
+        });
+    });
+});
+
+describe("getPublishedHistories", () => {
+    it("requests only published histories", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getPublishedHistories();
+
+        expect(queries[0]).toMatchObject({
+            keys: "username,owner,published",
+            show_own: "false",
+            show_published: "true",
+            show_shared: "false",
+            show_archived: "false",
+        });
+    });
+});
+
+describe("getArchivedHistories", () => {
+    it("uses the archived endpoint and forwards the listing options", async () => {
+        const expected = [mockHistory("h3", "Archived")];
+        const queries = interceptIndex("/api/histories/archived", expected, "3");
+
+        const result = await getArchivedHistories({ limit: 7, search: "old" });
+
+        expect(result.data).toEqual(expected);
+        expect(result.total).toBe(3);
+        expect(queries[0]).toMatchObject({
+            view: "summary",
+            limit: "7",
+            offset: "0",
+            search: "old",
+            sort_by: "update_time",
+            sort_desc: "false",
+        });
+    });
+});
+
+describe("getHistories", () => {
+    it("defaults to the current user's own, non-archived histories", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getHistories();
+
+        expect(queries[0]).toMatchObject({
+            show_own: "true",
+            show_published: "false",
+            show_shared: "false",
+            show_archived: "false",
+        });
+    });
+
+    it("accepts explicit visibility flags", async () => {
+        const queries = interceptIndex("/api/histories", []);
+
+        await getHistories({ showOwn: false, showPublished: true, showShared: true, showArchived: true });
+
+        expect(queries[0]).toMatchObject({
+            show_own: "false",
+            show_published: "true",
+            show_shared: "true",
+            show_archived: "true",
+        });
+    });
+});

--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -69,6 +69,39 @@ export interface GetHistoriesOptions {
 }
 
 /**
+ * Represents the visibility flags accepted by the histories index endpoint.
+ *
+ * The backend defaults `show_published` to `true`, so every request built here
+ * passes an explicit value for each flag. Otherwise a listing of the user's own
+ * histories would silently include other users' published histories.
+ */
+export interface HistoryVisibilityOptions {
+    showOwn?: boolean;
+    showPublished?: boolean;
+    showShared?: boolean;
+    showArchived?: boolean;
+}
+
+/**
+ * Represents the options for fetching histories from the index endpoint,
+ * including the visibility flags and the serialization keys to request.
+ */
+export interface GetHistoryListOptions extends Partial<GetHistoriesOptions>, HistoryVisibilityOptions {
+    /** Additional serialization keys requested on top of the `summary` view. */
+    keys?: string;
+}
+
+/**
+ * Represents a page of history entries together with the total number of matches.
+ */
+export interface HistoryListResult<T> {
+    data: T[];
+    total: number;
+}
+
+const DEFAULT_HISTORY_LIMIT = 24;
+
+/**
  * Checks if the current user owns a history entry.
  * @param {string} username The username of the history owner
  * @returns True if the current user owns the history, false otherwise
@@ -153,27 +186,45 @@ export async function getBeaconHistories(beaconHistoryName: string): Promise<Bea
 }
 
 /**
- * Fetches the current user's history entries.
- * @param {GetHistoriesOptions} options The options for fetching histories
- * @returns {Promise<{ data: MyHistory[]; total: number }>} A promise that resolves to the user's history entries
+ * Fetches history entries from the histories index endpoint.
+ *
+ * All visibility flags are optional and default to a listing of the current
+ * user's own, non-archived histories. They are always sent explicitly, so a
+ * listing can never pick up the backend's `show_published=true` default.
+ *
+ * @param {GetHistoryListOptions} options The options for fetching histories
+ * @returns {Promise<HistoryListResult<T>>} A promise that resolves to the matching history entries
  */
-export async function getMyHistories(options?: GetHistoriesOptions): Promise<{ data: MyHistory[]; total: number }> {
-    const { limit = 24, offset = 0, search = "", sortBy = "update_time", sortDesc = false } = options || {};
+export async function getHistories<T = AnyHistoryEntry>(
+    options?: GetHistoryListOptions,
+): Promise<HistoryListResult<T>> {
+    const {
+        limit = DEFAULT_HISTORY_LIMIT,
+        offset = 0,
+        search = "",
+        sortBy = "update_time",
+        sortDesc = false,
+        showOwn = true,
+        showPublished = false,
+        showShared = false,
+        showArchived = false,
+        keys = "username",
+    } = options || {};
 
     const { response, data, error } = await GalaxyApi().GET("/api/histories", {
         params: {
             query: {
                 view: "summary",
-                keys: "username",
+                keys: keys,
                 limit: limit,
                 offset: offset,
                 search: search,
                 sort_by: sortBy,
                 sort_desc: sortDesc,
-                show_own: true,
-                show_published: false,
-                show_shared: false,
-                show_archived: false,
+                show_own: showOwn,
+                show_published: showPublished,
+                show_shared: showShared,
+                show_archived: showArchived,
             },
         },
     });
@@ -182,88 +233,78 @@ export async function getMyHistories(options?: GetHistoriesOptions): Promise<{ d
         rethrowSimple(error);
     }
 
-    return { data: data as MyHistory[], total: parseInt(response.headers.get("total_matches") ?? "0") };
+    return { data: data as T[], total: parseInt(response.headers.get("total_matches") ?? "0") };
+}
+
+/**
+ * Fetches the current user's history entries.
+ * @param {Partial<GetHistoriesOptions>} options The options for fetching histories
+ * @returns {Promise<HistoryListResult<MyHistory>>} A promise that resolves to the user's history entries
+ */
+export function getMyHistories(options?: Partial<GetHistoriesOptions>): Promise<HistoryListResult<MyHistory>> {
+    return getHistories<MyHistory>({
+        ...options,
+        keys: "username",
+        showOwn: true,
+        showPublished: false,
+        showShared: false,
+        showArchived: false,
+    });
 }
 
 /**
  * Fetches the current user's shared history entries.
- * @param {GetHistoriesOptions} options The options for fetching histories
- * @returns {Promise<{ data: SharedHistory[]; total: number }>} A promise that resolves to the shared history entries
+ * @param {Partial<GetHistoriesOptions>} options The options for fetching histories
+ * @returns {Promise<HistoryListResult<SharedHistory>>} A promise that resolves to the shared history entries
  */
-export async function getSharedHistories(
-    options?: GetHistoriesOptions,
-): Promise<{ data: SharedHistory[]; total: number }> {
-    const { limit = 24, offset = 0, search = "", sortBy = "update_time", sortDesc = false } = options || {};
-
-    const { response, data, error } = await GalaxyApi().GET("/api/histories", {
-        params: {
-            query: {
-                view: "summary",
-                keys: "username,owner",
-                limit: limit,
-                offset: offset,
-                search: search,
-                sort_by: sortBy,
-                sort_desc: sortDesc,
-                show_own: false,
-                show_published: false,
-                show_shared: true,
-                show_archived: false,
-            },
-        },
+export function getSharedHistories(options?: Partial<GetHistoriesOptions>): Promise<HistoryListResult<SharedHistory>> {
+    return getHistories<SharedHistory>({
+        ...options,
+        keys: "username,owner",
+        showOwn: false,
+        showPublished: false,
+        showShared: true,
+        showArchived: false,
     });
-
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    return { data: data as SharedHistory[], total: parseInt(response.headers.get("total_matches") ?? "0") };
 }
 
 /**
  * Fetches the published history entries.
- * @param {GetHistoriesOptions} options The options for fetching histories
- * @returns {Promise<{ data: PublishedHistory[]; total: number }>} A promise that resolves to the published history entries
+ * @param {Partial<GetHistoriesOptions>} options The options for fetching histories
+ * @returns {Promise<HistoryListResult<PublishedHistory>>} A promise that resolves to the published history entries
  */
-export async function getPublishedHistories(
-    options?: GetHistoriesOptions,
-): Promise<{ data: PublishedHistory[]; total: number }> {
-    const { limit = 24, offset = 0, search = "", sortBy = "update_time", sortDesc = false } = options || {};
-
-    const { response, data, error } = await GalaxyApi().GET("/api/histories", {
-        params: {
-            query: {
-                view: "summary",
-                keys: "username,owner,published",
-                limit: limit,
-                offset: offset,
-                search: search,
-                sort_by: sortBy,
-                sort_desc: sortDesc,
-                show_own: false,
-                show_published: true,
-                show_shared: false,
-                show_archived: false,
-            },
-        },
+export function getPublishedHistories(
+    options?: Partial<GetHistoriesOptions>,
+): Promise<HistoryListResult<PublishedHistory>> {
+    return getHistories<PublishedHistory>({
+        ...options,
+        keys: "username,owner,published",
+        showOwn: false,
+        showPublished: true,
+        showShared: false,
+        showArchived: false,
     });
-
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    return { data: data as PublishedHistory[], total: parseInt(response.headers.get("total_matches") ?? "0") };
 }
 
 /**
  * Fetches the current user's archived history entries.
- * @param {GetHistoriesOptions} options The options for fetching histories
- * @returns {Promise<{ data: ArchivedHistorySummary[]; total: number }>} A promise that resolves to the archived history entries
+ *
+ * Archived histories have their own endpoint (which implies the visibility
+ * flags), so this wrapper does not go through `getHistories`.
+ *
+ * @param {Partial<GetHistoriesOptions>} options The options for fetching histories
+ * @returns {Promise<HistoryListResult<ArchivedHistorySummary>>} A promise that resolves to the archived history entries
  */
 export async function getArchivedHistories(
-    options?: GetHistoriesOptions,
-): Promise<{ data: ArchivedHistorySummary[]; total: number }> {
-    const { limit = 24, offset = 0, search = "", sortBy = "update_time", sortDesc = false } = options || {};
+    options?: Partial<GetHistoriesOptions>,
+): Promise<HistoryListResult<ArchivedHistorySummary>> {
+    const {
+        limit = DEFAULT_HISTORY_LIMIT,
+        offset = 0,
+        search = "",
+        sortBy = "update_time",
+        sortDesc = false,
+    } = options || {};
 
     const { response, data, error } = await GalaxyApi().GET("/api/histories/archived", {
         params: {

--- a/client/src/api/pages.test.ts
+++ b/client/src/api/pages.test.ts
@@ -13,9 +13,11 @@ import type {
 } from "./pages";
 import {
     createHistoryPage,
+    createPage,
     deleteHistoryPage,
     fetchHistoryPage,
     fetchHistoryPages,
+    loadPages,
     savePage,
     updateHistoryPage,
 } from "./pages";
@@ -224,6 +226,153 @@ describe("pages API", () => {
 
             expect(result.content).toBe("# Agent Content");
             expect(result.edit_source).toBe("agent");
+        });
+    });
+
+    describe("loadPages", () => {
+        it("requests own pages and parses total matches by default", async () => {
+            let query: URLSearchParams | undefined;
+
+            server.use(
+                http.get("/api/pages", ({ request, response }) => {
+                    query = new URL(request.url).searchParams;
+                    return response(200).json([TEST_PAGE_SUMMARY], { headers: { total_matches: "7" } });
+                }),
+            );
+
+            const result = await loadPages();
+
+            expect(result.data).toEqual([TEST_PAGE_SUMMARY]);
+            expect(result.totalMatches).toBe(7);
+            expect(query?.get("show_own")).toBe("true");
+            expect(query?.get("show_shared")).toBe("false");
+            expect(query?.get("show_published")).toBe("false");
+            expect(query?.get("sort_by")).toBe("update_time");
+            expect(query?.get("sort_desc")).toBe("true");
+            expect(query?.get("limit")).toBe("20");
+            expect(query?.get("offset")).toBe("0");
+        });
+
+        it("passes through visibility, search, sorting and paging options", async () => {
+            let query: URLSearchParams | undefined;
+
+            server.use(
+                http.get("/api/pages", ({ request, response }) => {
+                    query = new URL(request.url).searchParams;
+                    return response(200).json([]);
+                }),
+            );
+
+            await loadPages({
+                showOwn: false,
+                showShared: true,
+                showPublished: true,
+                search: "analysis",
+                sortBy: "title",
+                sortDesc: false,
+                limit: 5,
+                offset: 10,
+            });
+
+            expect(query?.get("show_own")).toBe("false");
+            expect(query?.get("show_shared")).toBe("true");
+            expect(query?.get("show_published")).toBe("true");
+            expect(query?.get("search")).toBe("analysis");
+            expect(query?.get("sort_by")).toBe("title");
+            expect(query?.get("sort_desc")).toBe("false");
+            expect(query?.get("limit")).toBe("5");
+            expect(query?.get("offset")).toBe("10");
+        });
+
+        it("converts the is:standalone filter to the backend type filter", async () => {
+            let query: URLSearchParams | undefined;
+
+            server.use(
+                http.get("/api/pages", ({ request, response }) => {
+                    query = new URL(request.url).searchParams;
+                    return response(200).json([]);
+                }),
+            );
+
+            await loadPages({ search: "notes is:standalone" });
+
+            expect(query?.get("search")).toBe("notes type:standalone");
+        });
+
+        it("defaults total matches to zero when the header is missing", async () => {
+            server.use(
+                http.get("/api/pages", ({ response }) => {
+                    return response(200).json([]);
+                }),
+            );
+
+            const result = await loadPages();
+
+            expect(result.totalMatches).toBe(0);
+        });
+
+        it("throws on server error", async () => {
+            server.use(
+                http.get("/api/pages", ({ response }) => {
+                    return response("4XX").json({ err_msg: "Not allowed", err_code: 403 }, { status: 403 });
+                }),
+            );
+
+            await expect(loadPages()).rejects.toThrow();
+        });
+    });
+
+    describe("createPage", () => {
+        it("creates a markdown page by default and returns it", async () => {
+            let body: Record<string, unknown> | undefined;
+
+            server.use(
+                http.post("/api/pages", async ({ request, response }) => {
+                    body = (await request.json()) as Record<string, unknown>;
+                    return response(200).json({ ...TEST_PAGE_DETAILS, title: "My Notes", slug: "my-notes" });
+                }),
+            );
+
+            const result = await createPage({ title: "My Notes", slug: "my-notes" });
+
+            expect(body).toEqual({
+                title: "My Notes",
+                slug: "my-notes",
+                content: "",
+                content_format: "markdown",
+            });
+            expect(result.id).toBe(TEST_PAGE_ID);
+            expect(result.slug).toBe("my-notes");
+        });
+
+        it("allows overriding the content format and content", async () => {
+            let body: Record<string, unknown> | undefined;
+
+            server.use(
+                http.post("/api/pages", async ({ request, response }) => {
+                    body = (await request.json()) as Record<string, unknown>;
+                    return response(200).json(TEST_PAGE_DETAILS);
+                }),
+            );
+
+            await createPage({ title: "Legacy", slug: "legacy", content_format: "html", content: "<p>hi</p>" });
+
+            expect(body).toEqual({
+                title: "Legacy",
+                slug: "legacy",
+                content: "<p>hi</p>",
+                content_format: "html",
+            });
+        });
+
+        it("throws when the slug is already taken", async () => {
+            server.use(
+                http.post("/api/pages", ({ response }) => {
+                    return response("4XX").json({ err_msg: "Slug already exists", err_code: 400 }, { status: 400 });
+                }),
+            );
+
+            await expect(createPage({ title: "My Notes", slug: "my-notes" })).rejects.toThrow();
         });
     });
 

--- a/client/src/api/pages.ts
+++ b/client/src/api/pages.ts
@@ -2,7 +2,7 @@
  * Unified API client for all Galaxy Pages (history-attached and standalone).
  * Uses the generated typed client against the /api/pages endpoints.
  */
-import { type components, GalaxyApi } from "@/api";
+import { type components, GalaxyApi, type GalaxyApiPaths } from "@/api";
 import { rethrowSimple } from "@/utils/simple-error";
 
 // --- Types (generated from the backend Page/PageRevision schemas) ---
@@ -14,7 +14,99 @@ export type PageRevisionDetails = components["schemas"]["PageRevisionDetails"];
 export type CreateHistoryPagePayload = components["schemas"]["CreatePagePayload"];
 export type UpdateHistoryPagePayload = components["schemas"]["UpdatePagePayload"];
 
+/** Neutral aliases for pages which are not necessarily attached to a history. */
+export type PageSummary = HistoryPageSummary;
+export type PageDetails = HistoryPageDetails;
+export type PageContentFormat = components["schemas"]["PageContentFormat"];
+
+export type PageSortBy = NonNullable<
+    NonNullable<GalaxyApiPaths["/api/pages"]["get"]["parameters"]["query"]>["sort_by"]
+>;
+
+export interface LoadPagesOptions {
+    /** Include pages owned by the current user. */
+    showOwn?: boolean;
+    /** Include pages shared with the current user. */
+    showShared?: boolean;
+    /** Include published pages. */
+    showPublished?: boolean;
+    /** Free text and GitHub-style tag filters. */
+    search?: string;
+    sortBy?: PageSortBy;
+    sortDesc?: boolean;
+    limit?: number;
+    offset?: number;
+}
+
+export interface LoadPagesResult {
+    data: PageSummary[];
+    totalMatches: number;
+}
+
+export interface CreatePageOptions {
+    title: string;
+    slug: string;
+    /** Defaults to `markdown` (the format used by the page editor). */
+    content_format?: PageContentFormat;
+    content?: string;
+}
+
 // --- API functions ---
+
+/**
+ * Pages that are not attached to a history have their type set to "standalone" on the backend,
+ * so the user facing `is:standalone` filter is converted before being sent to the backend.
+ */
+function normalizePageSearch(search: string): string {
+    return search.includes("is:standalone") ? search.replace("is:standalone", "type:standalone") : search;
+}
+
+/** Lists pages visible to the current user, optionally restricted to own/shared/published ones. */
+export async function loadPages(options: LoadPagesOptions = {}): Promise<LoadPagesResult> {
+    const {
+        showOwn = true,
+        showShared = false,
+        showPublished = false,
+        search = "",
+        sortBy = "update_time",
+        sortDesc = true,
+        limit = 20,
+        offset = 0,
+    } = options;
+
+    const { response, data, error } = await GalaxyApi().GET("/api/pages", {
+        params: {
+            query: {
+                limit,
+                offset,
+                search: normalizePageSearch(search),
+                sort_by: sortBy,
+                sort_desc: sortDesc,
+                show_own: showOwn,
+                show_shared: showShared,
+                show_published: showPublished,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0", 10) || 0;
+
+    return { data, totalMatches };
+}
+
+/** Creates a standalone page and returns the created page. */
+export async function createPage({
+    title,
+    slug,
+    content_format = "markdown",
+    content = "",
+}: CreatePageOptions): Promise<PageDetails> {
+    return createHistoryPage({ title, slug, content, content_format });
+}
 
 export async function fetchHistoryPages(historyId: string, invocationId?: string): Promise<HistoryPageSummary[]> {
     const { data, error } = await GalaxyApi().GET("/api/pages", {

--- a/client/src/api/visualizations.test.ts
+++ b/client/src/api/visualizations.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+
+import { loadVisualizations, type VisualizationSummary } from "./visualizations";
+
+const { server, http } = useServerMock();
+
+function mockVisualization(id: string, title: string): VisualizationSummary {
+    return {
+        id,
+        title,
+        type: "nvd3_bar",
+        annotation: null,
+        create_time: "2026-01-01T00:00:00",
+        update_time: "2026-01-02T00:00:00",
+        deleted: false,
+        importable: false,
+        published: false,
+        tags: [],
+        username: "test-user",
+    } as VisualizationSummary;
+}
+
+/** Captures the query parameters of the last intercepted index request. */
+function interceptIndex(visualizations: VisualizationSummary[], totalMatches = "0") {
+    const queries: Record<string, string>[] = [];
+
+    server.use(
+        http.get("/api/visualizations", ({ request, response }) => {
+            const url = new URL(request.url);
+            queries.push(Object.fromEntries(url.searchParams.entries()));
+            return response(200).json(visualizations, { headers: { total_matches: totalMatches } });
+        }),
+    );
+
+    return queries;
+}
+
+describe("loadVisualizations", () => {
+    it("requests own visualizations and returns the total matches header", async () => {
+        const expected = [mockVisualization("viz-1", "First"), mockVisualization("viz-2", "Second")];
+        const queries = interceptIndex(expected, "17");
+
+        const result = await loadVisualizations();
+
+        expect(result.data).toEqual(expected);
+        expect(result.totalMatches).toBe(17);
+        expect(queries[0]).toMatchObject({
+            limit: "24",
+            offset: "0",
+            search: "",
+            sort_by: "update_time",
+            sort_desc: "true",
+            show_own: "true",
+            show_published: "false",
+            show_shared: "false",
+        });
+    });
+
+    it("passes the explicit scope triplet and paging options through", async () => {
+        const queries = interceptIndex([]);
+
+        await loadVisualizations({
+            showOwn: false,
+            showShared: true,
+            showPublished: true,
+            search: "atac",
+            sortBy: "title",
+            sortDesc: false,
+            limit: 5,
+            offset: 10,
+        });
+
+        expect(queries[0]).toMatchObject({
+            limit: "5",
+            offset: "10",
+            search: "atac",
+            sort_by: "title",
+            sort_desc: "false",
+            show_own: "false",
+            show_published: "true",
+            show_shared: "true",
+        });
+    });
+
+    it("defaults the total matches to zero when the header is missing", async () => {
+        server.use(
+            http.get("/api/visualizations", ({ response }) => {
+                return response(200).json([]);
+            }),
+        );
+
+        const result = await loadVisualizations();
+
+        expect(result.data).toEqual([]);
+        expect(result.totalMatches).toBe(0);
+    });
+
+    it("throws on server errors", async () => {
+        server.use(
+            http.get("/api/visualizations", ({ response }) => {
+                return response("4XX").json({ err_code: 400, err_msg: "Bad request" }, { status: 400 });
+            }),
+        );
+
+        await expect(loadVisualizations()).rejects.toThrow();
+    });
+});

--- a/client/src/api/visualizations.ts
+++ b/client/src/api/visualizations.ts
@@ -1,0 +1,69 @@
+import { type components, GalaxyApi } from "@/api";
+import { rethrowSimple } from "@/utils/simple-error";
+
+export type VisualizationSummary = components["schemas"]["VisualizationSummary"];
+
+/** Attributes the visualizations index can be sorted by. */
+export type VisualizationSortByLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
+
+export interface LoadVisualizationsOptions {
+    /** Include visualizations owned by the current user. */
+    showOwn?: boolean;
+    /** Include visualizations shared with the current user. */
+    showShared?: boolean;
+    /** Include published visualizations. */
+    showPublished?: boolean;
+    /** A mix of free text and GitHub-style tags used to filter the index. */
+    search?: string;
+    sortBy?: VisualizationSortByLiteral;
+    sortDesc?: boolean;
+    limit?: number;
+    offset?: number;
+}
+
+export interface LoadVisualizationsResult {
+    data: VisualizationSummary[];
+    totalMatches: number;
+}
+
+/**
+ * Fetches visualization summaries from the visualizations index.
+ *
+ * The `showOwn`/`showShared`/`showPublished` triplet is always sent explicitly so
+ * callers never accidentally leak items from a scope they did not ask for.
+ */
+export async function loadVisualizations(options: LoadVisualizationsOptions = {}): Promise<LoadVisualizationsResult> {
+    const {
+        showOwn = true,
+        showShared = false,
+        showPublished = false,
+        search = "",
+        sortBy = "update_time",
+        sortDesc = true,
+        limit = 24,
+        offset = 0,
+    } = options;
+
+    const { response, data, error } = await GalaxyApi().GET("/api/visualizations", {
+        params: {
+            query: {
+                limit,
+                offset,
+                search,
+                sort_by: sortBy,
+                sort_desc: sortDesc,
+                show_own: showOwn,
+                show_published: showPublished,
+                show_shared: showShared,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0", 10) || 0;
+
+    return { data, totalMatches };
+}

--- a/client/src/api/workflows.test.ts
+++ b/client/src/api/workflows.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+
+import { loadWorkflows } from "./workflows";
+
+const { server, http } = useServerMock();
+
+const DEFAULT_OPTIONS = {
+    sortBy: "update_time",
+    sortDesc: true,
+    limit: 20,
+    offset: 0,
+    filterText: "",
+    showPublished: false,
+    skipStepCounts: true,
+} as const;
+
+function mockWorkflowsIndex() {
+    const requestedUrls: URL[] = [];
+
+    server.use(
+        http.get("/api/workflows", ({ request, response }: any) => {
+            requestedUrls.push(new URL(request.url));
+            return response(200).json([]);
+        }) as any,
+    );
+
+    return requestedUrls;
+}
+
+describe("workflows API", () => {
+    describe("loadWorkflows", () => {
+        it("omits show_shared unless it is requested", async () => {
+            const requestedUrls = mockWorkflowsIndex();
+
+            await loadWorkflows({ ...DEFAULT_OPTIONS });
+
+            expect(requestedUrls[0]?.searchParams.has("show_shared")).toBe(false);
+        });
+
+        it("passes show_shared through when requested", async () => {
+            const requestedUrls = mockWorkflowsIndex();
+
+            await loadWorkflows({ ...DEFAULT_OPTIONS, showShared: true, filterText: "is:shared_with_me" });
+
+            expect(requestedUrls[0]?.searchParams.get("show_shared")).toBe("true");
+            expect(requestedUrls[0]?.searchParams.get("search")).toBe("is:shared_with_me");
+        });
+    });
+});

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -48,15 +48,17 @@ export interface WorkflowVersion {
 
 export type AnyWorkflow = WorkflowSummary | StoredWorkflowDetailed;
 
-type SortBy = "create_time" | "update_time" | "name";
+export type WorkflowSortBy = "create_time" | "update_time" | "name";
 
 interface LoadWorkflowsOptions {
-    sortBy: SortBy;
+    sortBy: WorkflowSortBy;
     sortDesc: boolean;
     limit: number;
     offset: number;
     filterText: string;
     showPublished: boolean;
+    /** Include workflows shared with the requesting user (required by the `is:shared_with_me` filter). */
+    showShared?: boolean;
     skipStepCounts: boolean;
 }
 
@@ -67,6 +69,7 @@ export async function loadWorkflows({
     offset = 0,
     filterText = "",
     showPublished = false,
+    showShared,
     skipStepCounts = true,
 }: LoadWorkflowsOptions): Promise<{ data: WorkflowSummary[]; totalMatches: number }> {
     const {
@@ -82,6 +85,7 @@ export async function loadWorkflows({
                 offset,
                 search: filterText,
                 show_published: showPublished,
+                show_shared: showShared,
                 skip_step_counts: skipStepCounts,
             },
         },

--- a/client/src/components/Grid/configs/pages.ts
+++ b/client/src/components/Grid/configs/pages.ts
@@ -11,11 +11,12 @@ import {
 import { useEventBus } from "@vueuse/core";
 
 import { GalaxyApi } from "@/api";
+import { loadPages, type PageSortBy } from "@/api/pages";
 import { getGalaxyInstance } from "@/app";
 import { GRID_LABELS } from "@/components/Page/constants";
 import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
 import _l from "@/utils/localization";
-import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import type { ActionArray, FieldArray, GridConfig } from "./types";
 
@@ -24,39 +25,23 @@ const { emit } = useEventBus<string>("grid-router-push");
 /**
  * Local types
  */
-type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
 type PageEntry = Record<string, unknown>;
 
 /**
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    if (search.includes("is:standalone")) {
-        // Pages that are not attached to a history have their type set to "standalone" on the backend
-        // We convert the search term here before sending to the backend
-        search = search.replace("is:standalone", "type:standalone");
-    }
-
-    const { response, data, error } = await GalaxyApi().GET("/api/pages", {
-        params: {
-            query: {
-                limit,
-                offset,
-                search: search,
-                sort_by: sort_by as SortKeyLiteral,
-                sort_desc,
-                show_published: false,
-                show_own: true,
-                show_shared: false,
-            },
-        },
+    const { data, totalMatches } = await loadPages({
+        limit,
+        offset,
+        search,
+        sortBy: sort_by as PageSortBy,
+        sortDesc: sort_desc,
+        showOwn: true,
+        showShared: false,
+        showPublished: false,
     });
 
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
     return [data, totalMatches];
 }
 

--- a/client/src/components/Grid/configs/pagesPublished.ts
+++ b/client/src/components/Grid/configs/pagesPublished.ts
@@ -1,10 +1,9 @@
 import { faEye, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { GalaxyApi } from "@/api";
+import { loadPages, type PageSortBy } from "@/api/pages";
 import { GRID_LABELS } from "@/components/Page/constants";
 import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
-import { rethrowSimple } from "@/utils/simple-error";
 
 import type { ActionArray, FieldArray, GridConfig } from "./types";
 
@@ -13,39 +12,23 @@ const { emit } = useEventBus<string>("grid-router-push");
 /**
  * Local types
  */
-type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
 type PageEntry = Record<string, unknown>;
 
 /**
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    if (search.includes("is:standalone")) {
-        // Pages that are not attached to a history have their type set to "standalone" on the backend
-        // We convert the search term here before sending to the backend
-        search = search.replace("is:standalone", "type:standalone");
-    }
-
-    const { response, data, error } = await GalaxyApi().GET("/api/pages", {
-        params: {
-            query: {
-                limit,
-                offset,
-                search: search,
-                sort_by: sort_by as SortKeyLiteral,
-                sort_desc,
-                show_own: false,
-                show_published: true,
-                show_shared: true,
-            },
-        },
+    const { data, totalMatches } = await loadPages({
+        limit,
+        offset,
+        search,
+        sortBy: sort_by as PageSortBy,
+        sortDesc: sort_desc,
+        showOwn: false,
+        showShared: true,
+        showPublished: true,
     });
 
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
     return [data, totalMatches];
 }
 

--- a/client/src/components/Grid/configs/visualizations.ts
+++ b/client/src/components/Grid/configs/visualizations.ts
@@ -2,8 +2,8 @@ import { faCopy, faEdit, faEye, faPlus, faShareAlt, faTrash, faTrashRestore } fr
 import { useEventBus } from "@vueuse/core";
 import axios from "axios";
 
-import { GalaxyApi } from "@/api";
 import { updateTags } from "@/api/tags";
+import { loadVisualizations, type VisualizationSortByLiteral } from "@/api/visualizations";
 import Filtering, { contains, equals, expandNameTag, toBool, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
@@ -15,33 +15,23 @@ const { emit } = useEventBus<string>("grid-router-push");
 /**
  * Local types
  */
-type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
 type VisualizationEntry = Record<string, unknown>;
 
 /**
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    const { response, data, error } = await GalaxyApi().GET("/api/visualizations", {
-        params: {
-            query: {
-                limit,
-                offset,
-                search,
-                sort_by: sort_by as SortKeyLiteral,
-                sort_desc,
-                show_published: false,
-                show_own: true,
-                show_shared: false,
-            },
-        },
+    const { data, totalMatches } = await loadVisualizations({
+        limit,
+        offset,
+        search,
+        sortBy: sort_by as VisualizationSortByLiteral,
+        sortDesc: sort_desc,
+        showOwn: true,
+        showPublished: false,
+        showShared: false,
     });
 
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
     return [data, totalMatches];
 }
 

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -1,9 +1,8 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { GalaxyApi } from "@/api";
+import { loadVisualizations, type VisualizationSortByLiteral } from "@/api/visualizations";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
-import { rethrowSimple } from "@/utils/simple-error";
 
 import type { FieldArray, GridConfig } from "./types";
 
@@ -12,33 +11,23 @@ const { emit } = useEventBus<string>("grid-router-push");
 /**
  * Local types
  */
-type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
 type VisualizationEntry = Record<string, unknown>;
 
 /**
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    const { response, data, error } = await GalaxyApi().GET("/api/visualizations", {
-        params: {
-            query: {
-                limit,
-                offset,
-                search,
-                sort_by: sort_by as SortKeyLiteral,
-                sort_desc,
-                show_own: false,
-                show_published: true,
-                show_shared: true,
-            },
-        },
+    const { data, totalMatches } = await loadVisualizations({
+        limit,
+        offset,
+        search,
+        sortBy: sort_by as VisualizationSortByLiteral,
+        sortDesc: sort_desc,
+        showOwn: false,
+        showPublished: true,
+        showShared: true,
     });
 
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
     return [data, totalMatches];
 }
 

--- a/client/src/components/Grid/configs/visualizationsShared.ts
+++ b/client/src/components/Grid/configs/visualizationsShared.ts
@@ -1,9 +1,8 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { GalaxyApi } from "@/api";
+import { loadVisualizations, type VisualizationSortByLiteral } from "@/api/visualizations";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
-import { rethrowSimple } from "@/utils/simple-error";
 
 import type { FieldArray, GridConfig } from "./types";
 
@@ -12,33 +11,23 @@ const { emit } = useEventBus<string>("grid-router-push");
 /**
  * Local types
  */
-type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
 type VisualizationEntry = Record<string, unknown>;
 
 /**
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    const { response, data, error } = await GalaxyApi().GET("/api/visualizations", {
-        params: {
-            query: {
-                limit,
-                offset,
-                search,
-                sort_by: sort_by as SortKeyLiteral,
-                sort_desc,
-                show_own: false,
-                show_published: false,
-                show_shared: true,
-            },
-        },
+    const { data, totalMatches } = await loadVisualizations({
+        limit,
+        offset,
+        search,
+        sortBy: sort_by as VisualizationSortByLiteral,
+        sortDesc: sort_desc,
+        showOwn: false,
+        showPublished: false,
+        showShared: true,
     });
 
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
     return [data, totalMatches];
 }
 

--- a/client/src/stores/datasetListStore.test.ts
+++ b/client/src/stores/datasetListStore.test.ts
@@ -1,0 +1,146 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HDASummary } from "@/api";
+import { loadDatasets, type LoadDatasetsResult } from "@/api/datasets";
+
+import { useDatasetListStore } from "./datasetListStore";
+
+vi.mock("@/api/datasets");
+
+const mockLoadDatasets = vi.mocked(loadDatasets);
+
+function mockSummary(id: string, name = `dataset ${id}`): HDASummary {
+    return {
+        id,
+        name,
+        history_content_type: "dataset",
+        hid: 1,
+        history_id: "h1",
+        deleted: false,
+        visible: true,
+        state: "ok",
+        update_time: "2026-08-01T10:00:00.000Z",
+        create_time: "2026-08-01T10:00:00.000Z",
+    } as HDASummary;
+}
+
+function mockResult(data: HDASummary[], totalMatches = data.length): LoadDatasetsResult {
+    return { data, totalMatches };
+}
+
+describe("useDatasetListStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        mockLoadDatasets.mockReset();
+    });
+
+    it("fetches the latest datasets and caches them by id", async () => {
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("1"), mockSummary("2")], 7));
+        const store = useDatasetListStore();
+
+        const fetched = await store.fetchDatasets({ limit: 5 });
+
+        expect(mockLoadDatasets).toHaveBeenCalledWith({
+            sortBy: "update_time",
+            sortDesc: true,
+            limit: 5,
+            search: "",
+        });
+        expect(fetched).toHaveLength(2);
+        expect(Object.keys(store.storedDatasets)).toEqual(["1", "2"]);
+        expect(store.latestDatasetIds).toEqual(["1", "2"]);
+        expect(store.latestDatasets.map((dataset) => dataset.id)).toEqual(["1", "2"]);
+        expect(store.totalLatestMatches).toBe(7);
+        expect(store.hasLoadedLatest).toBe(true);
+        expect(store.isLoading).toBe(false);
+    });
+
+    it("merges repeated fetches into the cache without duplicating entries", async () => {
+        const store = useDatasetListStore();
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("1"), mockSummary("2")]));
+        await store.fetchDatasets();
+
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("2", "renamed"), mockSummary("3")]));
+        await store.fetchDatasets();
+
+        expect(Object.keys(store.storedDatasets).sort()).toEqual(["1", "2", "3"]);
+        expect(store.getDatasetSummary("2")?.name).toBe("renamed");
+        expect(store.latestDatasetIds).toEqual(["2", "3"]);
+    });
+
+    it("dedupes ids returned within a single response", async () => {
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("1"), mockSummary("1")]));
+        const store = useDatasetListStore();
+
+        await store.fetchDatasets();
+
+        expect(store.latestDatasetIds).toEqual(["1"]);
+        expect(store.latestDatasets).toHaveLength(1);
+    });
+
+    it("keeps the latest list untouched for searched fetches but still caches results", async () => {
+        const store = useDatasetListStore();
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("1")], 1));
+        await store.fetchDatasets();
+
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("9", "needle")], 1));
+        const found = await store.fetchDatasets({ search: "needle" });
+
+        expect(mockLoadDatasets).toHaveBeenLastCalledWith({
+            sortBy: "update_time",
+            sortDesc: true,
+            limit: 25,
+            search: "needle",
+        });
+        expect(found.map((dataset) => dataset.id)).toEqual(["9"]);
+        expect(store.latestDatasetIds).toEqual(["1"]);
+        expect(store.getDatasetSummary("9")?.name).toBe("needle");
+    });
+
+    it("ensureLatestLoaded only fetches once", async () => {
+        mockLoadDatasets.mockResolvedValue(mockResult([mockSummary("1")]));
+        const store = useDatasetListStore();
+
+        const first = await store.ensureLatestLoaded();
+        const second = await store.ensureLatestLoaded();
+
+        expect(mockLoadDatasets).toHaveBeenCalledTimes(1);
+        expect(first.map((dataset) => dataset.id)).toEqual(["1"]);
+        expect(second).toEqual(first);
+    });
+
+    it("records the error message and returns an empty list when the request fails", async () => {
+        mockLoadDatasets.mockRejectedValue(new Error("boom"));
+        const store = useDatasetListStore();
+
+        const result = await store.fetchDatasets();
+
+        expect(result).toEqual([]);
+        expect(store.loadError).toBe("boom");
+        expect(store.hasLoadedLatest).toBe(false);
+        expect(store.isLoading).toBe(false);
+    });
+
+    it("filters the cache client-side by name", async () => {
+        const store = useDatasetListStore();
+        store.saveDatasets([
+            mockSummary("1", "Alpha reads"),
+            mockSummary("2", "Beta reads"),
+            mockSummary("3", "Gamma"),
+        ]);
+
+        expect(store.searchCachedDatasets("beta").map((dataset) => dataset.id)).toEqual(["2"]);
+        expect(store.searchCachedDatasets("reads")).toHaveLength(2);
+        expect(store.searchCachedDatasets("", 2)).toHaveLength(2);
+        expect(store.searchCachedDatasets("nope")).toEqual([]);
+    });
+
+    it("ignores entries without an id when saving", () => {
+        const store = useDatasetListStore();
+
+        store.saveDatasets([mockSummary("1"), { name: "no id" } as HDASummary]);
+
+        expect(Object.keys(store.storedDatasets)).toEqual(["1"]);
+    });
+});

--- a/client/src/stores/datasetListStore.ts
+++ b/client/src/stores/datasetListStore.ts
@@ -38,9 +38,12 @@ export const useDatasetListStore = defineStore("datasetListStore", () => {
             .filter((dataset): dataset is HDASummary => Boolean(dataset)),
     );
 
-    function getDatasetSummary(id: string): HDASummary | undefined {
-        return storedDatasets.value[id];
-    }
+    /** Getter, not an action: reading the cache never touches the backend. */
+    const getDatasetSummary = computed(
+        () =>
+            (id: string): HDASummary | undefined =>
+                storedDatasets.value[id],
+    );
 
     /** Merges dataset summaries into the cache, keyed (and deduped) by id. */
     function saveDatasets(datasets: HDASummary[]) {
@@ -91,13 +94,17 @@ export const useDatasetListStore = defineStore("datasetListStore", () => {
         return latestDatasets.value;
     }
 
-    /** Client-side name filter over everything currently cached. */
-    function searchCachedDatasets(query: string, limit = DEFAULT_LIMIT): HDASummary[] {
+    /**
+     * Client-side name filter over everything currently cached. A getter rather
+     * than an action, so consumers that must not hit the backend (the command
+     * palette's unscoped fan-out) cannot accidentally trigger a request.
+     */
+    const searchCachedDatasets = computed(() => (query: string, limit = DEFAULT_LIMIT): HDASummary[] => {
         const term = query.trim().toLowerCase();
         const cached = Object.values(storedDatasets.value);
         const matches = term ? cached.filter((dataset) => dataset.name?.toLowerCase().includes(term)) : cached;
         return matches.slice(0, limit);
-    }
+    });
 
     return {
         storedDatasets,

--- a/client/src/stores/datasetListStore.ts
+++ b/client/src/stores/datasetListStore.ts
@@ -1,0 +1,120 @@
+import { defineStore } from "pinia";
+import { computed, ref, set } from "vue";
+
+import type { HDASummary } from "@/api";
+import { loadDatasets } from "@/api/datasets";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+/** Number of dataset summaries fetched when hydrating the "latest" list. */
+const DEFAULT_LIMIT = 25;
+
+export interface FetchDatasetsOptions {
+    /** Free text matched against the dataset name (server-side `name-contains`). */
+    search?: string;
+    /** Maximum number of datasets to request. */
+    limit?: number;
+}
+
+/**
+ * Caches dataset *summaries* (`HDASummary`) for list-like consumers such as the
+ * command palette. Detailed datasets (`HDADetailed`) keep living in
+ * `datasetStore`; this store only holds the lightweight list representation and
+ * the ordering of the most recently updated datasets.
+ */
+export const useDatasetListStore = defineStore("datasetListStore", () => {
+    const storedDatasets = ref<Record<string, HDASummary>>({});
+    /** Dataset ids ordered by `update_time` descending, as returned by the API. */
+    const latestDatasetIds = ref<string[]>([]);
+    const isLoading = ref(false);
+    const loadError = ref<string | undefined>(undefined);
+    /** Whether the unfiltered "latest" list has been fetched at least once. */
+    const hasLoadedLatest = ref(false);
+    /** Total number of datasets matching the last unfiltered fetch. */
+    const totalLatestMatches = ref(0);
+
+    const latestDatasets = computed<HDASummary[]>(() =>
+        latestDatasetIds.value
+            .map((id) => storedDatasets.value[id])
+            .filter((dataset): dataset is HDASummary => Boolean(dataset)),
+    );
+
+    function getDatasetSummary(id: string): HDASummary | undefined {
+        return storedDatasets.value[id];
+    }
+
+    /** Merges dataset summaries into the cache, keyed (and deduped) by id. */
+    function saveDatasets(datasets: HDASummary[]) {
+        for (const dataset of datasets) {
+            if (!dataset?.id) {
+                continue;
+            }
+            set(storedDatasets.value, dataset.id, dataset);
+        }
+    }
+
+    /**
+     * Fetches dataset summaries and merges them into the cache. Unfiltered
+     * fetches also (re)define the ordered "latest" list.
+     */
+    async function fetchDatasets(options: FetchDatasetsOptions = {}): Promise<HDASummary[]> {
+        const { search = "", limit = DEFAULT_LIMIT } = options;
+        isLoading.value = true;
+        loadError.value = undefined;
+        try {
+            const { data, totalMatches } = await loadDatasets({
+                sortBy: "update_time",
+                sortDesc: true,
+                limit,
+                search,
+            });
+            saveDatasets(data);
+            if (!search) {
+                latestDatasetIds.value = dedupeIds(data.map((dataset) => dataset.id));
+                totalLatestMatches.value = totalMatches;
+                hasLoadedLatest.value = true;
+            }
+            return data;
+        } catch (error) {
+            loadError.value = errorMessageAsString(error);
+            return [];
+        } finally {
+            isLoading.value = false;
+        }
+    }
+
+    /** Fetches the latest datasets once; later calls resolve from the cache. */
+    async function ensureLatestLoaded(limit = DEFAULT_LIMIT): Promise<HDASummary[]> {
+        if (hasLoadedLatest.value) {
+            return latestDatasets.value;
+        }
+        await fetchDatasets({ limit });
+        return latestDatasets.value;
+    }
+
+    /** Client-side name filter over everything currently cached. */
+    function searchCachedDatasets(query: string, limit = DEFAULT_LIMIT): HDASummary[] {
+        const term = query.trim().toLowerCase();
+        const cached = Object.values(storedDatasets.value);
+        const matches = term ? cached.filter((dataset) => dataset.name?.toLowerCase().includes(term)) : cached;
+        return matches.slice(0, limit);
+    }
+
+    return {
+        storedDatasets,
+        latestDatasetIds,
+        latestDatasets,
+        isLoading,
+        loadError,
+        hasLoadedLatest,
+        totalLatestMatches,
+        getDatasetSummary,
+        saveDatasets,
+        fetchDatasets,
+        ensureLatestLoaded,
+        searchCachedDatasets,
+    };
+});
+
+function dedupeIds(ids: string[]): string[] {
+    return Array.from(new Set(ids));
+}

--- a/client/src/stores/historyStore.lists.test.ts
+++ b/client/src/stores/historyStore.lists.test.ts
@@ -244,6 +244,35 @@ describe("historyStore — cached history listings", () => {
         expect(first).toEqual(second);
     });
 
+    it("hydrates the canonical listing independently of a one-off search", async () => {
+        const store = useHistoryStore();
+        let resolveSearch: (result: { data: AnyHistoryEntry[]; total: number }) => void = () => undefined;
+        let resolveCanonical: (result: { data: AnyHistoryEntry[]; total: number }) => void = () => undefined;
+        getSharedHistories.mockImplementation(({ search }: { search: string }) => {
+            return new Promise((resolve) => {
+                if (search) {
+                    resolveSearch = resolve;
+                } else {
+                    resolveCanonical = resolve;
+                }
+            });
+        });
+
+        const search = store.fetchHistoryList("shared", { search: "needle", record: false });
+        const hydration = store.ensureHistoryListLoaded("shared");
+
+        expect(getSharedHistories).toHaveBeenCalledTimes(2);
+        resolveSearch(resultOf([mockHistory("search-hit", "Needle", "2026-01-01T00:00:00")], 1));
+        resolveCanonical(resultOf([mockHistory("canonical-hit", "Latest", "2026-02-01T00:00:00")], 5));
+        const [, canonical] = await Promise.all([search, hydration]);
+
+        expect(canonical.map((history) => history.id)).toEqual(["canonical-hit"]);
+        expect(store.listedHistoryIds.shared).toEqual(["canonical-hit"]);
+        expect(store.listedHistories["search-hit"]).toBeDefined();
+        expect(store.getHistoryListTotal("shared")).toBe(5);
+        expect(store.hasLoadedHistoryList("shared")).toBe(true);
+    });
+
     it("re-fetches after the cached listing has been cleared", async () => {
         const store = useHistoryStore();
         getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));

--- a/client/src/stores/historyStore.lists.test.ts
+++ b/client/src/stores/historyStore.lists.test.ts
@@ -215,6 +215,35 @@ describe("historyStore — cached history listings", () => {
         expect(cached.map((history) => history.id)).toEqual(["h1"]);
     });
 
+    it("shares a running fetch instead of returning the still empty listing", async () => {
+        const store = useHistoryStore();
+        let resolveFetch: (result: { data: AnyHistoryEntry[]; total: number }) => void = () => undefined;
+        getSharedHistories.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFetch = resolve;
+            }),
+        );
+
+        const hydrating = store.ensureHistoryListLoaded("shared");
+        const duringFetch = store.ensureHistoryListLoaded("shared");
+        resolveFetch(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));
+        const [first, second] = await Promise.all([hydrating, duringFetch]);
+
+        expect(getSharedHistories).toHaveBeenCalledTimes(1);
+        expect(first.map((history) => history.id)).toEqual(["h1"]);
+        expect(second.map((history) => history.id)).toEqual(["h1"]);
+    });
+
+    it("deduplicates identical concurrent fetches of a listing", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));
+
+        const [first, second] = await Promise.all([store.fetchHistoryList("shared"), store.fetchHistoryList("shared")]);
+
+        expect(getSharedHistories).toHaveBeenCalledTimes(1);
+        expect(first).toEqual(second);
+    });
+
     it("re-fetches after the cached listing has been cleared", async () => {
         const store = useHistoryStore();
         getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));

--- a/client/src/stores/historyStore.lists.test.ts
+++ b/client/src/stores/historyStore.lists.test.ts
@@ -1,0 +1,231 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AnyHistoryEntry } from "@/api/histories";
+
+import { sseMockFactory } from "./_testing/sseStoreSupport";
+import { useHistoryStore } from "./historyStore";
+
+const sseState = vi.hoisted(() => {
+    return {
+        onEvent: null as ((event: MessageEvent) => void) | null,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+    };
+});
+
+vi.mock("@/composables/useNotificationSSE", () => sseMockFactory(sseState));
+
+vi.mock("@/watch/watchHistory", () => ({
+    ACTIVE_POLLING_INTERVAL: 3000,
+    INACTIVE_POLLING_INTERVAL: 60_000,
+    watchHistory: vi.fn().mockResolvedValue(undefined),
+    refreshHistoryFromPush: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/app", () => ({
+    getGalaxyInstance: () => ({ name: "fake-galaxy" }),
+}));
+
+const { getSharedHistories, getPublishedHistories, getArchivedHistories } = vi.hoisted(() => ({
+    getSharedHistories: vi.fn(),
+    getPublishedHistories: vi.fn(),
+    getArchivedHistories: vi.fn(),
+}));
+
+vi.mock("@/api/histories", () => ({
+    getSharedHistories,
+    getPublishedHistories,
+    getArchivedHistories,
+}));
+
+function mockHistory(id: string, name: string, updateTime: string, extra: Record<string, unknown> = {}) {
+    return {
+        id,
+        name,
+        model_class: "History",
+        update_time: updateTime,
+        username: "other-user",
+        ...extra,
+    } as unknown as AnyHistoryEntry;
+}
+
+function resultOf(histories: AnyHistoryEntry[], total = histories.length) {
+    return { data: histories, total };
+}
+
+describe("historyStore — cached history listings", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.clearAllMocks();
+        getSharedHistories.mockResolvedValue(resultOf([]));
+        getPublishedHistories.mockResolvedValue(resultOf([]));
+        getArchivedHistories.mockResolvedValue(resultOf([]));
+    });
+
+    it("fetches shared histories with update_time descending defaults", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "Shared", "2026-01-01T00:00:00")], 12));
+
+        const fetched = await store.fetchHistoryList("shared");
+
+        expect(getSharedHistories).toHaveBeenCalledWith({
+            limit: 25,
+            offset: 0,
+            search: "",
+            sortBy: "update_time",
+            sortDesc: true,
+        });
+        expect(fetched.map((history) => history.id)).toEqual(["h1"]);
+        expect(store.sharedHistories.map((history) => history.id)).toEqual(["h1"]);
+        expect(store.getHistoryListTotal("shared")).toBe(12);
+        expect(store.hasLoadedHistoryList("shared")).toBe(true);
+    });
+
+    it("forwards an optional search query and pagination options", async () => {
+        const store = useHistoryStore();
+
+        await store.fetchHistoryList("published", { search: "rna", limit: 5, offset: 10, sortBy: "name" });
+
+        expect(getPublishedHistories).toHaveBeenCalledWith({
+            limit: 5,
+            offset: 10,
+            search: "rna",
+            sortBy: "name",
+            sortDesc: true,
+        });
+    });
+
+    it("fetches archived histories through the archived endpoint wrapper", async () => {
+        const store = useHistoryStore();
+        getArchivedHistories.mockResolvedValue(
+            resultOf([mockHistory("a1", "Archived", "2026-01-01T00:00:00", { archived: true })]),
+        );
+
+        await store.fetchHistoryList("archived");
+
+        expect(getArchivedHistories).toHaveBeenCalledTimes(1);
+        expect(store.archivedHistories.map((history) => history.id)).toEqual(["a1"]);
+    });
+
+    it("sorts cached entries by update time, most recent first", async () => {
+        const store = useHistoryStore();
+        getPublishedHistories.mockResolvedValue(
+            resultOf([
+                mockHistory("old", "Old", "2026-01-01T00:00:00"),
+                mockHistory("new", "New", "2026-03-01T00:00:00"),
+                mockHistory("mid", "Mid", "2026-02-01T00:00:00"),
+            ]),
+        );
+
+        await store.fetchHistoryList("published");
+
+        expect(store.publishedHistories.map((history) => history.id)).toEqual(["new", "mid", "old"]);
+    });
+
+    it("merges repeated fetches without duplicating ids", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValueOnce(
+            resultOf([
+                mockHistory("h1", "One", "2026-01-01T00:00:00"),
+                mockHistory("h2", "Two", "2026-01-02T00:00:00"),
+            ]),
+        );
+        getSharedHistories.mockResolvedValueOnce(
+            resultOf([
+                mockHistory("h2", "Two", "2026-01-02T00:00:00"),
+                mockHistory("h3", "Three", "2026-01-03T00:00:00"),
+            ]),
+        );
+
+        await store.fetchHistoryList("shared");
+        await store.fetchHistoryList("shared", { search: "t" });
+
+        expect(store.listedHistoryIds.shared).toEqual(["h1", "h2", "h3"]);
+        expect(store.sharedHistories).toHaveLength(3);
+    });
+
+    it("keeps already cached fields when a later fetch returns a leaner summary", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValueOnce(
+            resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00", { owner: "someone" })]),
+        );
+        getSharedHistories.mockResolvedValueOnce(resultOf([mockHistory("h1", "One renamed", "2026-01-05T00:00:00")]));
+
+        await store.fetchHistoryList("shared");
+        await store.fetchHistoryList("shared");
+
+        const cached = store.listedHistories["h1"] as AnyHistoryEntry & { owner?: string };
+        expect(cached.owner).toBe("someone");
+        expect(cached.name).toBe("One renamed");
+    });
+
+    it("replaces the cached ids of a listing when asked to", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValueOnce(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));
+        getSharedHistories.mockResolvedValueOnce(resultOf([mockHistory("h2", "Two", "2026-01-02T00:00:00")]));
+
+        await store.fetchHistoryList("shared");
+        await store.fetchHistoryList("shared", { replace: true });
+
+        expect(store.listedHistoryIds.shared).toEqual(["h2"]);
+    });
+
+    it("keeps the listings separate while sharing a single summary map", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "Shared", "2026-01-01T00:00:00")]));
+        getPublishedHistories.mockResolvedValue(resultOf([mockHistory("h1", "Shared", "2026-01-01T00:00:00")]));
+
+        await store.fetchHistoryList("shared");
+        await store.fetchHistoryList("published");
+
+        expect(store.listedHistoryIds.shared).toEqual(["h1"]);
+        expect(store.listedHistoryIds.published).toEqual(["h1"]);
+        expect(store.listedHistoryIds.archived).toEqual([]);
+        expect(Object.keys(store.listedHistories)).toEqual(["h1"]);
+    });
+
+    it("never adds listed histories to the current user's own histories", async () => {
+        const store = useHistoryStore();
+        getPublishedHistories.mockResolvedValue(resultOf([mockHistory("foreign", "Someone else", "2026-01-01")]));
+
+        await store.fetchHistoryList("published");
+
+        expect(store.histories).toEqual([]);
+        expect(store.storedHistories).toEqual({});
+    });
+
+    it("clears the loading flag and rethrows when a fetch fails", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockRejectedValue(new Error("boom"));
+
+        await expect(store.fetchHistoryList("shared")).rejects.toThrow();
+        expect(store.isHistoryListLoading("shared")).toBe(false);
+        expect(store.hasLoadedHistoryList("shared")).toBe(false);
+    });
+
+    it("only fetches a listing once via ensureHistoryListLoaded", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));
+
+        await store.ensureHistoryListLoaded("shared");
+        const cached = await store.ensureHistoryListLoaded("shared");
+
+        expect(getSharedHistories).toHaveBeenCalledTimes(1);
+        expect(cached.map((history) => history.id)).toEqual(["h1"]);
+    });
+
+    it("re-fetches after the cached listing has been cleared", async () => {
+        const store = useHistoryStore();
+        getSharedHistories.mockResolvedValue(resultOf([mockHistory("h1", "One", "2026-01-01T00:00:00")]));
+
+        await store.ensureHistoryListLoaded("shared");
+        store.clearHistoryList("shared");
+
+        expect(store.sharedHistories).toEqual([]);
+        expect(store.getHistoryListTotal("shared")).toBe(0);
+
+        await store.ensureHistoryListLoaded("shared");
+        expect(getSharedHistories).toHaveBeenCalledTimes(2);
+    });
+});

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -628,13 +628,16 @@ export const useHistoryStore = defineStore("historyStore", () => {
      * Fetches a history listing only if it has not been fetched before, so that
      * consumers can hydrate a listing without hitting the backend repeatedly.
      *
-     * An identical canonical fetch already in progress is shared by
-     * `fetchHistoryList`; one-off searches use a different request key and do
-     * not suppress canonical hydration.
+     * An identical fetch already in progress is shared by `fetchHistoryList`;
+     * one-off searches use a different request key and do not suppress canonical
+     * hydration. Always records, so that the listing it returns is the one it
+     * hydrated.
+     *
+     * @returns the whole cached listing, not just the entries this call fetched
      */
     async function ensureHistoryListLoaded(
         variant: HistoryListVariant,
-        options: FetchHistoryListOptions = {},
+        options: Omit<FetchHistoryListOptions, "record"> = {},
     ): Promise<AnyHistoryEntry[]> {
         if (listedHistoriesLoaded.value[variant]) {
             return getListedHistories.value(variant);

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -81,6 +81,8 @@ export interface FetchHistoryListOptions {
     sortDesc?: boolean;
     /** Discard the cached ids of this variant instead of merging into them. */
     replace?: boolean;
+    /** Merge summaries by id without recording this request as the canonical variant listing. */
+    record?: boolean;
 }
 
 function emptyHistoryListIds(): Record<HistoryListVariant, string[]> {
@@ -120,7 +122,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
     /** In-flight own-history loads, keyed by request (see `loadHistories`). */
     const loadHistoriesPromises = new Map<string, Promise<void>>();
     /** In-flight listing fetches, keyed by request (see `fetchHistoryList`). */
-    const listPromises = new Map<string, { variant: HistoryListVariant; promise: Promise<AnyHistoryEntry[]> }>();
+    const listPromises = new Map<string, Promise<AnyHistoryEntry[]>>();
 
     const histories = computed(() => {
         return Object.values(storedHistories.value)
@@ -521,11 +523,8 @@ export const useHistoryStore = defineStore("historyStore", () => {
         return promise;
     }
 
-    /**
-     * Merges fetched entries into the shared summary map and updates the
-     * ordered id list of the given variant, keeping ids unique.
-     */
-    function setListedHistories(variant: HistoryListVariant, histories: AnyHistoryEntry[], replace = false) {
+    /** Merges fetched entries into the shared summary map without changing a variant listing. */
+    function mergeListedHistories(histories: AnyHistoryEntry[]) {
         histories.forEach((history) => {
             const storedHistory = listedHistories.value[history.id];
             // Incoming summaries may carry fewer fields than what is already
@@ -533,6 +532,11 @@ export const useHistoryStore = defineStore("historyStore", () => {
             // instead of overwriting.
             set(listedHistories.value, history.id, storedHistory ? { ...storedHistory, ...history } : history);
         });
+    }
+
+    /** Records fetched entries in the ordered id list of a variant, keeping ids unique. */
+    function setListedHistories(variant: HistoryListVariant, histories: AnyHistoryEntry[], replace = false) {
+        mergeListedHistories(histories);
         const incomingIds = histories.map((history) => history.id);
         const mergedIds = replace ? incomingIds : [...listedHistoryIds.value[variant], ...incomingIds];
         listedHistoryIds.value[variant] = Array.from(new Set(mergedIds));
@@ -558,19 +562,23 @@ export const useHistoryStore = defineStore("historyStore", () => {
             sortBy = "update_time",
             sortDesc = true,
             replace = false,
+            record = true,
         } = options;
-        const key = [variant, search, limit, offset, sortBy, sortDesc, replace].join("|");
+        const key = [variant, search, limit, offset, sortBy, sortDesc, replace, record].join("|");
 
         const pending = listPromises.get(key);
         if (pending) {
-            return pending.promise;
+            return pending;
         }
-        const promise = requestHistoryList(variant, { search, limit, offset, sortBy, sortDesc }, replace).finally(
-            () => {
-                listPromises.delete(key);
-            },
-        );
-        listPromises.set(key, { variant, promise });
+        const promise = requestHistoryList(
+            variant,
+            { search, limit, offset, sortBy, sortDesc },
+            replace,
+            record,
+        ).finally(() => {
+            listPromises.delete(key);
+        });
+        listPromises.set(key, promise);
         return promise;
     }
 
@@ -585,8 +593,11 @@ export const useHistoryStore = defineStore("historyStore", () => {
             sortDesc: boolean;
         },
         replace: boolean,
+        record: boolean,
     ): Promise<AnyHistoryEntry[]> {
-        listedHistoriesLoading.value[variant] = true;
+        if (record) {
+            listedHistoriesLoading.value[variant] = true;
+        }
         try {
             let result: { data: AnyHistoryEntry[]; total: number };
             if (variant === "shared") {
@@ -596,48 +607,40 @@ export const useHistoryStore = defineStore("historyStore", () => {
             } else {
                 result = await getArchivedHistories(requestOptions);
             }
-            setListedHistories(variant, result.data, replace);
-            listedHistoriesTotal.value[variant] = result.total;
-            listedHistoriesLoaded.value[variant] = true;
+            if (record) {
+                setListedHistories(variant, result.data, replace);
+                listedHistoriesTotal.value[variant] = result.total;
+                listedHistoriesLoaded.value[variant] = true;
+            } else {
+                mergeListedHistories(result.data);
+            }
             return result.data.map((history) => listedHistories.value[history.id] ?? history);
         } catch (error) {
-            rethrowSimple(error);
+            return rethrowSimple(error);
         } finally {
-            listedHistoriesLoading.value[variant] = false;
-        }
-    }
-
-    /** The request currently running for a listing, whatever its options. */
-    function pendingHistoryListFetch(variant: HistoryListVariant): Promise<AnyHistoryEntry[]> | undefined {
-        for (const pending of listPromises.values()) {
-            if (pending.variant === variant) {
-                return pending.promise;
+            if (record) {
+                listedHistoriesLoading.value[variant] = false;
             }
         }
-        return undefined;
     }
 
     /**
      * Fetches a history listing only if it has not been fetched before, so that
      * consumers can hydrate a listing without hitting the backend repeatedly.
      *
-     * A fetch that is already running is awaited rather than skipped: returning
-     * the (still empty) cache early would tell the caller the listing is loaded
-     * and leave it rendering "no results" until something else refetches.
+     * An identical canonical fetch already in progress is shared by
+     * `fetchHistoryList`; one-off searches use a different request key and do
+     * not suppress canonical hydration.
      */
     async function ensureHistoryListLoaded(
         variant: HistoryListVariant,
         options: FetchHistoryListOptions = {},
     ): Promise<AnyHistoryEntry[]> {
-        const pending = pendingHistoryListFetch(variant);
-        if (pending) {
-            await pending;
-            return getListedHistories.value(variant);
-        }
         if (listedHistoriesLoaded.value[variant]) {
             return getListedHistories.value(variant);
         }
-        return fetchHistoryList(variant, options);
+        await fetchHistoryList(variant, { ...options, record: true });
+        return getListedHistories.value(variant);
     }
 
     /** Drops the cached ids of a listing (the summaries themselves are kept). */

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -45,7 +45,12 @@ import {
 } from "@/watch/watchHistory";
 
 const PAGINATION_LIMIT = 10;
-const isLoadingHistory = new Set<string>();
+/**
+ * In-flight single history loads, keyed by id. The promise (rather than a bare
+ * "is loading" flag) is kept so a second caller awaits the running request
+ * instead of returning before its result reached the cache.
+ */
+const historyPromises = new Map<string, Promise<void>>();
 const retryCounts: { [key: string]: number } = {};
 const CONTENT_STATS_KEYS = ["size", "contents_active", "update_time"] as const;
 
@@ -112,6 +117,10 @@ export const useHistoryStore = defineStore("historyStore", () => {
     const listedHistoriesLoading = ref<Record<HistoryListVariant, boolean>>(historyListFlags(false));
     const listedHistoriesLoaded = ref<Record<HistoryListVariant, boolean>>(historyListFlags(false));
     const listedHistoriesTotal = ref<Record<HistoryListVariant, number>>(historyListCounts());
+    /** In-flight own-history loads, keyed by request (see `loadHistories`). */
+    const loadHistoriesPromises = new Map<string, Promise<void>>();
+    /** In-flight listing fetches, keyed by request (see `fetchHistoryList`). */
+    const listPromises = new Map<string, { variant: HistoryListVariant; promise: Promise<AnyHistoryEntry[]> }>();
 
     const histories = computed(() => {
         return Object.values(storedHistories.value)
@@ -458,35 +467,58 @@ export const useHistoryStore = defineStore("historyStore", () => {
      * - not handling filters with pagination for now
      *   "pausing" pagination at the existing offset if a filter exists
      */
-    async function loadHistories(paginate = true, queryString?: string) {
-        if (!historiesLoading.value) {
-            setHistoriesLoading(true);
-            let limit: number | null = null;
-            if (!queryString || queryString == "") {
-                if (paginate) {
-                    await loadTotalHistoryCount();
-                    if (historiesOffset.value >= totalHistoryCount.value) {
-                        setHistoriesLoading(false);
-                        return;
-                    }
-                    limit = PAGINATION_LIMIT;
-                } else {
-                    historiesOffset.value = 0;
+    async function fetchHistories(paginate: boolean, queryString?: string) {
+        setHistoriesLoading(true);
+        let limit: number | null = null;
+        if (!queryString || queryString == "") {
+            if (paginate) {
+                await loadTotalHistoryCount();
+                if (historiesOffset.value >= totalHistoryCount.value) {
+                    setHistoriesLoading(false);
+                    return;
                 }
-            }
-            const offset = queryString ? 0 : historiesOffset.value;
-            try {
-                const histories = (await getHistoryList(offset, limit, queryString)) as HistorySummary[];
-                setHistories(histories);
-                if (paginate && !queryString && historiesOffset.value == offset) {
-                    await handleTotalCountChange(histories.length);
-                }
-            } catch (error) {
-                rethrowSimple(error);
-            } finally {
-                setHistoriesLoading(false);
+                limit = PAGINATION_LIMIT;
+            } else {
+                historiesOffset.value = 0;
             }
         }
+        const offset = queryString ? 0 : historiesOffset.value;
+        try {
+            const histories = (await getHistoryList(offset, limit, queryString)) as HistorySummary[];
+            setHistories(histories);
+            if (paginate && !queryString && historiesOffset.value == offset) {
+                await handleTotalCountChange(histories.length);
+            }
+        } catch (error) {
+            rethrowSimple(error);
+        } finally {
+            setHistoriesLoading(false);
+        }
+    }
+
+    /**
+     * Loads the current user's histories into `storedHistories`.
+     *
+     * Identical calls made while a load is still running share that request and
+     * resolve with it, so a consumer which starts searching while the first
+     * fetch is in flight (the command palette) sees the filled cache instead of
+     * an empty one. A *different* load started meanwhile is still skipped: the
+     * store fetches one own-history list at a time.
+     */
+    function loadHistories(paginate = true, queryString?: string): Promise<void> {
+        const key = `${paginate}|${queryString ?? ""}`;
+        const inFlight = loadHistoriesPromises.get(key);
+        if (inFlight) {
+            return inFlight;
+        }
+        if (historiesLoading.value) {
+            return Promise.resolve();
+        }
+        const promise = fetchHistories(paginate, queryString).finally(() => {
+            loadHistoriesPromises.delete(key);
+        });
+        loadHistoriesPromises.set(key, promise);
+        return promise;
     }
 
     /**
@@ -515,7 +547,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
      * @param options Pagination, sorting and search options
      * @returns The fetched entries, in the order the backend returned them
      */
-    async function fetchHistoryList(
+    function fetchHistoryList(
         variant: HistoryListVariant,
         options: FetchHistoryListOptions = {},
     ): Promise<AnyHistoryEntry[]> {
@@ -527,8 +559,33 @@ export const useHistoryStore = defineStore("historyStore", () => {
             sortDesc = true,
             replace = false,
         } = options;
-        const requestOptions = { limit, offset, search, sortBy, sortDesc };
+        const key = [variant, search, limit, offset, sortBy, sortDesc, replace].join("|");
 
+        const pending = listPromises.get(key);
+        if (pending) {
+            return pending.promise;
+        }
+        const promise = requestHistoryList(variant, { search, limit, offset, sortBy, sortDesc }, replace).finally(
+            () => {
+                listPromises.delete(key);
+            },
+        );
+        listPromises.set(key, { variant, promise });
+        return promise;
+    }
+
+    /** Runs one listing request; `fetchHistoryList` owns the deduplication. */
+    async function requestHistoryList(
+        variant: HistoryListVariant,
+        requestOptions: {
+            search: string;
+            limit: number;
+            offset: number;
+            sortBy: HistorySortByLiteral;
+            sortDesc: boolean;
+        },
+        replace: boolean,
+    ): Promise<AnyHistoryEntry[]> {
         listedHistoriesLoading.value[variant] = true;
         try {
             let result: { data: AnyHistoryEntry[]; total: number };
@@ -550,15 +607,34 @@ export const useHistoryStore = defineStore("historyStore", () => {
         }
     }
 
+    /** The request currently running for a listing, whatever its options. */
+    function pendingHistoryListFetch(variant: HistoryListVariant): Promise<AnyHistoryEntry[]> | undefined {
+        for (const pending of listPromises.values()) {
+            if (pending.variant === variant) {
+                return pending.promise;
+            }
+        }
+        return undefined;
+    }
+
     /**
      * Fetches a history listing only if it has not been fetched before, so that
      * consumers can hydrate a listing without hitting the backend repeatedly.
+     *
+     * A fetch that is already running is awaited rather than skipped: returning
+     * the (still empty) cache early would tell the caller the listing is loaded
+     * and leave it rendering "no results" until something else refetches.
      */
     async function ensureHistoryListLoaded(
         variant: HistoryListVariant,
         options: FetchHistoryListOptions = {},
     ): Promise<AnyHistoryEntry[]> {
-        if (listedHistoriesLoaded.value[variant] || listedHistoriesLoading.value[variant]) {
+        const pending = pendingHistoryListFetch(variant);
+        if (pending) {
+            await pending;
+            return getListedHistories.value(variant);
+        }
+        if (listedHistoriesLoaded.value[variant]) {
             return getListedHistories.value(variant);
         }
         return fetchHistoryList(variant, options);
@@ -689,21 +765,29 @@ export const useHistoryStore = defineStore("historyStore", () => {
     }
 
     async function loadHistoryById(historyId: string) {
-        if (!isLoadingHistory.has(historyId)) {
-            isLoadingHistory.add(historyId);
-            try {
-                const result = await getHistoryByIdFromServer(historyId);
-                if (result.error) {
-                    retryCounts[historyId] = (retryCounts[historyId] ?? 0) + 1;
-                    set(historyLoadErrors.value, historyId, result.error);
-                } else {
-                    setHistory(result.data);
-                    del(historyLoadErrors.value, historyId);
-                    delete retryCounts[historyId];
-                }
-            } finally {
-                isLoadingHistory.delete(historyId);
+        const inFlight = historyPromises.get(historyId);
+        if (inFlight) {
+            // Share the running request: callers that need the name right after
+            // (the command palette's invocation rows) must not resolve before it.
+            await inFlight;
+            return;
+        }
+        const promise = (async () => {
+            const result = await getHistoryByIdFromServer(historyId);
+            if (result.error) {
+                retryCounts[historyId] = (retryCounts[historyId] ?? 0) + 1;
+                set(historyLoadErrors.value, historyId, result.error);
+            } else {
+                setHistory(result.data);
+                del(historyLoadErrors.value, historyId);
+                delete retryCounts[historyId];
             }
+        })();
+        historyPromises.set(historyId, promise);
+        try {
+            await promise;
+        } finally {
+            historyPromises.delete(historyId);
         }
     }
 

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -7,10 +7,17 @@ import {
     type HistoryContentsStats,
     type HistoryDetailed,
     type HistoryDevDetailed,
+    type HistorySortByLiteral,
     type HistorySummary,
     type HistorySummaryExtended,
 } from "@/api";
-import type { UpdateHistoryPayload } from "@/api/histories";
+import {
+    type AnyHistoryEntry,
+    getArchivedHistories,
+    getPublishedHistories,
+    getSharedHistories,
+    type UpdateHistoryPayload,
+} from "@/api/histories";
 import type { ArchivedHistoryDetailed } from "@/api/histories.archived";
 import { getGalaxyInstance } from "@/app";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
@@ -42,6 +49,51 @@ const isLoadingHistory = new Set<string>();
 const retryCounts: { [key: string]: number } = {};
 const CONTENT_STATS_KEYS = ["size", "contents_active", "update_time"] as const;
 
+/** Default number of entries requested per history listing fetch. */
+const HISTORY_LIST_LIMIT = 25;
+
+/**
+ * The cached history listings that are not the current user's own histories.
+ *
+ * Own histories are cached in `storedHistories` (see `loadHistories`), which
+ * also backs the current-history selection. Shared, published and archived
+ * listings are kept apart from it on purpose: they may contain histories owned
+ * by other users, which must never become candidates for the current history.
+ */
+export type HistoryListVariant = "shared" | "published" | "archived";
+
+/** Options for fetching one of the cached history listings. */
+export interface FetchHistoryListOptions {
+    /** Optional free-text search forwarded to the backend. */
+    search?: string;
+    /** Maximum number of entries to fetch. Defaults to `HISTORY_LIST_LIMIT`. */
+    limit?: number;
+    /** Offset of the first entry to fetch. Defaults to `0`. */
+    offset?: number;
+    /** Field to sort by on the backend. Defaults to `update_time`. */
+    sortBy?: HistorySortByLiteral;
+    /** Sort direction on the backend. Defaults to `true` (most recent first). */
+    sortDesc?: boolean;
+    /** Discard the cached ids of this variant instead of merging into them. */
+    replace?: boolean;
+}
+
+function emptyHistoryListIds(): Record<HistoryListVariant, string[]> {
+    return { shared: [], published: [], archived: [] };
+}
+
+function historyListFlags(value: boolean): Record<HistoryListVariant, boolean> {
+    return { shared: value, published: value, archived: value };
+}
+
+function historyListCounts(): Record<HistoryListVariant, number> {
+    return { shared: 0, published: 0, archived: 0 };
+}
+
+function byUpdateTimeDesc(a: AnyHistoryEntry, b: AnyHistoryEntry) {
+    return (b.update_time ?? "").localeCompare(a.update_time ?? "");
+}
+
 export const useHistoryStore = defineStore("historyStore", () => {
     const historiesLoading = ref(false);
     const historiesOffset = ref(0);
@@ -53,6 +105,13 @@ export const useHistoryStore = defineStore("historyStore", () => {
     const historyLoadErrors = ref<{ [key: string]: Error }>({});
     const changingCurrentHistory = ref(false);
     const knownHistorySizes = new Map<string, number>();
+    /** Summaries of every listed history, keyed by id, shared by all variants. */
+    const listedHistories = ref<{ [key: string]: AnyHistoryEntry }>({});
+    /** Ordered (and deduplicated) history ids per cached listing. */
+    const listedHistoryIds = ref<Record<HistoryListVariant, string[]>>(emptyHistoryListIds());
+    const listedHistoriesLoading = ref<Record<HistoryListVariant, boolean>>(historyListFlags(false));
+    const listedHistoriesLoaded = ref<Record<HistoryListVariant, boolean>>(historyListFlags(false));
+    const listedHistoriesTotal = ref<Record<HistoryListVariant, number>>(historyListCounts());
 
     const histories = computed(() => {
         return Object.values(storedHistories.value)
@@ -119,6 +178,39 @@ export const useHistoryStore = defineStore("historyStore", () => {
                 return "...";
             }
         };
+    });
+
+    /**
+     * Returns the cached entries of a history listing, most recently updated
+     * first. The entries returned by `fetchHistoryList` keep the order the
+     * backend replied with instead.
+     */
+    const getListedHistories = computed(() => {
+        return (variant: HistoryListVariant): AnyHistoryEntry[] => {
+            return listedHistoryIds.value[variant]
+                .map((historyId) => listedHistories.value[historyId])
+                .filter((history): history is AnyHistoryEntry => history !== undefined)
+                .sort(byUpdateTimeDesc);
+        };
+    });
+
+    const sharedHistories = computed(() => getListedHistories.value("shared"));
+    const publishedHistories = computed(() => getListedHistories.value("published"));
+    const archivedHistories = computed(() => getListedHistories.value("archived"));
+
+    /** Whether a listing fetch is currently in flight for the given variant. */
+    const isHistoryListLoading = computed(() => {
+        return (variant: HistoryListVariant) => listedHistoriesLoading.value[variant];
+    });
+
+    /** Whether the given listing has been fetched at least once. */
+    const hasLoadedHistoryList = computed(() => {
+        return (variant: HistoryListVariant) => listedHistoriesLoaded.value[variant];
+    });
+
+    /** Total number of entries the backend reported for the given listing. */
+    const getHistoryListTotal = computed(() => {
+        return (variant: HistoryListVariant) => listedHistoriesTotal.value[variant];
     });
 
     async function setCurrentHistory(historyId: string) {
@@ -397,6 +489,88 @@ export const useHistoryStore = defineStore("historyStore", () => {
         }
     }
 
+    /**
+     * Merges fetched entries into the shared summary map and updates the
+     * ordered id list of the given variant, keeping ids unique.
+     */
+    function setListedHistories(variant: HistoryListVariant, histories: AnyHistoryEntry[], replace = false) {
+        histories.forEach((history) => {
+            const storedHistory = listedHistories.value[history.id];
+            // Incoming summaries may carry fewer fields than what is already
+            // cached (e.g. a search result after a detailed listing), so merge
+            // instead of overwriting.
+            set(listedHistories.value, history.id, storedHistory ? { ...storedHistory, ...history } : history);
+        });
+        const incomingIds = histories.map((history) => history.id);
+        const mergedIds = replace ? incomingIds : [...listedHistoryIds.value[variant], ...incomingIds];
+        listedHistoryIds.value[variant] = Array.from(new Set(mergedIds));
+    }
+
+    /**
+     * Fetches one of the cached history listings and merges the result into the
+     * store. Only the entries which are not cached yet are added; already known
+     * histories are updated in place.
+     *
+     * @param variant Which listing to fetch
+     * @param options Pagination, sorting and search options
+     * @returns The fetched entries, in the order the backend returned them
+     */
+    async function fetchHistoryList(
+        variant: HistoryListVariant,
+        options: FetchHistoryListOptions = {},
+    ): Promise<AnyHistoryEntry[]> {
+        const {
+            search = "",
+            limit = HISTORY_LIST_LIMIT,
+            offset = 0,
+            sortBy = "update_time",
+            sortDesc = true,
+            replace = false,
+        } = options;
+        const requestOptions = { limit, offset, search, sortBy, sortDesc };
+
+        listedHistoriesLoading.value[variant] = true;
+        try {
+            let result: { data: AnyHistoryEntry[]; total: number };
+            if (variant === "shared") {
+                result = await getSharedHistories(requestOptions);
+            } else if (variant === "published") {
+                result = await getPublishedHistories(requestOptions);
+            } else {
+                result = await getArchivedHistories(requestOptions);
+            }
+            setListedHistories(variant, result.data, replace);
+            listedHistoriesTotal.value[variant] = result.total;
+            listedHistoriesLoaded.value[variant] = true;
+            return result.data.map((history) => listedHistories.value[history.id] ?? history);
+        } catch (error) {
+            rethrowSimple(error);
+        } finally {
+            listedHistoriesLoading.value[variant] = false;
+        }
+    }
+
+    /**
+     * Fetches a history listing only if it has not been fetched before, so that
+     * consumers can hydrate a listing without hitting the backend repeatedly.
+     */
+    async function ensureHistoryListLoaded(
+        variant: HistoryListVariant,
+        options: FetchHistoryListOptions = {},
+    ): Promise<AnyHistoryEntry[]> {
+        if (listedHistoriesLoaded.value[variant] || listedHistoriesLoading.value[variant]) {
+            return getListedHistories.value(variant);
+        }
+        return fetchHistoryList(variant, options);
+    }
+
+    /** Drops the cached ids of a listing (the summaries themselves are kept). */
+    function clearHistoryList(variant: HistoryListVariant) {
+        listedHistoryIds.value[variant] = [];
+        listedHistoriesLoaded.value[variant] = false;
+        listedHistoriesTotal.value[variant] = 0;
+    }
+
     function watchHistory() {
         const app = getGalaxyInstance();
         return watchHistorySuppliedApp(app);
@@ -664,6 +838,19 @@ export const useHistoryStore = defineStore("historyStore", () => {
         loadCurrentHistoryId,
         loadHistories,
         loadHistoryById,
+        listedHistories,
+        listedHistoryIds,
+        getListedHistories,
+        sharedHistories,
+        publishedHistories,
+        archivedHistories,
+        isHistoryListLoading,
+        hasLoadedHistoryList,
+        getHistoryListTotal,
+        setListedHistories,
+        fetchHistoryList,
+        ensureHistoryListLoaded,
+        clearHistoryList,
         secureHistory,
         updateHistory,
         archiveHistoryById,

--- a/client/src/stores/invocationStore.test.ts
+++ b/client/src/stores/invocationStore.test.ts
@@ -3,7 +3,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { useServerMock } from "@/api/client/__mocks__";
-import type { StepJobSummary, WorkflowJobMetric } from "@/api/invocations";
+import type { StepJobSummary, WorkflowInvocation, WorkflowJobMetric } from "@/api/invocations";
 
 import { useInvocationStore } from "./invocationStore";
 
@@ -25,6 +25,18 @@ function metricsResponse(jobIds: string[]): WorkflowJobMetric[] {
                 job_id,
             }) as unknown as WorkflowJobMetric,
     );
+}
+
+function invocationResponse(id: string, updateTime: string): WorkflowInvocation {
+    return {
+        id,
+        create_time: updateTime,
+        update_time: updateTime,
+        state: "scheduled",
+        history_id: `history-${id}`,
+        workflow_id: `workflow-${id}`,
+        model_class: "WorkflowInvocation",
+    } as unknown as WorkflowInvocation;
 }
 
 describe("stores/invocationStore", () => {
@@ -95,6 +107,107 @@ describe("stores/invocationStore", () => {
             await flushPromises();
 
             expect(metricsCallCount).toBe(1);
+        });
+    });
+
+    describe("fetchLatestInvocations", () => {
+        let invocations: WorkflowInvocation[];
+        let invocationsCallCount: number;
+        let requestedLimits: (string | null)[];
+
+        beforeEach(() => {
+            invocations = [invocationResponse("inv2", "2026-08-02"), invocationResponse("inv1", "2026-08-01")];
+            invocationsCallCount = 0;
+            requestedLimits = [];
+
+            server.use(
+                http.get("/api/invocations", ({ response, request }) => {
+                    invocationsCallCount++;
+                    requestedLimits.push(new URL(request.url).searchParams.get("limit"));
+                    return response(200).json(invocations);
+                }),
+                // Requested by the grid's `getData` to populate the name caches.
+                http.get("/api/histories/{history_id}", ({ response, params }) => {
+                    return response(200).json({ id: params.history_id, name: "History" } as never);
+                }),
+                http.get("/api/workflows/{workflow_id}", ({ response, params }) => {
+                    return response(200).json({ id: params.workflow_id, name: "Workflow" } as never);
+                }),
+            );
+        });
+
+        it("stores the latest invocations in server order and exposes them as summaries", async () => {
+            const store = useInvocationStore();
+
+            const fetched = await store.fetchLatestInvocations();
+
+            expect(fetched.map((invocation) => invocation.id)).toEqual(["inv2", "inv1"]);
+            expect(store.latestInvocations.map((invocation) => invocation.id)).toEqual(["inv2", "inv1"]);
+            expect(requestedLimits).toEqual(["15"]);
+        });
+
+        it("passes the requested limit on to the server", async () => {
+            const store = useInvocationStore();
+
+            await store.fetchLatestInvocations(5);
+
+            expect(requestedLimits).toEqual(["5"]);
+        });
+
+        it("merges the fetched invocations into the shared cache instead of duplicating them", async () => {
+            const store = useInvocationStore();
+
+            await store.fetchLatestInvocations();
+            store.updateInvocation("inv1", { state: "cancelled" });
+
+            expect(store.getInvocationById("inv1")?.state).toBe("cancelled");
+            expect(store.latestInvocations.find((invocation) => invocation.id === "inv1")?.state).toBe("cancelled");
+            expect(store.sortedStoredInvocations.map((invocation) => invocation.id)).toEqual(["inv2", "inv1"]);
+        });
+
+        it("dedupes repeated ids and replaces the previous list on refetch", async () => {
+            const store = useInvocationStore();
+
+            invocations = [invocationResponse("inv1", "2026-08-01"), invocationResponse("inv1", "2026-08-01")];
+            await store.fetchLatestInvocations();
+            expect(store.latestInvocations.map((invocation) => invocation.id)).toEqual(["inv1"]);
+
+            invocations = [invocationResponse("inv3", "2026-08-03")];
+            await store.fetchLatestInvocations();
+            expect(store.latestInvocations.map((invocation) => invocation.id)).toEqual(["inv3"]);
+        });
+
+        it("shares a single request between concurrent calls", async () => {
+            const store = useInvocationStore();
+
+            await Promise.all([store.fetchLatestInvocations(), store.fetchLatestInvocations()]);
+
+            expect(invocationsCallCount).toBe(1);
+            expect(store.isLoadingLatestInvocations).toBe(false);
+        });
+
+        it("resets the loading flag and allows retrying after a failed fetch", async () => {
+            const store = useInvocationStore();
+
+            server.use(
+                http.get("/api/invocations", ({ response }) => {
+                    invocationsCallCount++;
+                    return response("4XX").json({ err_msg: "nope", err_code: 400 }, { status: 400 });
+                }),
+            );
+            await expect(store.fetchLatestInvocations()).rejects.toBeDefined();
+            expect(store.isLoadingLatestInvocations).toBe(false);
+
+            server.use(
+                http.get("/api/invocations", ({ response }) => {
+                    invocationsCallCount++;
+                    return response(200).json(invocations);
+                }),
+            );
+            await store.fetchLatestInvocations();
+
+            expect(invocationsCallCount).toBe(2);
+            expect(store.latestInvocations.map((invocation) => invocation.id)).toEqual(["inv2", "inv1"]);
         });
     });
 

--- a/client/src/stores/invocationStore.test.ts
+++ b/client/src/stores/invocationStore.test.ts
@@ -3,7 +3,12 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { useServerMock } from "@/api/client/__mocks__";
-import type { StepJobSummary, WorkflowInvocation, WorkflowJobMetric } from "@/api/invocations";
+import type {
+    StepJobSummary,
+    WorkflowInvocation,
+    WorkflowInvocationElementView,
+    WorkflowJobMetric,
+} from "@/api/invocations";
 
 import { useInvocationStore } from "./invocationStore";
 
@@ -37,6 +42,20 @@ function invocationResponse(id: string, updateTime: string): WorkflowInvocation 
         workflow_id: `workflow-${id}`,
         model_class: "WorkflowInvocation",
     } as unknown as WorkflowInvocation;
+}
+
+/** The element view served by `GET /api/invocations/{invocation_id}`, unlike the index's collection view. */
+function invocationDetailsResponse(id: string, updateTime: string): WorkflowInvocationElementView {
+    return {
+        ...invocationResponse(id, updateTime),
+        steps: [{ id: `step-${id}` }],
+        inputs: {},
+        input_step_parameters: {},
+        outputs: {},
+        output_collections: {},
+        output_values: {},
+        messages: [],
+    } as unknown as WorkflowInvocationElementView;
 }
 
 describe("stores/invocationStore", () => {
@@ -208,6 +227,61 @@ describe("stores/invocationStore", () => {
 
             expect(invocationsCallCount).toBe(2);
             expect(store.latestInvocations.map((invocation) => invocation.id)).toEqual(["inv2", "inv1"]);
+        });
+
+        describe("getInvocationById", () => {
+            let requestedDetailIds: string[];
+
+            beforeEach(() => {
+                requestedDetailIds = [];
+
+                server.use(
+                    http.get("/api/invocations/{invocation_id}", ({ response, params }) => {
+                        requestedDetailIds.push(params.invocation_id);
+                        return response(200).json(invocationDetailsResponse(params.invocation_id, "2026-08-01"));
+                    }),
+                );
+            });
+
+            it("fetches the details of an invocation that is only cached as a list summary", async () => {
+                const store = useInvocationStore();
+
+                await store.fetchLatestInvocations();
+                expect(requestedDetailIds).toEqual([]);
+
+                expect(store.getInvocationById("inv1")).not.toHaveProperty("steps");
+                await flushPromises();
+
+                expect(requestedDetailIds).toEqual(["inv1"]);
+                expect(store.getInvocationById("inv1")).toHaveProperty("steps", [{ id: "step-inv1" }]);
+            });
+
+            it("does not refetch an invocation whose details are already cached", async () => {
+                const store = useInvocationStore();
+
+                await store.fetchLatestInvocations();
+                store.getInvocationById("inv1");
+                await flushPromises();
+
+                store.getInvocationById("inv1");
+                await flushPromises();
+
+                expect(requestedDetailIds).toEqual(["inv1"]);
+            });
+
+            it("keeps cached details when a list summary for the same invocation arrives later", async () => {
+                const store = useInvocationStore();
+
+                await store.fetchInvocationById({ id: "inv1" });
+                await store.fetchLatestInvocations();
+
+                const invocation = store.latestInvocations.find((item) => item.id === "inv1");
+                expect(invocation).toHaveProperty("steps", [{ id: "step-inv1" }]);
+                expect(store.getInvocationById("inv1")).toHaveProperty("steps", [{ id: "step-inv1" }]);
+                await flushPromises();
+
+                expect(requestedDetailIds).toEqual(["inv1"]);
+            });
         });
     });
 

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -10,6 +10,7 @@ import type {
     WorkflowInvocationRequest,
     WorkflowJobMetric,
 } from "@/api/invocations";
+import { getData as getInvocationsData } from "@/components/Grid/configs/invocations";
 import { numTerminal } from "@/components/WorkflowInvocationState/util";
 import { type FetchParams, useKeyedCache } from "@/composables/keyedCache";
 import { rethrowSimple, rethrowSimpleWithStatus } from "@/utils/simple-error";
@@ -258,8 +259,57 @@ export const useInvocationStore = defineStore("invocationStore", () => {
 
     const totalInvocationCount = ref<number | undefined>(undefined);
 
+    /** Ids of the most recently created invocations, in the order the server returned them. */
+    const latestInvocationIds = ref<string[]>([]);
+    const isLoadingLatestInvocations = ref(false);
+    let latestInvocationsPromise: Promise<WorkflowInvocation[]> | null = null;
+
+    /**
+     * The latest invocation summaries (see `fetchLatestInvocations`), resolved against the shared
+     * invocation cache -- so consumers always see the freshest version of an invocation, no matter
+     * which part of the app loaded it.
+     */
+    const latestInvocations = computed<WorkflowInvocation[]>(() =>
+        latestInvocationIds.value
+            .map((id) => storedInvocations.value[id])
+            .filter((invocation): invocation is WorkflowInvocation => invocation !== undefined),
+    );
+
+    /**
+     * Fetches the `limit` most recently created invocations and merges them into the shared
+     * invocation cache (no separate copy of the data is kept -- only the ordered list of ids).
+     *
+     * Reuses the invocations grid's `getData`, which also populates the history and workflow name
+     * caches needed to display an invocation. Concurrent calls share a single request.
+     */
+    async function fetchLatestInvocations(limit = 15): Promise<WorkflowInvocation[]> {
+        if (latestInvocationsPromise) {
+            return latestInvocationsPromise;
+        }
+        isLoadingLatestInvocations.value = true;
+        latestInvocationsPromise = (async () => {
+            try {
+                const [invocations] = await getInvocationsData(0, limit, "", "create_time", true);
+                const ids: string[] = [];
+                for (const invocation of invocations) {
+                    updateInvocation(invocation.id, invocation);
+                    if (!ids.includes(invocation.id)) {
+                        ids.push(invocation.id);
+                    }
+                }
+                latestInvocationIds.value = ids;
+                return latestInvocations.value;
+            } finally {
+                isLoadingLatestInvocations.value = false;
+                latestInvocationsPromise = null;
+            }
+        })();
+        return latestInvocationsPromise;
+    }
+
     return {
         cancelWorkflowScheduling,
+        fetchLatestInvocations,
         fetchInvocationById,
         fetchInvocationJobsSummaryForId,
         fetchInvocationStepJobsSummaryForId,
@@ -277,6 +327,8 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         getInvocationCountByWorkflowId,
         isLoadingInvocation,
         isLoadingInvocationStep,
+        isLoadingLatestInvocations,
+        latestInvocations,
         sortedStoredInvocations,
         totalInvocationCount,
         updateInvocation,

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -2,13 +2,14 @@ import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
-import type {
-    InvocationJobsSummary,
-    InvocationStep,
-    StepJobSummary,
-    WorkflowInvocation,
-    WorkflowInvocationRequest,
-    WorkflowJobMetric,
+import {
+    type InvocationJobsSummary,
+    type InvocationStep,
+    isWorkflowInvocationElementView,
+    type StepJobSummary,
+    type WorkflowInvocation,
+    type WorkflowInvocationRequest,
+    type WorkflowJobMetric,
 } from "@/api/invocations";
 import { getData as getInvocationsData } from "@/components/Grid/configs/invocations";
 import { numTerminal } from "@/components/WorkflowInvocationState/util";
@@ -123,13 +124,22 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         }
     }
 
+    /**
+     * `fetchLatestInvocations` seeds this cache with list summaries: the invocations index serializes the
+     * collection view, which has no `steps`, `inputs` or `outputs`. So `getInvocationById` must upgrade a
+     * cached summary to the element view rather than treat it as already loaded.
+     */
+    const shouldFetchInvocationDetails = computed(() => {
+        return (invocation?: WorkflowInvocation) => !invocation || !isWorkflowInvocationElementView(invocation);
+    });
+
     const {
         fetchItemById: fetchInvocationById,
         getItemById: getInvocationById,
         getItemLoadError: getInvocationLoadError,
         isLoadingItem: isLoadingInvocation,
         storedItems: storedInvocations,
-    } = useKeyedCache<WorkflowInvocation>(fetchInvocationDetails);
+    } = useKeyedCache<WorkflowInvocation>(fetchInvocationDetails, shouldFetchInvocationDetails);
 
     const { getItemById: getInvocationJobsSummaryById, fetchItemById: fetchInvocationJobsSummaryForId } =
         useKeyedCache<InvocationJobsSummary>(fetchInvocationJobsSummary);

--- a/client/src/stores/pageStore.test.ts
+++ b/client/src/stores/pageStore.test.ts
@@ -128,6 +128,24 @@ describe("usePageStore", () => {
             expect(loadPages).toHaveBeenCalledTimes(2);
         });
 
+        it("keeps one-off search results out of the canonical listing", async () => {
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("search-hit")], 1));
+
+            await pageStore.fetchPages("my", { search: "needle", record: false });
+
+            expect(pageStore.getPageById("search-hit")).toBeDefined();
+            expect(pageStore.myPages).toEqual([]);
+            expect(pageStore.isLoaded("my")).toBe(false);
+
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("canonical-hit")], 5));
+            const canonical = await pageStore.fetchPagesOnce("my");
+
+            expect(loadPages).toHaveBeenCalledTimes(2);
+            expect(canonical.map((page) => page.id)).toEqual(["canonical-hit"]);
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["canonical-hit"]);
+            expect(pageStore.getPageById("search-hit")).toBeDefined();
+        });
+
         it("resets the loading flag and rethrows when the request fails", async () => {
             vi.mocked(loadPages).mockRejectedValue(new Error("boom"));
 

--- a/client/src/stores/pageStore.test.ts
+++ b/client/src/stores/pageStore.test.ts
@@ -172,6 +172,25 @@ describe("usePageStore", () => {
             await pageStore.fetchPages("my");
             expect(pageStore.isComplete("my")).toBe(true);
         });
+
+        it("stays false after a search that found nothing", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([], 0));
+
+            await pageStore.fetchPages("my", { search: "nothing matches this" });
+
+            // the variant counts as loaded, but a filtered fetch never reports
+            // how many pages exist, so completeness cannot follow from it
+            expect(pageStore.isLoaded("my")).toBe(true);
+            expect(pageStore.isComplete("my")).toBe(false);
+        });
+
+        it("is true for an unfiltered listing that came back empty", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([], 0));
+
+            await pageStore.fetchPages("my");
+
+            expect(pageStore.isComplete("my")).toBe(true);
+        });
     });
 
     describe("savePages and removePage", () => {

--- a/client/src/stores/pageStore.test.ts
+++ b/client/src/stores/pageStore.test.ts
@@ -1,0 +1,196 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadPages, type PageSummary } from "@/api/pages";
+import { usePageStore } from "@/stores/pageStore";
+
+vi.mock("@/api/pages", () => ({
+    loadPages: vi.fn(),
+}));
+
+function mockPage(id: string, title = `Page ${id}`): PageSummary {
+    return { id, title } as PageSummary;
+}
+
+function mockResult(pages: PageSummary[], totalMatches = pages.length) {
+    return { data: pages, totalMatches };
+}
+
+describe("usePageStore", () => {
+    let pageStore: ReturnType<typeof usePageStore>;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        pageStore = usePageStore();
+        vi.clearAllMocks();
+    });
+
+    describe("fetchPages", () => {
+        it("requests own pages for the `my` variant and caches the result", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([mockPage("a"), mockPage("b")], 2));
+
+            const pages = await pageStore.fetchPages("my");
+
+            expect(loadPages).toHaveBeenCalledWith(
+                expect.objectContaining({ showOwn: true, showShared: false, showPublished: false }),
+            );
+            expect(pages).toHaveLength(2);
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["a", "b"]);
+            expect(pageStore.getPageById("a")?.title).toBe("Page a");
+            expect(pageStore.isLoaded("my")).toBe(true);
+            expect(pageStore.isLoading("my")).toBe(false);
+        });
+
+        it("requests published and shared pages for the `published` variant", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([mockPage("p1")]));
+
+            await pageStore.fetchPages("published");
+
+            expect(loadPages).toHaveBeenCalledWith(
+                expect.objectContaining({ showOwn: false, showShared: true, showPublished: true }),
+            );
+            expect(pageStore.publishedPages.map((page) => page.id)).toEqual(["p1"]);
+            expect(pageStore.myPages).toEqual([]);
+        });
+
+        it("forwards search, sorting and paging options", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([]));
+
+            await pageStore.fetchPages("my", {
+                search: "notes",
+                sortBy: "title",
+                sortDesc: false,
+                limit: 5,
+                offset: 5,
+            });
+
+            expect(loadPages).toHaveBeenCalledWith({
+                showOwn: true,
+                showShared: false,
+                showPublished: false,
+                search: "notes",
+                sortBy: "title",
+                sortDesc: false,
+                limit: 5,
+                offset: 5,
+            });
+        });
+
+        it("merges search results into the cache without duplicating entries", async () => {
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("a"), mockPage("b")], 2));
+            await pageStore.fetchPages("my");
+
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("b", "Renamed b"), mockPage("c")], 2));
+            await pageStore.fetchPages("my", { search: "b" });
+
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["a", "b", "c"]);
+            expect(pageStore.getPageById("b")?.title).toBe("Renamed b");
+            expect(Object.keys(pageStore.summariesById)).toHaveLength(3);
+        });
+
+        it("keeps the server order of a full listing in front of previously cached pages", async () => {
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("old")], 1));
+            await pageStore.fetchPages("my", { search: "old" });
+
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("new"), mockPage("older")], 3));
+            await pageStore.fetchPages("my");
+
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["new", "older", "old"]);
+        });
+
+        it("deduplicates identical concurrent requests", async () => {
+            let resolvePages: (value: { data: PageSummary[]; totalMatches: number }) => void = () => undefined;
+            vi.mocked(loadPages).mockReturnValue(
+                new Promise((resolve) => {
+                    resolvePages = resolve;
+                }),
+            );
+
+            const first = pageStore.fetchPages("my");
+            const second = pageStore.fetchPages("my");
+
+            expect(loadPages).toHaveBeenCalledTimes(1);
+            expect(pageStore.isLoading("my")).toBe(true);
+
+            resolvePages(mockResult([mockPage("a")]));
+            const [firstPages, secondPages] = await Promise.all([first, second]);
+
+            expect(firstPages).toEqual(secondPages);
+            expect(loadPages).toHaveBeenCalledTimes(1);
+            expect(pageStore.isLoading("my")).toBe(false);
+        });
+
+        it("issues separate requests for different queries", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([]));
+
+            await Promise.all([pageStore.fetchPages("my"), pageStore.fetchPages("my", { search: "notes" })]);
+
+            expect(loadPages).toHaveBeenCalledTimes(2);
+        });
+
+        it("resets the loading flag and rethrows when the request fails", async () => {
+            vi.mocked(loadPages).mockRejectedValue(new Error("boom"));
+
+            await expect(pageStore.fetchPages("my")).rejects.toThrow("boom");
+
+            expect(pageStore.isLoading("my")).toBe(false);
+            expect(pageStore.isLoaded("my")).toBe(false);
+        });
+    });
+
+    describe("fetchPagesOnce", () => {
+        it("fetches only the first time and serves the cache afterwards", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([mockPage("a")], 1));
+
+            const first = await pageStore.fetchPagesOnce("my");
+            const second = await pageStore.fetchPagesOnce("my");
+
+            expect(loadPages).toHaveBeenCalledTimes(1);
+            expect(first.map((page) => page.id)).toEqual(["a"]);
+            expect(second.map((page) => page.id)).toEqual(["a"]);
+        });
+
+        it("fetches each variant separately", async () => {
+            vi.mocked(loadPages).mockResolvedValue(mockResult([mockPage("a")], 1));
+
+            await pageStore.fetchPagesOnce("my");
+            await pageStore.fetchPagesOnce("published");
+
+            expect(loadPages).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("isComplete", () => {
+        it("is false until a full listing is cached", async () => {
+            expect(pageStore.isComplete("my")).toBe(false);
+
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("a")], 5));
+            await pageStore.fetchPages("my");
+            expect(pageStore.isComplete("my")).toBe(false);
+
+            vi.mocked(loadPages).mockResolvedValueOnce(mockResult([mockPage("a"), mockPage("b")], 2));
+            await pageStore.fetchPages("my");
+            expect(pageStore.isComplete("my")).toBe(true);
+        });
+    });
+
+    describe("savePages and removePage", () => {
+        it("saves pages without a request", () => {
+            pageStore.savePages("my", [mockPage("a"), mockPage("b")]);
+
+            expect(loadPages).not.toHaveBeenCalled();
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["a", "b"]);
+        });
+
+        it("removes a page from the cache and from all variant lists", () => {
+            pageStore.savePages("my", [mockPage("a"), mockPage("b")]);
+            pageStore.savePages("published", [mockPage("a")]);
+
+            pageStore.removePage("a");
+
+            expect(pageStore.getPageById("a")).toBeUndefined();
+            expect(pageStore.myPages.map((page) => page.id)).toEqual(["b"]);
+            expect(pageStore.publishedPages).toEqual([]);
+        });
+    });
+});

--- a/client/src/stores/pageStore.ts
+++ b/client/src/stores/pageStore.ts
@@ -17,7 +17,10 @@ const VARIANT_QUERY: Record<PageListVariant, Pick<LoadPagesOptions, "showOwn" | 
     published: { showOwn: false, showShared: true, showPublished: true },
 };
 
-export type FetchPagesOptions = Omit<LoadPagesOptions, "showOwn" | "showShared" | "showPublished">;
+export type FetchPagesOptions = Omit<LoadPagesOptions, "showOwn" | "showShared" | "showPublished"> & {
+    /** Merge summaries by id without recording this request as the canonical variant listing. */
+    record?: boolean;
+};
 
 export const usePageStore = defineStore("pageStore", () => {
     const summariesById = ref<Record<string, PageSummary>>({});
@@ -74,13 +77,17 @@ export const usePageStore = defineStore("pageStore", () => {
         return [...existing, ...incoming.filter((pageId) => !existingIds.has(pageId))];
     }
 
-    /** Merges pages into the summary cache and into the given variant's id list. */
-    function savePages(variant: PageListVariant, pages: PageSummary[], atFront = false) {
-        const incomingIds: string[] = [];
+    /** Merges pages into the shared summary cache without changing a variant listing. */
+    function mergePageSummaries(pages: PageSummary[]) {
         for (const page of pages) {
             set(summariesById.value, page.id, page);
-            incomingIds.push(page.id);
         }
+    }
+
+    /** Merges pages into the summary cache and into the given variant's id list. */
+    function savePages(variant: PageListVariant, pages: PageSummary[], atFront = false) {
+        mergePageSummaries(pages);
+        const incomingIds = pages.map((page) => page.id);
         set(idsByVariant.value, variant, mergeIds(idsByVariant.value[variant], incomingIds, atFront));
     }
 
@@ -101,18 +108,20 @@ export const usePageStore = defineStore("pageStore", () => {
      * Concurrent identical requests share a single promise.
      */
     async function fetchPages(variant: PageListVariant, options: FetchPagesOptions = {}): Promise<PageSummary[]> {
-        const { search = "", sortBy = "update_time", sortDesc = true, limit = 20, offset = 0 } = options;
-        const key = [variant, search, sortBy, sortDesc, limit, offset].join("|");
+        const { search = "", sortBy = "update_time", sortDesc = true, limit = 20, offset = 0, record = true } = options;
+        const key = [variant, search, sortBy, sortDesc, limit, offset, record].join("|");
 
         const pending = fetchPromises.get(key);
         if (pending) {
             return pending;
         }
 
-        const isFullListing = !search && offset === 0;
+        const isFullListing = record && !search && offset === 0;
 
         const promise = (async () => {
-            set(loadingVariants.value, variant, true);
+            if (record) {
+                set(loadingVariants.value, variant, true);
+            }
             try {
                 const { data, totalMatches } = await loadPages({
                     ...VARIANT_QUERY[variant],
@@ -122,15 +131,21 @@ export const usePageStore = defineStore("pageStore", () => {
                     limit,
                     offset,
                 });
-                savePages(variant, data, isFullListing);
-                if (isFullListing) {
-                    set(totalMatchesByVariant.value, variant, totalMatches);
-                    set(fullyListedVariants.value, variant, true);
+                if (record) {
+                    savePages(variant, data, isFullListing);
+                    if (isFullListing) {
+                        set(totalMatchesByVariant.value, variant, totalMatches);
+                        set(fullyListedVariants.value, variant, true);
+                    }
+                    set(loadedVariants.value, variant, true);
+                } else {
+                    mergePageSummaries(data);
                 }
-                set(loadedVariants.value, variant, true);
                 return data;
             } finally {
-                set(loadingVariants.value, variant, false);
+                if (record) {
+                    set(loadingVariants.value, variant, false);
+                }
                 fetchPromises.delete(key);
             }
         })();

--- a/client/src/stores/pageStore.ts
+++ b/client/src/stores/pageStore.ts
@@ -155,12 +155,19 @@ export const usePageStore = defineStore("pageStore", () => {
         return promise;
     }
 
-    /** Fetches the variant once; later calls resolve from the cache. */
-    async function fetchPagesOnce(variant: PageListVariant, options: FetchPagesOptions = {}): Promise<PageSummary[]> {
+    /**
+     * Fetches the variant once; later calls resolve from the cache.
+     *
+     * Always records, so that the variant it reads back is the one it hydrated.
+     */
+    async function fetchPagesOnce(
+        variant: PageListVariant,
+        options: Omit<FetchPagesOptions, "record"> = {},
+    ): Promise<PageSummary[]> {
         if (loadedVariants.value[variant]) {
             return getPages.value(variant);
         }
-        await fetchPages(variant, options);
+        await fetchPages(variant, { ...options, record: true });
         return getPages.value(variant);
     }
 

--- a/client/src/stores/pageStore.ts
+++ b/client/src/stores/pageStore.ts
@@ -1,0 +1,159 @@
+/**
+ * Caches page summaries for list-like consumers (command palette scopes, pickers).
+ *
+ * The store is the single source of truth: fetches merge their results into the
+ * `summariesById` cache and only keep id lists per variant, so no page is duplicated.
+ */
+import { defineStore } from "pinia";
+import { computed, del, ref, set } from "vue";
+
+import { loadPages, type LoadPagesOptions, type PageSummary } from "@/api/pages";
+
+/** `my` = pages owned by the current user, `published` = published (and shared) pages. */
+export type PageListVariant = "my" | "published";
+
+const VARIANT_QUERY: Record<PageListVariant, Pick<LoadPagesOptions, "showOwn" | "showShared" | "showPublished">> = {
+    my: { showOwn: true, showShared: false, showPublished: false },
+    published: { showOwn: false, showShared: true, showPublished: true },
+};
+
+export type FetchPagesOptions = Omit<LoadPagesOptions, "showOwn" | "showShared" | "showPublished">;
+
+export const usePageStore = defineStore("pageStore", () => {
+    const summariesById = ref<Record<string, PageSummary>>({});
+    const idsByVariant = ref<Record<PageListVariant, string[]>>({ my: [], published: [] });
+    const totalMatchesByVariant = ref<Record<PageListVariant, number>>({ my: 0, published: 0 });
+    const loadedVariants = ref<Record<PageListVariant, boolean>>({ my: false, published: false });
+    const loadingVariants = ref<Record<PageListVariant, boolean>>({ my: false, published: false });
+
+    /** In-flight requests, keyed by variant and query, to avoid duplicate fetches. */
+    const fetchPromises = new Map<string, Promise<PageSummary[]>>();
+
+    const getPageById = computed(() => (pageId: string) => summariesById.value[pageId]);
+
+    const getPages = computed(() => (variant: PageListVariant) => {
+        const pages: PageSummary[] = [];
+        for (const pageId of idsByVariant.value[variant]) {
+            const page = summariesById.value[pageId];
+            if (page) {
+                pages.push(page);
+            }
+        }
+        return pages;
+    });
+
+    const myPages = computed(() => getPages.value("my"));
+    const publishedPages = computed(() => getPages.value("published"));
+
+    const isLoaded = computed(() => (variant: PageListVariant) => loadedVariants.value[variant]);
+    const isLoading = computed(() => (variant: PageListVariant) => loadingVariants.value[variant]);
+
+    /** True when the cached id list is known to hold every page of that variant. */
+    const isComplete = computed(
+        () => (variant: PageListVariant) =>
+            loadedVariants.value[variant] && idsByVariant.value[variant].length >= totalMatchesByVariant.value[variant],
+    );
+
+    function mergeIds(existing: string[], incoming: string[], atFront: boolean) {
+        if (atFront) {
+            const incomingIds = new Set(incoming);
+            return [...incoming, ...existing.filter((pageId) => !incomingIds.has(pageId))];
+        }
+        const existingIds = new Set(existing);
+        return [...existing, ...incoming.filter((pageId) => !existingIds.has(pageId))];
+    }
+
+    /** Merges pages into the summary cache and into the given variant's id list. */
+    function savePages(variant: PageListVariant, pages: PageSummary[], atFront = false) {
+        const incomingIds: string[] = [];
+        for (const page of pages) {
+            set(summariesById.value, page.id, page);
+            incomingIds.push(page.id);
+        }
+        set(idsByVariant.value, variant, mergeIds(idsByVariant.value[variant], incomingIds, atFront));
+    }
+
+    /** Removes a page from the cache and from every variant list. */
+    function removePage(pageId: string) {
+        del(summariesById.value, pageId);
+        for (const variant of Object.keys(idsByVariant.value) as PageListVariant[]) {
+            set(
+                idsByVariant.value,
+                variant,
+                idsByVariant.value[variant].filter((id) => id !== pageId),
+            );
+        }
+    }
+
+    /**
+     * Fetches pages of the given variant from the server and merges them into the cache.
+     * Concurrent identical requests share a single promise.
+     */
+    async function fetchPages(variant: PageListVariant, options: FetchPagesOptions = {}): Promise<PageSummary[]> {
+        const { search = "", sortBy = "update_time", sortDesc = true, limit = 20, offset = 0 } = options;
+        const key = [variant, search, sortBy, sortDesc, limit, offset].join("|");
+
+        const pending = fetchPromises.get(key);
+        if (pending) {
+            return pending;
+        }
+
+        const isFullListing = !search && offset === 0;
+
+        const promise = (async () => {
+            set(loadingVariants.value, variant, true);
+            try {
+                const { data, totalMatches } = await loadPages({
+                    ...VARIANT_QUERY[variant],
+                    search,
+                    sortBy,
+                    sortDesc,
+                    limit,
+                    offset,
+                });
+                savePages(variant, data, isFullListing);
+                if (isFullListing) {
+                    set(totalMatchesByVariant.value, variant, totalMatches);
+                }
+                set(loadedVariants.value, variant, true);
+                return data;
+            } finally {
+                set(loadingVariants.value, variant, false);
+                fetchPromises.delete(key);
+            }
+        })();
+
+        fetchPromises.set(key, promise);
+
+        return promise;
+    }
+
+    /** Fetches the variant once; later calls resolve from the cache. */
+    async function fetchPagesOnce(variant: PageListVariant, options: FetchPagesOptions = {}): Promise<PageSummary[]> {
+        if (loadedVariants.value[variant]) {
+            return getPages.value(variant);
+        }
+        await fetchPages(variant, options);
+        return getPages.value(variant);
+    }
+
+    return {
+        // state
+        summariesById,
+        idsByVariant,
+        totalMatchesByVariant,
+        // getters
+        getPageById,
+        getPages,
+        myPages,
+        publishedPages,
+        isLoaded,
+        isLoading,
+        isComplete,
+        // actions
+        savePages,
+        removePage,
+        fetchPages,
+        fetchPagesOnce,
+    };
+});

--- a/client/src/stores/pageStore.ts
+++ b/client/src/stores/pageStore.ts
@@ -25,6 +25,12 @@ export const usePageStore = defineStore("pageStore", () => {
     const totalMatchesByVariant = ref<Record<PageListVariant, number>>({ my: 0, published: 0 });
     const loadedVariants = ref<Record<PageListVariant, boolean>>({ my: false, published: false });
     const loadingVariants = ref<Record<PageListVariant, boolean>>({ my: false, published: false });
+    /**
+     * Whether an *unfiltered* listing of the variant has been fetched. Only such
+     * a fetch reports how many pages exist in total, so only it can tell whether
+     * the cached ids are the complete list.
+     */
+    const fullyListedVariants = ref<Record<PageListVariant, boolean>>({ my: false, published: false });
 
     /** In-flight requests, keyed by variant and query, to avoid duplicate fetches. */
     const fetchPromises = new Map<string, Promise<PageSummary[]>>();
@@ -48,10 +54,15 @@ export const usePageStore = defineStore("pageStore", () => {
     const isLoaded = computed(() => (variant: PageListVariant) => loadedVariants.value[variant]);
     const isLoading = computed(() => (variant: PageListVariant) => loadingVariants.value[variant]);
 
-    /** True when the cached id list is known to hold every page of that variant. */
+    /**
+     * True when the cached id list is known to hold every page of that variant.
+     * A search that came back empty proves nothing about the full list, so this
+     * stays false until an unfiltered listing has reported the total.
+     */
     const isComplete = computed(
         () => (variant: PageListVariant) =>
-            loadedVariants.value[variant] && idsByVariant.value[variant].length >= totalMatchesByVariant.value[variant],
+            fullyListedVariants.value[variant] &&
+            idsByVariant.value[variant].length >= totalMatchesByVariant.value[variant],
     );
 
     function mergeIds(existing: string[], incoming: string[], atFront: boolean) {
@@ -114,6 +125,7 @@ export const usePageStore = defineStore("pageStore", () => {
                 savePages(variant, data, isFullListing);
                 if (isFullListing) {
                     set(totalMatchesByVariant.value, variant, totalMatches);
+                    set(fullyListedVariants.value, variant, true);
                 }
                 set(loadedVariants.value, variant, true);
                 return data;

--- a/client/src/stores/services/history.services.test.ts
+++ b/client/src/stores/services/history.services.test.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getHistoryList } from "./history.services";
+
+vi.mock("axios", () => ({
+    default: {
+        get: vi.fn(),
+    },
+}));
+
+const mockedGet = vi.mocked(axios.get);
+
+/** The url the last `axios.get` call was made with, parsed as query params. */
+function lastRequestParams() {
+    const url = mockedGet.mock.calls.at(-1)?.[0] as string;
+    return new URLSearchParams(url.slice(url.indexOf("?") + 1));
+}
+
+describe("getHistoryList", () => {
+    beforeEach(() => {
+        mockedGet.mockReset();
+        mockedGet.mockResolvedValue({ status: 200, data: [] } as any);
+    });
+
+    it("restricts the listing to histories owned by the current user", async () => {
+        await getHistoryList();
+
+        const params = lastRequestParams();
+        expect(params.get("show_own")).toBe("true");
+        expect(params.get("show_published")).toBe("false");
+        expect(params.get("show_shared")).toBe("false");
+    });
+
+    it("keeps the ownership flags when paginating and filtering", async () => {
+        await getHistoryList(20, 25, "q=name-contains&qv=zebrafish");
+
+        const params = lastRequestParams();
+        expect(params.get("show_own")).toBe("true");
+        expect(params.get("show_published")).toBe("false");
+        expect(params.get("show_shared")).toBe("false");
+        expect(params.get("offset")).toBe("20");
+        expect(params.get("limit")).toBe("25");
+        expect(params.get("qv")).toBe("zebrafish");
+    });
+});

--- a/client/src/stores/services/history.services.ts
+++ b/client/src/stores/services/history.services.ts
@@ -74,7 +74,12 @@ export async function setCurrentHistoryOnServer(historyId: string) {
 }
 
 /**
- * Get list of histories from server and return them.
+ * Get list of histories owned by the current user and return them.
+ *
+ * The backend defaults to `show_published=true`, so the `show_*` flags have to be
+ * sent explicitly to keep other users' published or shared histories out of the
+ * listing.
+ *
  * @param offset to start from (default = 0)
  * @param limit of histories to load (default = null; in which case no limit)
  * @param queryString to append to url in the form `q=filter&qv=val&q=...`
@@ -84,7 +89,7 @@ export async function getHistoryList(offset = 0, limit: number | null = null, qu
     // TODO: to convert this to openapi-fetch we need to fix the query string handling
     // in the caller code to use the query object instead of a string
 
-    const params = `view=summary&order=update_time&offset=${offset}`;
+    const params = `view=summary&order=update_time&offset=${offset}&show_own=true&show_published=false&show_shared=false`;
     let url = `api/histories?${params}`;
     if (limit !== null) {
         url += `&limit=${limit}`;

--- a/client/src/stores/visualizationStore.test.ts
+++ b/client/src/stores/visualizationStore.test.ts
@@ -1,0 +1,139 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadVisualizations, type VisualizationSummary } from "@/api/visualizations";
+import { useVisualizationStore } from "@/stores/visualizationStore";
+
+vi.mock("@/api/visualizations", () => ({
+    loadVisualizations: vi.fn(),
+}));
+
+function mockVisualization(id: string, title: string): VisualizationSummary {
+    return {
+        id,
+        title,
+        type: "nvd3_bar",
+        annotation: null,
+        create_time: "2026-01-01T00:00:00",
+        update_time: "2026-01-02T00:00:00",
+        deleted: false,
+        importable: false,
+        published: false,
+        tags: [],
+        username: "test-user",
+    } as VisualizationSummary;
+}
+
+describe("useVisualizationStore", () => {
+    let store: ReturnType<typeof useVisualizationStore>;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        store = useVisualizationStore();
+        vi.mocked(loadVisualizations).mockReset();
+    });
+
+    it("stores summaries by id and keeps the returned order per variant", async () => {
+        const data = [mockVisualization("viz-2", "Second"), mockVisualization("viz-1", "First")];
+        vi.mocked(loadVisualizations).mockResolvedValue({ data, totalMatches: 2 });
+
+        await store.fetchVisualizations("my");
+
+        expect(store.visualizationIdsByVariant.my).toEqual(["viz-2", "viz-1"]);
+        expect(store.getVisualizations("my").map((viz) => viz.title)).toEqual(["Second", "First"]);
+        expect(store.getVisualizationSummary("viz-1")?.title).toBe("First");
+        expect(store.totalMatchesByVariant.my).toBe(2);
+        expect(store.hasLoadedVariant("my")).toBe(true);
+        expect(store.hasLoadedVariant("shared")).toBe(false);
+    });
+
+    it("sends the explicit scope triplet of the requested variant", async () => {
+        vi.mocked(loadVisualizations).mockResolvedValue({ data: [], totalMatches: 0 });
+
+        await store.fetchVisualizations("published", { limit: 5 });
+
+        expect(loadVisualizations).toHaveBeenCalledWith({
+            showOwn: false,
+            showShared: false,
+            showPublished: true,
+            sortBy: "update_time",
+            sortDesc: true,
+            limit: 5,
+            search: "",
+        });
+    });
+
+    it("merges repeated fetches into a single cache entry per id", async () => {
+        vi.mocked(loadVisualizations).mockResolvedValueOnce({
+            data: [mockVisualization("viz-1", "First"), mockVisualization("viz-2", "Second")],
+            totalMatches: 2,
+        });
+        vi.mocked(loadVisualizations).mockResolvedValueOnce({
+            data: [mockVisualization("viz-2", "Second renamed")],
+            totalMatches: 1,
+        });
+
+        await store.fetchVisualizations("my");
+        await store.fetchVisualizations("shared");
+
+        expect(Object.keys(store.storedVisualizations).sort()).toEqual(["viz-1", "viz-2"]);
+        expect(store.getVisualizationSummary("viz-2")?.title).toBe("Second renamed");
+        expect(store.visualizationIdsByVariant.shared).toEqual(["viz-2"]);
+    });
+
+    it("does not redefine the variant list for a filtered fetch", async () => {
+        vi.mocked(loadVisualizations).mockResolvedValueOnce({
+            data: [mockVisualization("viz-1", "First")],
+            totalMatches: 1,
+        });
+        vi.mocked(loadVisualizations).mockResolvedValueOnce({
+            data: [mockVisualization("viz-9", "Ninth")],
+            totalMatches: 1,
+        });
+
+        await store.fetchVisualizations("my");
+        await store.fetchVisualizations("my", { search: "ninth" });
+
+        expect(store.visualizationIdsByVariant.my).toEqual(["viz-1"]);
+        expect(store.getVisualizationSummary("viz-9")?.title).toBe("Ninth");
+    });
+
+    it("fetches a variant only once via ensureVariantLoaded", async () => {
+        vi.mocked(loadVisualizations).mockResolvedValue({
+            data: [mockVisualization("viz-1", "First")],
+            totalMatches: 1,
+        });
+
+        const first = await store.ensureVariantLoaded("my");
+        const second = await store.ensureVariantLoaded("my");
+
+        expect(loadVisualizations).toHaveBeenCalledTimes(1);
+        expect(first).toEqual(second);
+        expect(first.map((viz) => viz.id)).toEqual(["viz-1"]);
+    });
+
+    it("filters the cached variant list by title", async () => {
+        vi.mocked(loadVisualizations).mockResolvedValue({
+            data: [mockVisualization("viz-1", "ATAC peaks"), mockVisualization("viz-2", "Coverage plot")],
+            totalMatches: 2,
+        });
+
+        await store.fetchVisualizations("my");
+
+        expect(store.searchCachedVisualizations("my", "atac").map((viz) => viz.id)).toEqual(["viz-1"]);
+        expect(store.searchCachedVisualizations("my", "").map((viz) => viz.id)).toEqual(["viz-1", "viz-2"]);
+        expect(store.searchCachedVisualizations("my", "cov", 1)).toHaveLength(1);
+        expect(store.searchCachedVisualizations("shared", "atac")).toEqual([]);
+    });
+
+    it("records a load error instead of throwing", async () => {
+        vi.mocked(loadVisualizations).mockRejectedValue(new Error("boom"));
+
+        const result = await store.fetchVisualizations("my");
+
+        expect(result).toEqual([]);
+        expect(store.loadError).toBe("boom");
+        expect(store.isLoading).toBe(false);
+        expect(store.hasLoadedVariant("my")).toBe(false);
+    });
+});

--- a/client/src/stores/visualizationStore.ts
+++ b/client/src/stores/visualizationStore.ts
@@ -1,0 +1,154 @@
+import { defineStore } from "pinia";
+import { computed, ref, set } from "vue";
+
+import { loadVisualizations, type VisualizationSummary } from "@/api/visualizations";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+/** Number of visualization summaries fetched when hydrating a variant list. */
+const DEFAULT_LIMIT = 25;
+
+/** The visualization lists the palette (and other list consumers) can ask for. */
+export type VisualizationVariant = "my" | "shared" | "published";
+
+interface VariantFlags {
+    showOwn: boolean;
+    showShared: boolean;
+    showPublished: boolean;
+}
+
+/**
+ * Explicit `show_*` triplets so a variant never leaks items from another one.
+ */
+const VARIANT_FLAGS: Record<VisualizationVariant, VariantFlags> = {
+    my: { showOwn: true, showShared: false, showPublished: false },
+    shared: { showOwn: false, showShared: true, showPublished: false },
+    published: { showOwn: false, showShared: false, showPublished: true },
+};
+
+const VARIANTS = Object.keys(VARIANT_FLAGS) as VisualizationVariant[];
+
+export interface FetchVisualizationsOptions {
+    /** Free text matched server-side against title, slug, tag and type. */
+    search?: string;
+    /** Maximum number of visualizations to request. */
+    limit?: number;
+}
+
+function emptyVariantRecord<T>(value: () => T): Record<VisualizationVariant, T> {
+    return Object.fromEntries(VARIANTS.map((variant) => [variant, value()])) as Record<VisualizationVariant, T>;
+}
+
+/**
+ * Caches visualization *summaries* keyed by id, plus the ordered id list of each
+ * variant ("my" / "shared" / "published"). Fetches merge into the same cache, so
+ * a visualization visible in more than one list is stored exactly once.
+ */
+export const useVisualizationStore = defineStore("visualizationStore", () => {
+    const storedVisualizations = ref<Record<string, VisualizationSummary>>({});
+    /** Visualization ids per variant, ordered by `update_time` descending. */
+    const visualizationIdsByVariant = ref(emptyVariantRecord<string[]>(() => []));
+    /** Whether the unfiltered list of a variant has been fetched at least once. */
+    const loadedVariants = ref(emptyVariantRecord<boolean>(() => false));
+    /** Total number of visualizations matching the last unfiltered fetch. */
+    const totalMatchesByVariant = ref(emptyVariantRecord<number>(() => 0));
+    const isLoading = ref(false);
+    const loadError = ref<string | undefined>(undefined);
+
+    const getVisualizations = computed(() => (variant: VisualizationVariant): VisualizationSummary[] => {
+        return visualizationIdsByVariant.value[variant]
+            .map((id) => storedVisualizations.value[id])
+            .filter((visualization): visualization is VisualizationSummary => Boolean(visualization));
+    });
+
+    const hasLoadedVariant = computed(() => (variant: VisualizationVariant) => loadedVariants.value[variant]);
+
+    function getVisualizationSummary(id: string): VisualizationSummary | undefined {
+        return storedVisualizations.value[id];
+    }
+
+    /** Merges visualization summaries into the cache, keyed (and deduped) by id. */
+    function saveVisualizations(visualizations: VisualizationSummary[]) {
+        for (const visualization of visualizations) {
+            if (!visualization?.id) {
+                continue;
+            }
+            set(storedVisualizations.value, visualization.id, visualization);
+        }
+    }
+
+    /**
+     * Fetches summaries for a variant and merges them into the cache. Unfiltered
+     * fetches also (re)define the ordered id list of that variant.
+     */
+    async function fetchVisualizations(
+        variant: VisualizationVariant,
+        options: FetchVisualizationsOptions = {},
+    ): Promise<VisualizationSummary[]> {
+        const { search = "", limit = DEFAULT_LIMIT } = options;
+        isLoading.value = true;
+        loadError.value = undefined;
+        try {
+            const { data, totalMatches } = await loadVisualizations({
+                ...VARIANT_FLAGS[variant],
+                sortBy: "update_time",
+                sortDesc: true,
+                limit,
+                search,
+            });
+            saveVisualizations(data);
+            if (!search) {
+                const ids = Array.from(new Set(data.map((visualization) => visualization.id)));
+                set(visualizationIdsByVariant.value, variant, ids);
+                set(totalMatchesByVariant.value, variant, totalMatches);
+                set(loadedVariants.value, variant, true);
+            }
+            return data;
+        } catch (error) {
+            loadError.value = errorMessageAsString(error);
+            return [];
+        } finally {
+            isLoading.value = false;
+        }
+    }
+
+    /** Fetches a variant once; later calls resolve from the cache. */
+    async function ensureVariantLoaded(
+        variant: VisualizationVariant,
+        limit = DEFAULT_LIMIT,
+    ): Promise<VisualizationSummary[]> {
+        if (!loadedVariants.value[variant]) {
+            await fetchVisualizations(variant, { limit });
+        }
+        return getVisualizations.value(variant);
+    }
+
+    /** Client-side title filter over the cached ids of a variant. */
+    function searchCachedVisualizations(
+        variant: VisualizationVariant,
+        query: string,
+        limit = DEFAULT_LIMIT,
+    ): VisualizationSummary[] {
+        const term = query.trim().toLowerCase();
+        const cached = getVisualizations.value(variant);
+        const matches = term
+            ? cached.filter((visualization) => visualization.title?.toLowerCase().includes(term))
+            : cached;
+        return matches.slice(0, limit);
+    }
+
+    return {
+        storedVisualizations,
+        visualizationIdsByVariant,
+        loadedVariants,
+        totalMatchesByVariant,
+        isLoading,
+        loadError,
+        getVisualizations,
+        hasLoadedVariant,
+        getVisualizationSummary,
+        saveVisualizations,
+        fetchVisualizations,
+        ensureVariantLoaded,
+        searchCachedVisualizations,
+    };
+});

--- a/client/src/stores/workflowStore.test.ts
+++ b/client/src/stores/workflowStore.test.ts
@@ -281,6 +281,40 @@ describe("useWorkflowStore", () => {
             expect(first).toEqual(second);
         });
 
+        it("keeps concurrent pages in separate request and cache slots", async () => {
+            type WorkflowListResult = { data: WorkflowSummary[]; totalMatches: number };
+            let resolvePage0: (result: WorkflowListResult) => void = () => undefined;
+            let resolvePage1: (result: WorkflowListResult) => void = () => undefined;
+            vi.mocked(loadWorkflows).mockImplementation(({ offset }) => {
+                return new Promise((resolve) => {
+                    if (offset === 0) {
+                        resolvePage0 = resolve;
+                    } else {
+                        resolvePage1 = resolve;
+                    }
+                });
+            });
+            const page0Options = { limit: 20, offset: 0 };
+            const page1Options = { limit: 20, offset: 20 };
+
+            const page0 = workflowStore.fetchWorkflowList("my", "", page0Options);
+            const page1 = workflowStore.fetchWorkflowList("my", "", page1Options);
+
+            expect(loadWorkflows).toHaveBeenCalledTimes(2);
+            resolvePage0({ data: [workflowSummary("w0", "Page zero")], totalMatches: 2 });
+            resolvePage1({ data: [workflowSummary("w1", "Page one")], totalMatches: 2 });
+            const [page0Result, page1Result] = await Promise.all([page0, page1]);
+
+            expect(page0Result.map((workflow) => workflow.id)).toEqual(["w0"]);
+            expect(page1Result.map((workflow) => workflow.id)).toEqual(["w1"]);
+            expect(workflowStore.getWorkflowList("my", "", page0Options).map((workflow) => workflow.id)).toEqual([
+                "w0",
+            ]);
+            expect(workflowStore.getWorkflowList("my", "", page1Options).map((workflow) => workflow.id)).toEqual([
+                "w1",
+            ]);
+        });
+
         it("refetches after a previous fetch settled", async () => {
             mockLoadWorkflowsOnce([]);
             await workflowStore.fetchWorkflowList("my");

--- a/client/src/stores/workflowStore.test.ts
+++ b/client/src/stores/workflowStore.test.ts
@@ -307,12 +307,40 @@ describe("useWorkflowStore", () => {
 
             expect(page0Result.map((workflow) => workflow.id)).toEqual(["w0"]);
             expect(page1Result.map((workflow) => workflow.id)).toEqual(["w1"]);
-            expect(workflowStore.getWorkflowList("my", "", page0Options).map((workflow) => workflow.id)).toEqual([
-                "w0",
-            ]);
-            expect(workflowStore.getWorkflowList("my", "", page1Options).map((workflow) => workflow.id)).toEqual([
-                "w1",
-            ]);
+            expect(workflowStore.getWorkflowList("my").map((workflow) => workflow.id)).toEqual(["w0", "w1"]);
+        });
+
+        it("keeps both pages when they are fetched one after the other", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w0", "Page zero")]);
+            await workflowStore.fetchWorkflowList("my", "", { limit: 1, offset: 0 });
+
+            mockLoadWorkflowsOnce([workflowSummary("w1", "Page one")]);
+            await workflowStore.fetchWorkflowList("my", "", { limit: 1, offset: 1 });
+
+            expect(workflowStore.getWorkflowList("my").map((workflow) => workflow.id)).toEqual(["w0", "w1"]);
+        });
+
+        it("refreshes the head of the listing without dropping later pages", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w0", "Page zero")]);
+            await workflowStore.fetchWorkflowList("my", "", { limit: 1, offset: 0 });
+            mockLoadWorkflowsOnce([workflowSummary("w1", "Page one")]);
+            await workflowStore.fetchWorkflowList("my", "", { limit: 1, offset: 1 });
+
+            mockLoadWorkflowsOnce([workflowSummary("w2", "Brand new")]);
+            await workflowStore.fetchWorkflowList("my", "", { limit: 1, offset: 0 });
+
+            expect(workflowStore.getWorkflowList("my").map((workflow) => workflow.id)).toEqual(["w2", "w0", "w1"]);
+        });
+
+        it("reads back a listing fetched with non-default options", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w1", "First")]);
+
+            await workflowStore.fetchWorkflowList("my", "", { limit: 25 });
+
+            // consumers hydrate with their own page size but read the listing
+            // without repeating it
+            expect(workflowStore.isWorkflowListLoaded("my")).toBe(true);
+            expect(workflowStore.getWorkflowList("my").map((workflow) => workflow.id)).toEqual(["w1"]);
         });
 
         it("refetches after a previous fetch settled", async () => {

--- a/client/src/stores/workflowStore.test.ts
+++ b/client/src/stores/workflowStore.test.ts
@@ -2,6 +2,8 @@ import flushPromises from "flush-promises";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { WorkflowSummary } from "@/api/workflows";
+import { loadWorkflows } from "@/api/workflows";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
 import { useWorkflowStore } from "@/stores/workflowStore";
 
@@ -10,12 +12,25 @@ vi.mock("@/components/Workflow/workflows.services", () => ({
     getWorkflowFull: vi.fn(),
 }));
 
+// Mock the workflows API layer used by the list cache
+vi.mock("@/api/workflows", () => ({
+    loadWorkflows: vi.fn(),
+}));
+
 const mockWorkflow = {
     id: "workflow-123",
     name: "Test Workflow",
     version: 1,
     steps: {},
 };
+
+function workflowSummary(id: string, name: string, extra: Partial<WorkflowSummary> = {}): WorkflowSummary {
+    return { id, name, update_time: "2026-08-31T10:00:00", ...extra } as WorkflowSummary;
+}
+
+function mockLoadWorkflowsOnce(data: WorkflowSummary[]) {
+    vi.mocked(loadWorkflows).mockResolvedValueOnce({ data, totalMatches: data.length });
+}
 
 describe("useWorkflowStore", () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>;
@@ -156,6 +171,135 @@ describe("useWorkflowStore", () => {
 
             // Still only one API call total
             expect(getWorkflowFull).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("fetchWorkflowList", () => {
+        it("requests the params of the 'my' variant and caches the returned summaries", async () => {
+            const summaries = [workflowSummary("w1", "First"), workflowSummary("w2", "Second")];
+            mockLoadWorkflowsOnce(summaries);
+
+            const result = await workflowStore.fetchWorkflowList("my");
+
+            expect(loadWorkflows).toHaveBeenCalledWith({
+                sortBy: "update_time",
+                sortDesc: true,
+                limit: 20,
+                offset: 0,
+                filterText: "",
+                showPublished: false,
+                showShared: undefined,
+                skipStepCounts: true,
+            });
+            expect(result).toEqual(summaries);
+            expect(workflowStore.getWorkflowList("my")).toEqual(summaries);
+            expect(workflowStore.getWorkflowSummaryById("w1")).toEqual(summaries[0]);
+        });
+
+        it("requests shared workflows with show_shared and the shared filter", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w3", "Shared")]);
+
+            await workflowStore.fetchWorkflowList("shared", "rna");
+
+            expect(loadWorkflows).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filterText: "rna is:shared_with_me",
+                    showShared: true,
+                    showPublished: false,
+                }),
+            );
+        });
+
+        it("requests published workflows with show_published and the published filter", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w4", "Published")]);
+
+            await workflowStore.fetchWorkflowList("published");
+
+            expect(loadWorkflows).toHaveBeenCalledWith(
+                expect.objectContaining({ filterText: "is:published", showPublished: true }),
+            );
+        });
+
+        it("requests bookmarked workflows with the bookmarked filter", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w5", "Bookmarked")]);
+
+            await workflowStore.fetchWorkflowList("bookmarked");
+
+            expect(loadWorkflows).toHaveBeenCalledWith(
+                expect.objectContaining({ filterText: "is:bookmarked", showPublished: false }),
+            );
+        });
+
+        it("applies sorting and paging overrides", async () => {
+            mockLoadWorkflowsOnce([]);
+
+            await workflowStore.fetchWorkflowList("my", "", { sortBy: "name", sortDesc: false, limit: 5, offset: 10 });
+
+            expect(loadWorkflows).toHaveBeenCalledWith(
+                expect.objectContaining({ sortBy: "name", sortDesc: false, limit: 5, offset: 10 }),
+            );
+        });
+
+        it("merges updated summaries into the existing cache entry instead of duplicating it", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w1", "Old name", { tags: ["a"] })]);
+            await workflowStore.fetchWorkflowList("my");
+
+            mockLoadWorkflowsOnce([workflowSummary("w1", "New name")]);
+            await workflowStore.fetchWorkflowList("published");
+
+            expect(workflowStore.allWorkflowSummaries).toHaveLength(1);
+            expect(workflowStore.getWorkflowSummaryById("w1")).toEqual(
+                expect.objectContaining({ name: "New name", tags: ["a"] }),
+            );
+            // Both lists read the same cached summary
+            expect(workflowStore.getWorkflowList("my")[0]).toEqual(workflowStore.getWorkflowList("published")[0]);
+        });
+
+        it("keeps separate ordered id lists per variant and query", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w2", "Second"), workflowSummary("w1", "First")]);
+            await workflowStore.fetchWorkflowList("my");
+
+            mockLoadWorkflowsOnce([workflowSummary("w1", "First")]);
+            await workflowStore.fetchWorkflowList("my", "first");
+
+            expect(workflowStore.getWorkflowList("my").map((workflow) => workflow.id)).toEqual(["w2", "w1"]);
+            expect(workflowStore.getWorkflowList("my", "first").map((workflow) => workflow.id)).toEqual(["w1"]);
+            expect(workflowStore.getWorkflowList("shared")).toEqual([]);
+        });
+
+        it("deduplicates concurrent fetches of the same list", async () => {
+            mockLoadWorkflowsOnce([workflowSummary("w1", "First")]);
+
+            const [first, second] = await Promise.all([
+                workflowStore.fetchWorkflowList("my"),
+                workflowStore.fetchWorkflowList("my"),
+            ]);
+
+            expect(loadWorkflows).toHaveBeenCalledTimes(1);
+            expect(first).toEqual(second);
+        });
+
+        it("refetches after a previous fetch settled", async () => {
+            mockLoadWorkflowsOnce([]);
+            await workflowStore.fetchWorkflowList("my");
+
+            mockLoadWorkflowsOnce([workflowSummary("w1", "First")]);
+            await workflowStore.fetchWorkflowList("my");
+
+            expect(loadWorkflows).toHaveBeenCalledTimes(2);
+            expect(workflowStore.getWorkflowList("my")).toHaveLength(1);
+        });
+
+        it("reports whether a list has been loaded and does not cache failed fetches", async () => {
+            expect(workflowStore.isWorkflowListLoaded("my")).toBe(false);
+
+            vi.mocked(loadWorkflows).mockRejectedValueOnce(new Error("boom"));
+            await expect(workflowStore.fetchWorkflowList("my")).rejects.toThrow("boom");
+            expect(workflowStore.isWorkflowListLoaded("my")).toBe(false);
+
+            mockLoadWorkflowsOnce([]);
+            await workflowStore.fetchWorkflowList("my");
+            expect(workflowStore.isWorkflowListLoaded("my")).toBe(true);
         });
     });
 });

--- a/client/src/stores/workflowStore.test.ts
+++ b/client/src/stores/workflowStore.test.ts
@@ -188,7 +188,9 @@ describe("useWorkflowStore", () => {
                 offset: 0,
                 filterText: "",
                 showPublished: false,
-                showShared: undefined,
+                // explicit `false`, so the request does not fall back to the
+                // backend default (which includes shared-with-me workflows)
+                showShared: false,
                 skipStepCounts: true,
             });
             expect(result).toEqual(summaries);
@@ -226,7 +228,7 @@ describe("useWorkflowStore", () => {
             await workflowStore.fetchWorkflowList("bookmarked");
 
             expect(loadWorkflows).toHaveBeenCalledWith(
-                expect.objectContaining({ filterText: "is:bookmarked", showPublished: false }),
+                expect.objectContaining({ filterText: "is:bookmarked", showPublished: false, showShared: false }),
             );
         });
 

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -56,14 +56,29 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
     /** Single cache of workflow summaries, keyed by workflow id. */
     const workflowSummariesById = ref<{ [index: string]: WorkflowSummary }>({});
 
-    /** Ordered workflow ids per normalized request -- ids only, never copies of the summaries. */
+    /** Ordered workflow ids per list variant and query -- ids only, never copies of the summaries. */
     const listIdsByKey = ref<{ [index: string]: string[] }>({});
 
     /** In progress list fetches, to avoid firing the same request twice. */
     const listPromises = new Map<string, Promise<WorkflowSummary[]>>();
 
-    function listKey(variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) {
-        const { sortBy, sortDesc, limit, offset } = normalizeListOptions(options);
+    /**
+     * Which cached listing a request contributes to. Sorting and paging pick
+     * *how much* of a listing to fetch, not *which* listing it is, so they stay
+     * out of this key and readers never have to repeat the request options the
+     * listing happened to be hydrated with.
+     */
+    function listKey(variant: WorkflowListVariant, query = "") {
+        return `${variant}:${query.trim()}`;
+    }
+
+    /**
+     * Identity of a single request, used to share one in-flight promise. Two
+     * pages of the same listing are separate requests even though they land in
+     * the same cache slot.
+     */
+    function requestKey(variant: WorkflowListVariant, query: string, options: NormalizedFetchWorkflowListOptions) {
+        const { sortBy, sortDesc, limit, offset } = options;
         return JSON.stringify([variant, query.trim(), sortBy, sortDesc, limit, offset]);
     }
 
@@ -71,22 +86,24 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
 
     const allWorkflowSummaries = computed(() => Object.values(workflowSummariesById.value));
 
+    function summariesForIds(ids: string[]) {
+        return ids
+            .map((workflowId) => workflowSummariesById.value[workflowId])
+            .filter((workflow): workflow is WorkflowSummary => Boolean(workflow));
+    }
+
     /** Summaries for a cached list, in the order the backend returned them. */
     const getWorkflowList = computed(
         () =>
-            (variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) => {
-                const ids = listIdsByKey.value[listKey(variant, query, options)] ?? [];
-                return ids
-                    .map((workflowId) => workflowSummariesById.value[workflowId])
-                    .filter((workflow): workflow is WorkflowSummary => Boolean(workflow));
-            },
+            (variant: WorkflowListVariant, query = "") =>
+                summariesForIds(listIdsByKey.value[listKey(variant, query)] ?? []),
     );
 
     /** Whether a list has been fetched at least once (an empty result still counts as loaded). */
     const isWorkflowListLoaded = computed(
         () =>
-            (variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) =>
-                listKey(variant, query, options) in listIdsByKey.value,
+            (variant: WorkflowListVariant, query = "") =>
+                listKey(variant, query) in listIdsByKey.value,
     );
 
     /** Merges summaries into the cache, updating existing entries instead of duplicating them. */
@@ -97,8 +114,24 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
         });
     }
 
+    /**
+     * Records a fetched page in its listing, keeping every id once.
+     *
+     * The first page redefines the head of the listing, so a refresh reorders it
+     * and still drops nothing a later page contributed; later pages are
+     * appended, so two pages arriving in either order both survive.
+     */
+    function recordListPage(key: string, incomingIds: string[], isFirstPage: boolean) {
+        const cached = listIdsByKey.value[key] ?? [];
+        const incoming = new Set(incomingIds);
+        const merged = isFirstPage
+            ? [...incomingIds, ...cached.filter((workflowId) => !incoming.has(workflowId))]
+            : [...cached, ...incomingIds.filter((workflowId) => !cached.includes(workflowId))];
+        set(listIdsByKey.value, key, merged);
+    }
+
     async function fetchAndMergeWorkflowList(
-        key: string,
+        requestId: string,
         variant: WorkflowListVariant,
         query: string,
         options: NormalizedFetchWorkflowListOptions,
@@ -119,23 +152,26 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
             });
 
             mergeWorkflowSummaries(data);
-            set(
-                listIdsByKey.value,
-                key,
-                data.map((workflow) => workflow.id),
-            );
+            const incomingIds = data.map((workflow) => workflow.id);
+            recordListPage(listKey(variant, query), incomingIds, offset === 0);
 
-            return getWorkflowList.value(variant, query, options);
+            return summariesForIds(incomingIds);
         } finally {
-            listPromises.delete(key);
+            listPromises.delete(requestId);
         }
     }
 
     /**
      * Fetches a workflow list and merges it into the summary cache.
+     *
+     * Identical requests share one promise; requests differing only in sorting
+     * or paging are issued separately and all land in the listing of their
+     * variant and query.
+     *
      * @param variant which list to fetch
      * @param query optional free text search
      * @param options sorting and paging overrides
+     * @returns the summaries of the fetched page, not the whole cached listing
      */
     function fetchWorkflowList(
         variant: WorkflowListVariant,
@@ -143,15 +179,15 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
         options: FetchWorkflowListOptions = {},
     ): Promise<WorkflowSummary[]> {
         const normalizedOptions = normalizeListOptions(options);
-        const key = listKey(variant, query, normalizedOptions);
+        const requestId = requestKey(variant, query, normalizedOptions);
 
-        const existingPromise = listPromises.get(key);
+        const existingPromise = listPromises.get(requestId);
         if (existingPromise) {
             return existingPromise;
         }
 
-        const promise = fetchAndMergeWorkflowList(key, variant, query, normalizedOptions);
-        listPromises.set(key, promise);
+        const promise = fetchAndMergeWorkflowList(requestId, variant, query, normalizedOptions);
+        listPromises.set(requestId, promise);
         return promise;
     }
 

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -16,6 +16,13 @@ export interface FetchWorkflowListOptions {
     offset?: number;
 }
 
+type NormalizedFetchWorkflowListOptions = Required<FetchWorkflowListOptions>;
+
+function normalizeListOptions(options: FetchWorkflowListOptions = {}): NormalizedFetchWorkflowListOptions {
+    const { sortBy = "update_time", sortDesc = true, limit = 20, offset = 0 } = options;
+    return { sortBy, sortDesc, limit, offset };
+}
+
 /**
  * Filter token and query params each variant adds on top of the user provided query.
  *
@@ -49,14 +56,15 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
     /** Single cache of workflow summaries, keyed by workflow id. */
     const workflowSummariesById = ref<{ [index: string]: WorkflowSummary }>({});
 
-    /** Ordered workflow ids per list variant and query -- ids only, never copies of the summaries. */
+    /** Ordered workflow ids per normalized request -- ids only, never copies of the summaries. */
     const listIdsByKey = ref<{ [index: string]: string[] }>({});
 
     /** In progress list fetches, to avoid firing the same request twice. */
     const listPromises = new Map<string, Promise<WorkflowSummary[]>>();
 
-    function listKey(variant: WorkflowListVariant, query = "") {
-        return `${variant}:${query.trim()}`;
+    function listKey(variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) {
+        const { sortBy, sortDesc, limit, offset } = normalizeListOptions(options);
+        return JSON.stringify([variant, query.trim(), sortBy, sortDesc, limit, offset]);
     }
 
     const getWorkflowSummaryById = computed(() => (workflowId: string) => workflowSummariesById.value[workflowId]);
@@ -64,18 +72,21 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
     const allWorkflowSummaries = computed(() => Object.values(workflowSummariesById.value));
 
     /** Summaries for a cached list, in the order the backend returned them. */
-    const getWorkflowList = computed(() => (variant: WorkflowListVariant, query = "") => {
-        const ids = listIdsByKey.value[listKey(variant, query)] ?? [];
-        return ids
-            .map((workflowId) => workflowSummariesById.value[workflowId])
-            .filter((workflow): workflow is WorkflowSummary => Boolean(workflow));
-    });
+    const getWorkflowList = computed(
+        () =>
+            (variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) => {
+                const ids = listIdsByKey.value[listKey(variant, query, options)] ?? [];
+                return ids
+                    .map((workflowId) => workflowSummariesById.value[workflowId])
+                    .filter((workflow): workflow is WorkflowSummary => Boolean(workflow));
+            },
+    );
 
     /** Whether a list has been fetched at least once (an empty result still counts as loaded). */
     const isWorkflowListLoaded = computed(
         () =>
-            (variant: WorkflowListVariant, query = "") =>
-                listKey(variant, query) in listIdsByKey.value,
+            (variant: WorkflowListVariant, query = "", options: FetchWorkflowListOptions = {}) =>
+                listKey(variant, query, options) in listIdsByKey.value,
     );
 
     /** Merges summaries into the cache, updating existing entries instead of duplicating them. */
@@ -90,9 +101,9 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
         key: string,
         variant: WorkflowListVariant,
         query: string,
-        options: FetchWorkflowListOptions,
+        options: NormalizedFetchWorkflowListOptions,
     ) {
-        const { sortBy = "update_time", sortDesc = true, limit = 20, offset = 0 } = options;
+        const { sortBy, sortDesc, limit, offset } = options;
         const { filterText, showPublished, showShared } = variantParams(variant, query);
 
         try {
@@ -114,7 +125,7 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
                 data.map((workflow) => workflow.id),
             );
 
-            return getWorkflowList.value(variant, query);
+            return getWorkflowList.value(variant, query, options);
         } finally {
             listPromises.delete(key);
         }
@@ -131,14 +142,15 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
         query = "",
         options: FetchWorkflowListOptions = {},
     ): Promise<WorkflowSummary[]> {
-        const key = listKey(variant, query);
+        const normalizedOptions = normalizeListOptions(options);
+        const key = listKey(variant, query, normalizedOptions);
 
         const existingPromise = listPromises.get(key);
         if (existingPromise) {
             return existingPromise;
         }
 
-        const promise = fetchAndMergeWorkflowList(key, variant, query, options);
+        const promise = fetchAndMergeWorkflowList(key, variant, query, normalizedOptions);
         listPromises.set(key, promise);
         return promise;
     }

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -2,12 +2,139 @@ import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import type { StoredWorkflowDetailed, WorkflowSortBy, WorkflowSummary } from "@/api/workflows";
+import { loadWorkflows } from "@/api/workflows";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
+
+/** The workflow lists the store keeps ordered id caches for. */
+export type WorkflowListVariant = "my" | "shared" | "published" | "bookmarked";
+
+export interface FetchWorkflowListOptions {
+    sortBy?: WorkflowSortBy;
+    sortDesc?: boolean;
+    limit?: number;
+    offset?: number;
+}
+
+/** Filter token and query params each variant adds on top of the user provided query. */
+function variantParams(variant: WorkflowListVariant, query: string) {
+    const filters = query.trim() ? [query.trim()] : [];
+
+    switch (variant) {
+        case "shared":
+            filters.push("is:shared_with_me");
+            return { filterText: filters.join(" "), showPublished: false, showShared: true };
+        case "published":
+            filters.push("is:published");
+            return { filterText: filters.join(" "), showPublished: true, showShared: undefined };
+        case "bookmarked":
+            filters.push("is:bookmarked");
+            return { filterText: filters.join(" "), showPublished: false, showShared: undefined };
+        default:
+            return { filterText: filters.join(" "), showPublished: false, showShared: undefined };
+    }
+}
 
 export const useWorkflowStore = defineStore("workflowStore", () => {
     const workflowsByInstanceId = ref<{ [index: string]: StoredWorkflowDetailed }>({});
     const fullWorkflowsByIdAndVersion = ref(new Map<string, any>());
+
+    /** Single cache of workflow summaries, keyed by workflow id. */
+    const workflowSummariesById = ref<{ [index: string]: WorkflowSummary }>({});
+
+    /** Ordered workflow ids per list variant and query -- ids only, never copies of the summaries. */
+    const listIdsByKey = ref<{ [index: string]: string[] }>({});
+
+    /** In progress list fetches, to avoid firing the same request twice. */
+    const listPromises = new Map<string, Promise<WorkflowSummary[]>>();
+
+    function listKey(variant: WorkflowListVariant, query = "") {
+        return `${variant}:${query.trim()}`;
+    }
+
+    const getWorkflowSummaryById = computed(() => (workflowId: string) => workflowSummariesById.value[workflowId]);
+
+    const allWorkflowSummaries = computed(() => Object.values(workflowSummariesById.value));
+
+    /** Summaries for a cached list, in the order the backend returned them. */
+    const getWorkflowList = computed(() => (variant: WorkflowListVariant, query = "") => {
+        const ids = listIdsByKey.value[listKey(variant, query)] ?? [];
+        return ids
+            .map((workflowId) => workflowSummariesById.value[workflowId])
+            .filter((workflow): workflow is WorkflowSummary => Boolean(workflow));
+    });
+
+    /** Whether a list has been fetched at least once (an empty result still counts as loaded). */
+    const isWorkflowListLoaded = computed(
+        () =>
+            (variant: WorkflowListVariant, query = "") =>
+                listKey(variant, query) in listIdsByKey.value,
+    );
+
+    /** Merges summaries into the cache, updating existing entries instead of duplicating them. */
+    function mergeWorkflowSummaries(workflows: WorkflowSummary[]) {
+        workflows.forEach((workflow) => {
+            const cached = workflowSummariesById.value[workflow.id];
+            set(workflowSummariesById.value, workflow.id, cached ? { ...cached, ...workflow } : workflow);
+        });
+    }
+
+    async function fetchAndMergeWorkflowList(
+        key: string,
+        variant: WorkflowListVariant,
+        query: string,
+        options: FetchWorkflowListOptions,
+    ) {
+        const { sortBy = "update_time", sortDesc = true, limit = 20, offset = 0 } = options;
+        const { filterText, showPublished, showShared } = variantParams(variant, query);
+
+        try {
+            const { data } = await loadWorkflows({
+                sortBy,
+                sortDesc,
+                limit,
+                offset,
+                filterText,
+                showPublished,
+                showShared,
+                skipStepCounts: true,
+            });
+
+            mergeWorkflowSummaries(data);
+            set(
+                listIdsByKey.value,
+                key,
+                data.map((workflow) => workflow.id),
+            );
+
+            return getWorkflowList.value(variant, query);
+        } finally {
+            listPromises.delete(key);
+        }
+    }
+
+    /**
+     * Fetches a workflow list and merges it into the summary cache.
+     * @param variant which list to fetch
+     * @param query optional free text search
+     * @param options sorting and paging overrides
+     */
+    function fetchWorkflowList(
+        variant: WorkflowListVariant,
+        query = "",
+        options: FetchWorkflowListOptions = {},
+    ): Promise<WorkflowSummary[]> {
+        const key = listKey(variant, query);
+
+        const existingPromise = listPromises.get(key);
+        if (existingPromise) {
+            return existingPromise;
+        }
+
+        const promise = fetchAndMergeWorkflowList(key, variant, query, options);
+        listPromises.set(key, promise);
+        return promise;
+    }
 
     /** Cached promises for fetching full workflows to prevent duplicate requests */
     const fullWorkflowPromises = new Map<string, Promise<any>>();
@@ -115,12 +242,18 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
     }
 
     return {
+        allWorkflowSummaries,
         fetchWorkflowForInstanceId,
         fetchWorkflowForInstanceIdCached,
+        fetchWorkflowList,
         getFullWorkflowCached,
         getStoredWorkflowByInstanceId,
         getStoredWorkflowIdByInstanceId,
         getStoredWorkflowNameByInstanceId,
+        getWorkflowList,
+        getWorkflowSummaryById,
+        isWorkflowListLoaded,
         workflowsByInstanceId,
+        workflowSummariesById,
     };
 });

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -16,7 +16,14 @@ export interface FetchWorkflowListOptions {
     offset?: number;
 }
 
-/** Filter token and query params each variant adds on top of the user provided query. */
+/**
+ * Filter token and query params each variant adds on top of the user provided query.
+ *
+ * `showShared` is always spelled out: the backend defaults `show_shared` to true
+ * and an `undefined` value is dropped from the query string altogether, so the
+ * lists of the user's own workflows have to ask for `false` explicitly to stay
+ * free of workflows that were only shared with them.
+ */
 function variantParams(variant: WorkflowListVariant, query: string) {
     const filters = query.trim() ? [query.trim()] : [];
 
@@ -29,9 +36,9 @@ function variantParams(variant: WorkflowListVariant, query: string) {
             return { filterText: filters.join(" "), showPublished: true, showShared: undefined };
         case "bookmarked":
             filters.push("is:bookmarked");
-            return { filterText: filters.join(" "), showPublished: false, showShared: undefined };
+            return { filterText: filters.join(" "), showPublished: false, showShared: false };
         default:
-            return { filterText: filters.join(" "), showPublished: false, showShared: undefined };
+            return { filterText: filters.join(" "), showPublished: false, showShared: false };
     }
 }
 


### PR DESCRIPTION
Groundwork for the upcoming command palette (a global Cmd/Ctrl+K search, #23472) is split out so it can be reviewed on its own. Nothing here changes the UI, apart from one bug fix in the history listings. Every change is covered by unit tests and is independently useful: grids consume the extracted helpers, and the new caches give any component a store-first way to read list data.

### API helpers (`client/src/api`)

- `loadPages`, `createPage` and `loadVisualizations` are extracted from the private grid configs into `api/pages.ts` and `api/visualizations.ts`; the Reports and Visualizations grids now call them.
- `api/workflows.ts` gains an optional `shared` filter and `api/histories.ts` gains explicit `show_own` / `show_published` / `show_shared` scope flags for the list calls.

### Store caches (`client/src/stores`)

- `workflowStore`: cached list variants (own, shared, published) with in-flight request sharing.
- `historyStore`: shared, published and archived history caches next to the existing own-history list; `loadHistories` accepts an optional page cap for callers that only need the head of the list; concurrent callers share in-flight fetches; `cacheIsComplete` only trusts an unfiltered, short page.
- New small stores: `pageStore`, `visualizationStore`, `datasetListStore`; `invocationStore` keeps a latest-invocations cache; the dataset cache is read through store getters.
- `fetchHistoryList` / `fetchPages` accept `record: false` for one-off searches that must not be recorded as the variant's canonical listing (results still land in the shared summary caches).

### Bug fix

Own listings no longer rely on backend defaults that include shared and published items: the history switcher and the "my histories" list previously showed other users' published histories as your own. `getHistoryList` now pins `show_own=true&show_published=false&show_shared=false` (see the request line in the screenshot below).

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html) (`client/src/api/*.test.ts`, `client/src/stores/*.test.ts`, ~1.5k lines of Vitest specs: in-flight sharing, cache completeness, record:false, scope flags).
- [x] Instructions for manual testing are as follows:
  1. Open the Reports list (`/pages/list`, `/pages/list_published`) and the Visualizations lists; they render the page as before.
  2. Open the history switcher: only your own histories are listed (the request carries `show_own=true&show_published=false&show_shared=false`).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
