### PR TITLE
Update jupyterlite package version to 0.0.31

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -53,7 +53,7 @@ jsonviewer:
     version: 0.0.0
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.30
+    version: 0.0.31
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3


### PR DESCRIPTION
This pulls in the newly published @galaxyproject/jupyterlite@0.31 package, which migrates the plugin to JupyterLite 0.8 bringing the environment up to date with the latest JupyterLab 4.6 base

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Verify that the JupyterLite environment initializes successfully

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
