### PR TITLE
Simplify/Refactor `Filtering` class by tokenizing the filter text once

### DIFF
--- a/client/src/components/Common/FilterMenu.vue
+++ b/client/src/components/Common/FilterMenu.vue
@@ -169,8 +169,8 @@ function onPopoverHidden() {
 }
 
 function onSearch() {
-    const newFilterText = props.filterClass.getFilterText(filters.value);
-    const newBackendFilter = props.filterClass.getFilterText(filters.value, true);
+    const newFilterText = props.filterClass.getFilterText(filters.value, false, props.filterText);
+    const newBackendFilter = props.filterClass.getFilterText(filters.value, true, props.filterText);
     if (props.menuType !== "linked") {
         emit("on-search", filters.value, newFilterText, newBackendFilter);
     } else {

--- a/client/src/components/Grid/GridList.test.ts
+++ b/client/src/components/Grid/GridList.test.ts
@@ -74,7 +74,7 @@ function createTestGrid(): GridConfig {
                 ],
             },
         ],
-        filtering: new Filtering({}, undefined, false, false),
+        filtering: new Filtering({}, undefined, false),
         getData: vi.fn(async (offset: number, limit: number): Promise<[RowData[], number]> => {
             const data: RowData[] = [];
             for (let i = offset; i < offset + limit; i++) {

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -288,7 +288,7 @@ function validatedFilterText() {
         return filterText.value;
     }
     // there are valid filters derived from the `filterText`
-    return filterClass?.getFilterText(validFilters.value || {}, false) || "";
+    return filterClass?.getFilterText(validFilters.value || {}, false, filterText.value) || "";
 }
 
 /**

--- a/client/src/components/Grid/configs/adminForms.ts
+++ b/client/src/components/Grid/configs/adminForms.ts
@@ -143,7 +143,7 @@ const gridConfig: GridConfig = {
     id: "forms-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Forms",
     sortBy: "name",

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -184,7 +184,7 @@ const gridConfig: GridConfig = {
     id: "groups-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Groups",
     sortBy: "name",

--- a/client/src/components/Grid/configs/adminQuotas.ts
+++ b/client/src/components/Grid/configs/adminQuotas.ts
@@ -221,7 +221,7 @@ const gridConfig: GridConfig = {
     id: "quotas-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Quotas",
     sortBy: "name",

--- a/client/src/components/Grid/configs/adminRoles.ts
+++ b/client/src/components/Grid/configs/adminRoles.ts
@@ -195,7 +195,7 @@ const gridConfig: GridConfig = {
     id: "roles-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Roles",
     sortBy: "name",

--- a/client/src/components/Grid/configs/adminUsers.ts
+++ b/client/src/components/Grid/configs/adminUsers.ts
@@ -362,7 +362,7 @@ const gridConfig: GridConfig = {
     id: "users-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Users",
     sortBy: "email",

--- a/client/src/components/Grid/configs/pages.ts
+++ b/client/src/components/Grid/configs/pages.ts
@@ -248,7 +248,7 @@ const gridConfig: GridConfig = {
     id: "pages-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: GRID_LABELS.gridPlural,
     sortBy: "update_time",

--- a/client/src/components/Grid/configs/pagesPublished.ts
+++ b/client/src/components/Grid/configs/pagesPublished.ts
@@ -124,7 +124,7 @@ const gridConfig: GridConfig = {
     id: "pages-published-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: GRID_LABELS.gridPlural,
     sortBy: "update_time",

--- a/client/src/components/Grid/configs/visualizations.ts
+++ b/client/src/components/Grid/configs/visualizations.ts
@@ -236,7 +236,7 @@ const gridConfig: GridConfig = {
     id: "visualizations-grid",
     actions: actions,
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Visualizations",
     sortBy: "update_time",

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -110,7 +110,7 @@ const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = 
 const gridConfig: GridConfig = {
     id: "visualizations-published-grid",
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Visualizations",
     sortBy: "update_time",

--- a/client/src/components/Grid/configs/visualizationsShared.ts
+++ b/client/src/components/Grid/configs/visualizationsShared.ts
@@ -106,7 +106,7 @@ const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = 
 const gridConfig: GridConfig = {
     id: "visualizations-published-grid",
     fields: fields,
-    filtering: new Filtering(validFilters, undefined, false, false),
+    filtering: new Filtering(validFilters, undefined, false),
     getData: getData,
     plural: "Visualizations",
     sortBy: "update_time",

--- a/client/src/components/History/HistoriesFilters.js
+++ b/client/src/components/History/HistoriesFilters.js
@@ -14,4 +14,4 @@ const validFilters = {
     update_time_ge: { handler: compare("update_time", "ge", toDate), menuItem: false },
     update_time_le: { handler: compare("update_time", "le", toDate), menuItem: false },
 };
-export const HistoriesFilters = new Filtering(validFilters);
+export const HistoriesFilters = new Filtering(validFilters, undefined, true, "name");

--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -101,4 +101,4 @@ const validFilters = {
     update_time_lt: { handler: compare("update_time", "lt", toDate), menuItem: false },
 };
 
-export const HistoryFilters = new Filtering(validFilters);
+export const HistoryFilters = new Filtering(validFilters, undefined, true, "name");

--- a/client/src/components/History/HistoryList.vue
+++ b/client/src/components/History/HistoryList.vue
@@ -302,7 +302,7 @@ function validatedFilterText(): string {
         return filterText.value;
     }
     // there are valid filters derived from the `filterText`
-    return historyListFilters.value.getFilterText(validFilters.value, true);
+    return historyListFilters.value.getFilterText(validFilters.value, true, filterText.value);
 }
 
 /**

--- a/client/src/components/History/StorageOperations/StorageOperationRunView.vue
+++ b/client/src/components/History/StorageOperations/StorageOperationRunView.vue
@@ -65,7 +65,6 @@ const runItemFilterClass = new Filtering(
     },
     undefined,
     true,
-    false,
 );
 
 const breadcrumbItems = computed(() => [

--- a/client/src/components/History/historyList.ts
+++ b/client/src/components/History/historyList.ts
@@ -51,7 +51,7 @@ export function getHistoryListFilters(activeList = "my") {
             },
             undefined,
             false,
-            false,
+            "name",
         );
     } else {
         return new Filtering(
@@ -66,7 +66,7 @@ export function getHistoryListFilters(activeList = "my") {
             },
             undefined,
             false,
-            false,
+            "name",
         );
     }
 }

--- a/client/src/components/ToolsList/ToolsList.vue
+++ b/client/src/components/ToolsList/ToolsList.vue
@@ -194,9 +194,7 @@ const validFilters = computed<Record<string, ValidFilter<string | string[]>>>(()
 // See: https://whoosh.readthedocs.io/en/latest/querylang.html#query
 // For now, I've changed the `quoteStrings` param to `false` to avoid issues with the quotes, and added
 // a "hint" to the `FilterMenu` help text.
-const ToolFilters = computed<Filtering<string | string[]>>(
-    () => new Filtering(validFilters.value, undefined, false, false),
-);
+const ToolFilters = computed<Filtering<string | string[]>>(() => new Filtering(validFilters.value, undefined, false));
 
 function normalizePropsToFilterSettings(routeProps: Props): FilterSettings {
     const filters: FilterSettings = {};

--- a/client/src/components/User/Credentials/CredentialsManagement.vue
+++ b/client/src/components/User/Credentials/CredentialsManagement.vue
@@ -43,11 +43,16 @@ import ServiceCredentialsGroupsList from "@/components/User/Credentials/ServiceC
 const breadcrumbItems = [{ title: "User Preferences", to: "/user" }, { title: "Tools Credentials Management" }];
 
 /** Filter configuration for credential groups */
-const credentialsFilterClass = new Filtering({
-    name: { placeholder: "credential group name", type: String, handler: contains("name"), menuItem: true },
-    tool: { placeholder: "tool name", type: String, handler: contains("tool"), menuItem: true },
-    service: { placeholder: "service name", type: String, handler: contains("service"), menuItem: true },
-});
+const credentialsFilterClass = new Filtering(
+    {
+        name: { placeholder: "credential group name", type: String, handler: contains("name"), menuItem: true },
+        tool: { placeholder: "tool name", type: String, handler: contains("tool"), menuItem: true },
+        service: { placeholder: "service name", type: String, handler: contains("service"), menuItem: true },
+    },
+    undefined,
+    true,
+    "name",
+);
 
 const userStore = useUserStore();
 const { currentUser } = storeToRefs(userStore);
@@ -186,7 +191,7 @@ function validatedFilterText(): string {
         return filterText.value;
     }
     // there are valid filters derived from the `filterText`
-    return credentialsFilterClass.getFilterText(validFilters.value, true);
+    return credentialsFilterClass.getFilterText(validFilters.value, true, filterText.value);
 }
 
 /**

--- a/client/src/components/Workflow/List/workflowFilters.ts
+++ b/client/src/components/Workflow/List/workflowFilters.ts
@@ -128,7 +128,6 @@ export function getWorkflowFilters(activeList = "my", isAnonymous = false) {
             },
             undefined,
             false,
-            false,
         );
     } else if (activeList === "shared_with_me") {
         return new Filtering(
@@ -151,7 +150,6 @@ export function getWorkflowFilters(activeList = "my", isAnonymous = false) {
             },
             undefined,
             false,
-            false,
         );
     } else {
         const publishedFilters: Record<string, any> = {
@@ -173,6 +171,6 @@ export function getWorkflowFilters(activeList = "my", isAnonymous = false) {
                 menuItem: true,
             };
         }
-        return new Filtering(publishedFilters, undefined, false, false);
+        return new Filtering(publishedFilters, undefined, false);
     }
 }

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -195,9 +195,13 @@ export default {
                 handler: { placeholder: "handler", type: String, handler: contains("handler"), menuItem: true },
                 runner: { placeholder: "job runner", type: String, handler: contains("runner"), menuItem: true },
                 tool: { placeholder: "tool id", type: String, handler: contains("tool"), menuItem: true },
+                /** Unspecified text (e.g. the user just typing "grep1" with no `key:value` filter), which is
+                 * sent to the backend `search` param as is, alongside `user:`/`tool:`/etc. */
+                unspecified_text: { handler: contains("unspecified_text"), menuItem: false },
             },
             undefined,
             false,
+            "unspecified_text",
         );
 
         function appendTagFilter(filterName, filterVal) {

--- a/client/src/utils/filterConversion.test.js
+++ b/client/src/utils/filterConversion.test.js
@@ -21,7 +21,6 @@ describe("test filtering helpers to convert filters to filter text", () => {
         },
         undefined,
         false,
-        false,
     );
     it("conversion from filters to new filter text", async () => {
         const normalized = HistoryFilters.defaultFilters;

--- a/client/src/utils/filterConversion.test.js
+++ b/client/src/utils/filterConversion.test.js
@@ -219,3 +219,31 @@ describe("validatedFilterText keeps unspecified text alongside other filters", (
         expect(validatedFilterText(gf, "grep1")).toBe("grep1");
     });
 });
+
+describe("quoteStrings: false (Workflows) maintains behavior with unquoted multi-word values", () => {
+    const wf = getWorkflowFilters("my");
+
+    it("parses key:value tokens the same way", () => {
+        expect(Object.fromEntries(wf.getFiltersForText("name:RNAseq tag:foo"))).toEqual({
+            name: "RNAseq",
+            tag: ["foo"],
+        });
+    });
+
+    it("keeps a quoted value's quotes in the parsed value (no stripping in this mode)", () => {
+        expect(Object.fromEntries(wf.getFiltersForText("name:'RNAseq'"))).toEqual({ name: "'RNAseq'" });
+    });
+
+    it("leaves multi-word unquoted values intact", () => {
+        expect(Object.fromEntries(wf.getFiltersForText("name:my workflow name"))).toEqual({
+            name: "my workflow name",
+        });
+    });
+
+    it("validates filter text unchanged", () => {
+        expect(validatedFilterText(wf, "name:RNAseq is:published")).toBe("name:RNAseq is:published");
+        expect(validatedFilterText(wf, "tag:amrfinderplus_report metagenomics")).toBe(
+            "tag:amrfinderplus_report metagenomics",
+        );
+    });
+});

--- a/client/src/utils/filterConversion.test.js
+++ b/client/src/utils/filterConversion.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { HistoryFilters } from "@/components/History/HistoryFilters";
+import { getHistoryListFilters } from "@/components/History/historyList";
 import { quoteToolTagValue } from "@/components/Panels/utilities";
 import { getWorkflowFilters } from "@/components/Workflow/List/workflowFilters";
 import Filtering, { contains } from "@/utils/filtering";
@@ -149,5 +150,72 @@ describe("test filtering helpers to convert filter text to filters", () => {
         filterText = "name:name invalid:invalid user:testUser";
         filters["user"] = "testUser";
         expect(getFilters(PublishedWorkflowFilters, filterText)).toEqual(filters);
+    });
+});
+
+/**
+ * `validatedFilterText` in WorkflowList.vue/HistoryList.vue/GridList.vue/CredentialsManagement.vue
+ * all follow this same shape: pass `filterText` through untouched if nothing matched, otherwise
+ * rebuild it from the parsed filters. Mirrored here so a regression in any of those trips this test
+ *
+ * **TODO:** _We need to put this in a centralized file (maybe the `Filtering` class...)._
+ */
+function validatedFilterText(filterClass, filterText) {
+    const rawFilters = Object.fromEntries(filterClass.getFiltersForText(filterText, true, false));
+    if (Object.keys(rawFilters).length === 0) {
+        return filterText;
+    }
+    const validFilters = filterClass.getValidFilters(rawFilters, true).validFilters;
+    return filterClass.getFilterText(validFilters, true, filterText);
+}
+
+describe("validatedFilterText keeps unspecified text alongside other filters", () => {
+    // WorkflowList (getWorkflowFilters) intentionally has no autoFilterKey: it uses
+    // quoteStrings: false, whose regex matches a filter value up to the *next* `key:` token so
+    // values can contain unquoted spaces (e.g. `tool:my tool name`). That means it can't tell
+    // "tag:foo bar" apart from "tag value is 'foo bar'".
+    // `autoFilterKey` would corrupt the tag value by absorbing trailing unspecified text into it.
+    // Pure unspecified text alone still passes straight through untouched.
+    it("WorkflowList (getWorkflowFilters) leaves multi-word tag values untouched", () => {
+        const wf = getWorkflowFilters("my");
+        expect(validatedFilterText(wf, "tag:amrfinderplus_report metagenomics")).toBe(
+            "tag:amrfinderplus_report metagenomics",
+        );
+        expect(validatedFilterText(wf, "grep1")).toBe("grep1");
+    });
+
+    it("HistoryList (getHistoryListFilters)", () => {
+        const hl = getHistoryListFilters("my");
+        expect(validatedFilterText(hl, "grep1 tag:foo")).toBe("tag:foo grep1");
+        expect(validatedFilterText(hl, "grep1")).toBe("grep1");
+    });
+
+    it("CredentialsManagement (name/tool/service)", () => {
+        const cf = new Filtering(
+            {
+                name: { type: String, handler: contains("name"), menuItem: true },
+                tool: { type: String, handler: contains("tool"), menuItem: true },
+                service: { type: String, handler: contains("service"), menuItem: true },
+            },
+            undefined,
+            true,
+            "name",
+        );
+        expect(validatedFilterText(cf, "grep1 tool:foo")).toBe("tool:foo grep1");
+        expect(validatedFilterText(cf, "grep1")).toBe("grep1");
+    });
+
+    it("GridList (a config with name + another filter)", () => {
+        const gf = new Filtering(
+            {
+                name: { type: String, handler: contains("name"), menuItem: true },
+                extension: { type: String, handler: contains("extension"), menuItem: true },
+            },
+            undefined,
+            true,
+            "name",
+        );
+        expect(validatedFilterText(gf, "grep1 extension:txt")).toBe("extension:txt grep1");
+        expect(validatedFilterText(gf, "grep1")).toBe("grep1");
     });
 });

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { HistoryFilters } from "@/components/History/HistoryFilters";
+import Filtering, { contains, equals } from "@/utils/filtering";
 
 const filterTexts = [
     "name:'name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state:success extension:ext tag:first deleted:False visible:'TRUE'",
@@ -106,7 +107,7 @@ describe("filtering", () => {
         });
     });
     test("parse filter text as entries", () => {
-        filterTexts.forEach((filterText) => {
+        filterTexts.forEach((filterText, i) => {
             const filters = HistoryFilters.getFiltersForText(filterText);
             expect(filters[0][0]).toBe("name");
             expect(filters[0][1]).toBe("name of item");
@@ -127,7 +128,9 @@ describe("filtering", () => {
             expect(filters[8][0]).toBe("deleted");
             expect(filters[8][1]).toBe("false");
             expect(filters[9][0]).toBe("visible");
-            expect(filters[9][1]).toBe("true");
+            // filterTexts[0] quotes `visible:'TRUE'`, so its parsed value keeps the original
+            // case; filterTexts[1] uses the bare `visible:true`. toBool folds both downstream.
+            expect(filters[9][1]).toBe(i === 0 ? "TRUE" : "true");
             const filters_eq = HistoryFilters.getFiltersForText('genome_build_eq:"hg19"');
             expect(filters_eq[0][0]).toBe("genome_build_eq");
             expect(filters_eq[0][1]).toBe("hg19");
@@ -136,7 +139,10 @@ describe("filtering", () => {
     test("parse filter text as query dictionary", () => {
         filterTexts.forEach((filterText) => {
             const queryDict = HistoryFilters.getQueryDict(filterText);
-            expect(queryDict["name-contains"]).toBe("name of item");
+            // both fixtures quote the name (`name:'name of item'`), so it routes to the
+            // exact-match `name-eq` handler rather than `name-contains`
+            expect(queryDict["name-eq"]).toBe("name of item");
+            expect(queryDict["name-contains"]).toBeUndefined();
             expect(queryDict["hid-gt"]).toBe("10");
             expect(queryDict["hid-lt"]).toBe("100");
             expect(queryDict["create_time-gt"]).toBe(1609459200);
@@ -167,7 +173,7 @@ describe("filtering", () => {
                 filterTexts[0],
                 true,
             ),
-        ).toEqual("name:'name of item' hid>10 update_time<2022-01-01 extension:ext");
+        ).toEqual("name:'name of item' hid>10 update_time<'2022-01-01' extension:ext");
         expect(HistoryFilters.applyFiltersToText({ deleted: "any", visible: true }, "")).toEqual(
             "deleted:any visible:true",
         );
@@ -230,9 +236,12 @@ describe("filtering", () => {
             deleted: "false",
             visible: "true",
         };
-        // iterate through filterTexts and compare with parsedFilters
-        filterTexts.forEach((filterText) => {
-            expect(Object.fromEntries(HistoryFilters.getFiltersForText(filterText))).toEqual(parsedFilters);
+        // iterate through filterTexts and compare with parsedFilters. filterTexts[0] quotes
+        // `visible:'TRUE'`, so its parsed value keeps the original case (see the quoted-value
+        // block below); everything else folds the same either way.
+        filterTexts.forEach((filterText, i) => {
+            const expected = i === 0 ? { ...parsedFilters, visible: "TRUE" } : parsedFilters;
+            expect(Object.fromEntries(HistoryFilters.getFiltersForText(filterText))).toEqual(expected);
         });
     });
     test("named tag (hash) conversion", () => {

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -139,10 +139,9 @@ describe("filtering", () => {
     test("parse filter text as query dictionary", () => {
         filterTexts.forEach((filterText) => {
             const queryDict = HistoryFilters.getQueryDict(filterText);
-            // both fixtures quote the name (`name:'name of item'`), so it routes to the
-            // exact-match `name-eq` handler rather than `name-contains`
-            expect(queryDict["name-eq"]).toBe("name of item");
-            expect(queryDict["name-contains"]).toBeUndefined();
+            // both fixtures quote the name (`name:'name of item'`) but the value has a space
+            expect(queryDict["name-contains"]).toBe("name of item");
+            expect(queryDict["name-eq"]).toBeUndefined();
             expect(queryDict["hid-gt"]).toBe("10");
             expect(queryDict["hid-lt"]).toBe("100");
             expect(queryDict["create_time-gt"]).toBe(1609459200);
@@ -378,7 +377,110 @@ describe("a lone quoted bare token routes autoFilterKey through exact match", ()
         expect(F.getQueryDict("foo 'Grep1'")["search-eq"]).toBeUndefined();
     });
 
-    test("getFilterText writes the folded value back as plain (unlabeled) text", () => {
-        expect(F.getFilterText({ search: "Grep1" }, false, "'Grep1'")).toBe("Grep1");
+    test("getFilterText writes the folded value back unlabeled, keeping its exact-match quotes", () => {
+        expect(F.getFilterText({ search: "Grep1" }, false, "'Grep1'")).toBe("'Grep1'");
+        // an unquoted bare token stays unquoted
+        expect(F.getFilterText({ search: "Grep1" }, false, "Grep1")).toBe("Grep1");
+    });
+
+    test("the exact-match quotes survive applying another filter alongside the bare token", () => {
+        // regression: the `key === unspecifiedTextKey` branch used to write the value before the
+        // quoting could be applied, so adding a sibling filter silently dropped the exact match
+        // (JobsFilters uses this shape: quoted bare text for an exact tool search, plus state:)
+        const cf = new Filtering(
+            {
+                search: { type: String, handler: contains("search"), menuItem: true },
+                search_eq: { handler: equals("search"), menuItem: false },
+                state: { type: String, handler: equals("state"), menuItem: true },
+            },
+            undefined,
+            true,
+            "search",
+        );
+        expect(cf.applyFiltersToText({ state: "ok" }, "'Grep1'")).toBe("'Grep1' state:ok");
+    });
+});
+
+describe("quote matching + unspecified text + autoFilterKey combined (JobsFilters-shaped)", () => {
+    const JF = new Filtering(
+        {
+            tool_id: { type: String, handler: contains("tool_id"), menuItem: true },
+            tool_id_eq: { handler: equals("tool_id"), menuItem: false },
+            state: { type: String, handler: equals("state"), menuItem: true },
+        },
+        undefined,
+        true,
+        "tool_id",
+    );
+
+    test("unquoted unspecified text is a plain, case-folded contains search", () => {
+        expect(JF.getQueryDict("grep1")).toEqual({ "tool_id-contains": "grep1" });
+    });
+
+    test("an explicit key:value is unaffected by quoting rules for unspecified text", () => {
+        expect(JF.getQueryDict("tool_id:foo")).toEqual({ "tool_id-contains": "foo" });
+        expect(JF.getQueryDict("tool_id:'Foo'")).toEqual({ "tool_id-eq": "Foo" });
+    });
+
+    test("a quoted bare token is an exact match, case preserved", () => {
+        expect(JF.getQueryDict("'Grep1'")).toEqual({ "tool_id-eq": "Grep1" });
+    });
+
+    test("adding state: alongside a quoted bare token keeps the exact match (regression)", () => {
+        const text = JF.applyFiltersToText({ state: "ok" }, "'Grep1'");
+        expect(text).toBe("'Grep1' state:ok");
+        expect(JF.getQueryDict(text)).toEqual({ "tool_id-eq": "Grep1", "state-eq": "ok" });
+    });
+
+    test("adding state: alongside an unquoted bare token stays a plain search", () => {
+        const text = JF.applyFiltersToText({ state: "ok" }, "grep1");
+        expect(text).toBe("grep1 state:ok");
+        expect(JF.getQueryDict(text)).toEqual({ "tool_id-contains": "grep1", "state-eq": "ok" });
+    });
+
+    test("unspecified text alongside an explicit key:value does not itself become an exact match", () => {
+        // two bare/keyed tokens for the same autoFilterKey -- only a LONE quoted bare token is exact
+        expect(JF.getQueryDict("grep1 tool_id:foo")["tool_id-eq"]).toBeUndefined();
+    });
+});
+
+/**
+ * Quoting a value for `getFilterText` to keep it as one token (because it contains whitespace) must not
+ * be re-read as an exact-match request on the next parse, and a quoted state must follow whichever
+ * occurrence of a repeated key actually survives.
+ */
+describe("quoting for whitespace grouping is syntactic, not an exact-match signal", () => {
+    test("getFilterText -> getQueryDict round-trip: a multi-word contains value stays contains", () => {
+        const text = HistoryFilters.getFilterText({
+            name: "foo bar",
+            ...HistoryFilters.defaultFilters,
+        });
+        expect(text).toBe("name:'foo bar'");
+        expect(HistoryFilters.getQueryDict(text)).toMatchObject({ "name-contains": "foo bar" });
+        expect(HistoryFilters.getQueryDict(text)["name-eq"]).toBeUndefined();
+    });
+
+    test("a single-word quoted value stays an unambiguous exact match", () => {
+        const text = HistoryFilters.getFilterText({
+            name: "GREP",
+            ...HistoryFilters.defaultFilters,
+        });
+        // no source text and no whitespace -> nothing forces quoting here, so this stays unquoted
+        expect(text).toBe("name:GREP");
+        // but a user who explicitly quotes a single word still gets the exact match
+        expect(HistoryFilters.getQueryDict("name:'GREP'")).toMatchObject({ "name-eq": "GREP" });
+    });
+
+    test("duplicate keys: the surviving value's quote-state wins, not any earlier occurrence", () => {
+        // last `name:` wins the value (existing behavior); it must also decide exact-vs-contains
+        expect(HistoryFilters.getQueryDict("name:'Exact' name:partial")).toMatchObject({
+            "name-contains": "partial",
+        });
+        expect(HistoryFilters.getQueryDict("name:'Exact' name:partial")["name-eq"]).toBeUndefined();
+
+        expect(HistoryFilters.getQueryDict("name:partial name:'Exact'")).toMatchObject({
+            "name-eq": "Exact",
+        });
+        expect(HistoryFilters.getQueryDict("name:partial name:'Exact'")["name-contains"]).toBeUndefined();
     });
 });

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -258,3 +258,90 @@ describe("filtering", () => {
         expect(queryDict["tag"]).toBe("name:test");
     });
 });
+
+/**
+ * Quoted filter values (`name:'GREP'`) are meant to produce an exact, case-sensitive
+ * backend match, while the unquoted form (`name:grep`) stays a case-insensitive substring
+ * match. This was fully broken: `getFiltersForText` lowercased + unquoted every value at
+ * parse time, so both forms produced byte-identical output everywhere.
+ *
+ * Contract:
+ * - unquoted: value is lowercased at parse; backend query uses the `-contains` handler.
+ * - quoted:   value keeps its original case; if the filter has a sibling `<key>_eq`
+ *             handler, the backend query routes through it (`<attr>-eq`, exact match).
+ *             Local (`testFilters`) matching is unaffected — it stays case-insensitive.
+ */
+describe("quoted filter values (exact, case-sensitive backend match)", () => {
+    // A filter set with a `name`/`name_eq` sibling pair and no default filters, so the
+    // parsed output isn't padded with `deleted`/`visible` defaults.
+    const F = new Filtering(
+        {
+            name: { type: String, handler: contains("name"), menuItem: true },
+            name_eq: { handler: equals("name"), menuItem: false },
+            state: { type: String, handler: equals("state"), menuItem: true },
+        },
+        undefined,
+        true,
+    );
+
+    test("getFiltersForText keeps original case for quoted values, folds unquoted", () => {
+        expect(Object.fromEntries(F.getFiltersForText("name:'GREP'"))).toEqual({ name: "GREP" });
+        expect(Object.fromEntries(F.getFiltersForText("name:GREP"))).toEqual({ name: "grep" });
+        expect(Object.fromEntries(F.getFiltersForText('name:"GREP"'))).toEqual({ name: "GREP" });
+    });
+
+    test("getFiltersForText strips the surrounding quotes from the stored value", () => {
+        const [[, value]] = F.getFiltersForText("name:'GREP'");
+        expect(value).toBe("GREP");
+        expect(value).not.toContain("'");
+    });
+
+    test("getQueryDict routes a quoted value through the sibling _eq handler", () => {
+        // quoted -> exact, case preserved
+        expect(F.getQueryDict("name:'GREP'")).toEqual({ "name-eq": "GREP" });
+        // unquoted -> case-insensitive substring, lowercased
+        expect(F.getQueryDict("name:GREP")).toEqual({ "name-contains": "grep" });
+    });
+
+    test("getQueryDict routes quoted genome_build through genome_build_eq (HistoryFilters)", () => {
+        expect(HistoryFilters.getQueryDict("genome_build:'Hg19'")).toMatchObject({ "genome_build-eq": "Hg19" });
+        expect(HistoryFilters.getQueryDict("genome_build:hg19")).toMatchObject({ "genome_build-contains": "hg19" });
+    });
+
+    test("getQueryString emits the routed, case-preserved query", () => {
+        expect(F.getQueryString("name:'GREP'")).toBe("q=name-eq&qv=GREP");
+        expect(F.getQueryString("name:grep")).toBe("q=name-contains&qv=grep");
+    });
+
+    test("a quoted value with no _eq sibling still strips quotes and preserves case", () => {
+        // `state` here has no `state_eq`; best-effort: quotes gone, case kept, normal `equals` handler
+        expect(F.getQueryDict("state:'OK'")).toEqual({ "state-eq": "OK" });
+    });
+
+    test("getFilterText round-trips a quoted value unchanged", () => {
+        expect(F.getFilterText({ name: "GREP" }, false, "name:'GREP'")).toBe("name:'GREP'");
+        // unquoted source -> unquoted output
+        expect(F.getFilterText({ name: "grep" }, false, "name:grep")).toBe("name:grep");
+    });
+
+    test("getFilterText keeps quoting values that contain a space", () => {
+        expect(F.getFilterText({ name: "name of item" })).toBe("name:'name of item'");
+    });
+
+    test("getFilterValue returns the case-preserved value for a quoted filter", () => {
+        expect(F.getFilterValue("name:'GREP'", "name")).toBe("GREP");
+        expect(F.getFilterValue("name:grep", "name")).toBe("grep");
+    });
+
+    test("local testFilters matching is unaffected by quoting (stays case-insensitive)", () => {
+        const quoted = HistoryFilters.getFiltersForText("name:'GREP'");
+        const unquoted = HistoryFilters.getFiltersForText("name:grep");
+        const item = { name: "my grep tool", deleted: false, visible: true };
+        expect(HistoryFilters.testFilters(quoted, { ...item })).toBe(true);
+        expect(HistoryFilters.testFilters(unquoted, { ...item })).toBe(true);
+    });
+
+    test("checkFilter stays case-insensitive for quoted values", () => {
+        expect(HistoryFilters.checkFilter("name:'GREP'", "name", "grep")).toBe(true);
+    });
+});

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -345,3 +345,40 @@ describe("quoted filter values (exact, case-sensitive backend match)", () => {
         expect(HistoryFilters.checkFilter("name:'GREP'", "name", "grep")).toBe(true);
     });
 });
+
+/**
+ * A single quoted bare token (`'Grep1'` typed on its own, with no `key:`) is an exact-match
+ * request for the `autoFilterKey`: the quotes are stripped from the folded value, and the query
+ * routes through the `_eq` handler like a keyed quoted value would. An unquoted bare token, or
+ * more than one bare token, stays a plain case-insensitive substring search.
+ */
+describe("a lone quoted bare token routes autoFilterKey through exact match", () => {
+    const F = new Filtering(
+        {
+            search: { type: String, handler: contains("search"), menuItem: true },
+            search_eq: { handler: equals("search"), menuItem: false },
+        },
+        undefined,
+        true,
+        "search",
+    );
+
+    test("getFiltersForText strips the quotes when folding into autoFilterKey", () => {
+        expect(Object.fromEntries(F.getFiltersForText("'Grep1'"))).toEqual({ search: "Grep1" });
+        // an unquoted bare token is folded verbatim (the backend lowercases a `-contains` search)
+        expect(Object.fromEntries(F.getFiltersForText("Grep1"))).toEqual({ search: "Grep1" });
+    });
+
+    test("getQueryDict routes the lone quoted bare token to the _eq handler", () => {
+        expect(F.getQueryDict("'Grep1'")).toEqual({ "search-eq": "Grep1" });
+        expect(F.getQueryDict("Grep1")).toEqual({ "search-contains": "Grep1" });
+    });
+
+    test("more than one bare token is a plain search, not an exact match", () => {
+        expect(F.getQueryDict("foo 'Grep1'")["search-eq"]).toBeUndefined();
+    });
+
+    test("getFilterText writes the folded value back as plain (unlabeled) text", () => {
+        expect(F.getFilterText({ search: "Grep1" }, false, "'Grep1'")).toBe("Grep1");
+    });
+});

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -125,6 +125,21 @@ export function toLowerNoQuotes<T>(value: T): string {
     return toLower(value).replace(/('|")/g, "");
 }
 
+/** Whether a value is wrapped in a matching pair of surrounding quotes, e.g. `'foo'` or `"foo"`.
+ * A quoted value signals an exact, case-sensitive backend match.
+ * */
+export function isQuoted<T>(value: T): boolean {
+    return typeof value === "string" && /^(['"]).*\1$/.test(value);
+}
+
+/** Strips one layer of matching surrounding quotes, preserving case. Leaves unquoted values as is.
+ * @param value
+ * @returns The value without its surrounding quote pair
+ * */
+export function stripQuotes<T>(value: T): string {
+    return isQuoted(value) ? String(value).slice(1, -1) : String(value);
+}
+
 /** Converts name tags starting with '#' to 'name:'
  * @param value
  * @returns String value with 'name:' replaced with '#'
@@ -390,6 +405,62 @@ export default class Filtering<T> {
         return this.autoFilterKey;
     }
 
+    /**
+     * Re-scans `filterText` for `key:'value'` tokens whose value is quoted. `getFiltersForText`
+     * strips the quotes from the stored value, so `getQueryDict`/`getFilterText` call this to
+     * learn which filters the user quoted (an exact, case-sensitive match request).
+     *
+     * @param filterText Raw filter text string
+     * @returns Set of normalized field names (`create_time_gt`, not `create-time>`) with quoted values
+     */
+    private getQuotedFilterKeys(filterText: string): Set<string> {
+        const quotedKeys = new Set<string>();
+        if (!this.quoteStrings) {
+            return quotedKeys;
+        }
+        const pairSplitRE = /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g;
+        const matches = filterText.trim().match(pairSplitRE) || [];
+
+        /**
+         * Tokens with no `key:value` shape at all, i.e. unspecified text; folded into
+         * `autoFilterKey`, collected so a *single*, quoted bare token (e.g. `'Grep1'` on its own)
+         * can count as quoted below.
+         */
+        const unstructuredPairs: string[] = [];
+        for (const pair of matches) {
+            const elgMatch = /(\S+)([:><])(.+)/g.exec(pair);
+            if (!elgMatch) {
+                unstructuredPairs.push(pair);
+                continue;
+            }
+            let field = elgMatch[1]!;
+            const elg = elgMatch[2];
+            const value = elgMatch[3]!;
+            for (const [alias, substitute] of this.validAliases) {
+                if (elg === alias) {
+                    field = `${field}${substitute}`;
+                    break;
+                }
+            }
+            if (isQuoted(value)) {
+                quotedKeys.add(field.split("-").join("_"));
+            }
+        }
+        if (this.autoFilterKey !== undefined && unstructuredPairs.length === 1 && isQuoted(unstructuredPairs[0]!)) {
+            quotedKeys.add(this.autoFilterKey);
+        }
+        return quotedKeys;
+    }
+
+    /**
+     * The valid filter key whose backend query should be used for an exact, case-sensitive match
+     * of `key` — a sibling `${key}_eq` filter if one is declared (e.g. `name` -> `name_eq`),
+     * otherwise `key` itself.
+     */
+    private exactMatchKeyFor(key: string): string {
+        return this.validFilters[`${key}_eq`] !== undefined ? `${key}_eq` : key;
+    }
+
     /** Build a text filter from filters {filter: "value", ...} => "filter:value"
      * @param filters Object containing filters
      * @param backendFormatted If true, returns a string formatted for the backend
@@ -403,6 +474,9 @@ export default class Filtering<T> {
         const hasDefaults = this.containsDefaults(filters);
         const unspecifiedTextKey =
             sourceFilterText !== undefined ? this.getUnspecifiedTextKey(sourceFilterText) : undefined;
+        // keys the user quoted in the source text -- re-emitted quoted so the exact-match intent survives
+        const quotedKeys =
+            sourceFilterText !== undefined ? this.getQuotedFilterKeys(sourceFilterText) : new Set<string>();
 
         let newFilterText = "";
         Object.entries(filters).forEach(([key, value]) => {
@@ -424,8 +498,13 @@ export default class Filtering<T> {
                         .map((v) => this.getConvertedValue(key, v, backendFormatted))
                         .filter((v) => v !== undefined) as T[];
                     newFilterText += `${convertedValues.map((v) => `${this.toAliasKey(key)}${v}`).join(" ")}`;
-                } else if (this.quoteStrings && String(value).includes(" ")) {
-                    newFilterText += `${this.toAliasKey(key)}'${value}'`;
+                } else if (
+                    this.quoteStrings &&
+                    (quotedKeys.has(key) || isQuoted(value) || String(value).includes(" "))
+                ) {
+                    // re-emit quoted: the user quoted it in the source text, it's already a
+                    // quoted literal (e.g. from setFilterValue), or it contains a space
+                    newFilterText += `${this.toAliasKey(key)}'${stripQuotes(value)}'`;
                 } else {
                     newFilterText += `${this.toAliasKey(key)}${value}`;
                 }
@@ -495,8 +574,13 @@ export default class Filtering<T> {
                         this.validFilters[normalizedField]?.boolType !== "is" &&
                         ((!validate && normalizedField !== "is") || this.validFilters[normalizedField])
                     ) {
-                        // removes quotation and applies lower-case to filter value
-                        const newVal = this.quoteStrings ? (toLowerNoQuotes(value) as T) : (value as T);
+                        // A quoted value keeps its original case (exact, case-sensitive match);
+                        // an unquoted value is folded to lower case (case-insensitive match).
+                        // Either way the surrounding quotes are stripped from the stored value —
+                        // `getQueryDict`/`getFilterText` re-derive quoted-ness from the source text.
+                        const newVal = this.quoteStrings
+                            ? ((isQuoted(value) ? stripQuotes(value) : toLowerNoQuotes(value)) as T)
+                            : (value as T);
                         // if the field is a MultiTags field, we need to push each value to an array
                         if (this.validFilters[normalizedField]?.type === "MultiTags") {
                             if (result[normalizedField] === undefined) {
@@ -521,9 +605,12 @@ export default class Filtering<T> {
                 }
             });
         }
-        // fold unspecified text into the auto-filter key
+        // fold unspecified text into the auto-filter key (make sure quoted tokens are stripped of quotes)
         if (this.autoFilterKey !== undefined && unstructuredPairs.length > 0) {
-            const unmatchedText = unstructuredPairs.join(" ");
+            const unmatchedText =
+                unstructuredPairs.length === 1 && isQuoted(unstructuredPairs[0]!)
+                    ? stripQuotes(unstructuredPairs[0]!)
+                    : unstructuredPairs.join(" ");
             const existing = result[this.autoFilterKey];
             result[this.autoFilterKey] = (existing !== undefined ? `${existing} ${unmatchedText}` : unmatchedText) as T;
         }
@@ -622,15 +709,25 @@ export default class Filtering<T> {
     }
 
     /** Returns a dictionary with query key and values.
+     *
+     * A quoted filter value (`name:'GREP'`) is an exact, case-sensitive match: it is routed
+     * through the filter's sibling `${key}_eq` handler if one exists (`name-eq`, which the
+     * backend compares with `==`), rather than the default (`name-contains`, a case-insensitive
+     * substring match). The value keeps its original case; `getFiltersForText` has already
+     * stripped the surrounding quotes.
+     *
      * @param filterText Raw filter text string
      * @returns Dictionary with query key and values
      */
     getQueryDict(filterText: string) {
         const queryDict: Record<string, T> = {};
         const filters = this.getFiltersForText(filterText);
+        const quotedKeys = this.getQuotedFilterKeys(filterText);
         for (const [key, value] of filters) {
-            const query = this.validFilters[key]?.handler.query;
-            const converter = this.validFilters[key]?.handler.converter;
+            const queryKey = quotedKeys.has(key) ? this.exactMatchKeyFor(key) : key;
+            const handler = this.validFilters[queryKey]?.handler;
+            const query = handler?.query;
+            const converter = handler?.converter;
             if (query) {
                 queryDict[query] = converter ? converter(value) : value;
             }

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -248,42 +248,29 @@ export function compare<T>(attribute: string, variant: string, converter?: Conve
     };
 }
 
-/**
- * Class for filtering (menus). Handles user input as one string filterText
- * or multiple filters (e.g. 'name:foo type:bar'), with appropriate functions.
- * @param validFilters: Record of valid filters with their handlers,
- *                      and FilterMenu properties (if menuItem = true)
- * @param validAliases: Array of valid aliases for filters
- * @param quoteStrings: Whether to auto quote filter strings in the query
- * @param nameMatching: Whether to apply name filter for unspecified filterText
- *                      (e.g. filterText = 'foo' -> 'name:foo').
- *                      Typically, when this is false, we index every field in
- *                      the backend for unspecified filterText.
- * @returns Filtering object
- * */
 export default class Filtering<T> {
-    validFilters: Record<string, ValidFilter<T>>;
-    validAliases: Array<[string, string]>;
+    /** Filter keys/values to apply when `filterText` is empty, built from `validFilters[key].default` */
     defaultFilters: Record<string, T>;
-    quoteStrings: boolean;
-    nameMatching: boolean;
 
+    /**
+     * Class for filtering (menus). Handles user input as one string filterText
+     * or multiple filters (e.g. 'name:foo type:bar'), with appropriate functions.
+     * @param validFilters Record of valid filters with their handlers,
+     *                      and FilterMenu properties (if menuItem = true)
+     * @param validAliases Array of valid aliases for filters
+     * @param quoteStrings Whether to auto quote filter strings in the query
+     * @param autoFilterKey Filter key that unspecified text (e.g. 'foo' in 'foo type:bar') maps to,
+     *                      e.g. 'name'. Must already be declared in `validFilters`. Omit to leave
+     *                      unspecified text unmatched.
+     */
     constructor(
-        validFilters: Record<string, ValidFilter<T>>,
-        validAliases?: Array<[string, string]>,
-        quoteStrings = true,
-        nameMatching = true,
+        public validFilters: Record<string, ValidFilter<T>>,
+        public validAliases: Array<[string, string]> = defaultValidAliases,
+        public quoteStrings = true,
+        public autoFilterKey?: string,
     ) {
-        this.validFilters = validFilters;
-        this.validAliases = validAliases || defaultValidAliases;
-        this.quoteStrings = quoteStrings;
-        this.nameMatching = nameMatching;
-        // If (default) we are nameMatching, add `name` filter if not present
-        if (this.nameMatching && this.validFilters["name"] === undefined) {
-            this.validFilters["name"] = {
-                handler: contains("name"),
-                menuItem: false,
-            };
+        if (this.autoFilterKey !== undefined && this.validFilters[this.autoFilterKey] === undefined) {
+            throw new Error(`Filtering: autoFilterKey "${this.autoFilterKey}" must be declared in validFilters`);
         }
         this.defaultFilters = this.createDefaultFiltersIfPresent();
         this.addRangedFiltersIfNotPresent();
@@ -360,14 +347,62 @@ export default class Filtering<T> {
         );
     }
 
+    /**
+     * Returns `autoFilterKey`, unless it appears in `filterText` as an explicit
+     * `autoFilterKey:value` token (i.e. the user typed it themselves).
+     *
+     * @param filterText Raw filter text string
+     * @returns `autoFilterKey` if not explicitly typed, else `undefined`
+     * @example
+     * // autoFilterKey = "name"
+     * getUnspecifiedTextKey("foo") // returns "name"
+     * getUnspecifiedTextKey("name:foo") // returns undefined
+     */
+    private getUnspecifiedTextKey(filterText: string): string | undefined {
+        if (this.autoFilterKey === undefined) {
+            return undefined;
+        }
+        filterText = filterText.trim();
+        const pairSplitRE = this.quoteStrings
+            ? /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g
+            : /(\S+):(.*?)(?=\s+\S+:|$)/g;
+        const matches = filterText.match(pairSplitRE) || [];
+        for (const pair of matches) {
+            const elgRE = /(\S+)([:><])(.+)/g;
+            const elgMatch = elgRE.exec(pair);
+            if (!elgMatch) {
+                continue;
+            }
+            let field = elgMatch[1];
+            const elg = elgMatch[2];
+            for (const [alias, substitute] of this.validAliases) {
+                if (elg === alias) {
+                    field = `${field}${substitute}`;
+                    break;
+                }
+            }
+            const normalizedField = field?.split("-").join("_");
+            if (normalizedField === this.autoFilterKey) {
+                // an explicit `autoFilterKey:value` token exists -- the user typed it themselves
+                return undefined;
+            }
+        }
+        return this.autoFilterKey;
+    }
+
     /** Build a text filter from filters {filter: "value", ...} => "filter:value"
      * @param filters Object containing filters
      * @param backendFormatted If true, returns a string formatted for the backend
+     * @param sourceFilterText The filterText `filters` came from, if any. Used to tell whether
+     *                      `autoFilterKey`'s value was unspecified text (write back as plain text)
+     *                      or an explicit `key:value` token (write back as `key:value`).
      * @returns Parsed filter text string
      * */
-    getFilterText(filters: Record<string, T>, backendFormatted = false): string {
+    getFilterText(filters: Record<string, T>, backendFormatted = false, sourceFilterText?: string): string {
         filters = this.getValidFilters(filters, backendFormatted).validFilters;
         const hasDefaults = this.containsDefaults(filters);
+        const unspecifiedTextKey =
+            sourceFilterText !== undefined ? this.getUnspecifiedTextKey(sourceFilterText) : undefined;
 
         let newFilterText = "";
         Object.entries(filters).forEach(([key, value]) => {
@@ -377,7 +412,10 @@ export default class Filtering<T> {
                 if (newFilterText) {
                     newFilterText += " ";
                 }
-                if (this.validFilters[key]?.type === Boolean && this.validFilters[key]?.boolType === "is") {
+                if (key === unspecifiedTextKey) {
+                    // write unspecified text back as plain text, not `key:value`
+                    newFilterText += `${value}`;
+                } else if (this.validFilters[key]?.type === Boolean && this.validFilters[key]?.boolType === "is") {
                     if (value === true) {
                         newFilterText += `is:${key}`;
                     }
@@ -423,7 +461,18 @@ export default class Filtering<T> {
             : /(\S+):(.*?)(?=\s+\S+:|$)/g;
         const matches = filterText.match(pairSplitRE);
         let result: Record<string, T> = {};
-        let hasMatches = false;
+        /** Tokens with no `key:value` shape at all, i.e. unspecified text; folded into
+         * `autoFilterKey` below, alongside any other filters matched in the same filterText
+         */
+        const unstructuredPairs: string[] = [];
+        if (!this.quoteStrings) {
+            // this regex only matches from the first `key:` onward, so grab any leading text separately
+            const firstMatchStart = matches?.length ? filterText.indexOf(matches[0]!) : filterText.length;
+            const leadingText = filterText.slice(0, firstMatchStart).trim();
+            if (leadingText) {
+                unstructuredPairs.push(leadingText);
+            }
+        }
         if (matches) {
             matches.forEach((pair) => {
                 const elgRE = /(\S+)([:><])(.+)/g;
@@ -458,7 +507,6 @@ export default class Filtering<T> {
                         } else {
                             result[normalizedField] = newVal;
                         }
-                        hasMatches = true;
                     } else if (
                         value &&
                         field === "is" &&
@@ -467,14 +515,17 @@ export default class Filtering<T> {
                     ) {
                         // handle `is:filter` syntax
                         result[value] = true as T;
-                        hasMatches = true;
                     }
+                } else {
+                    unstructuredPairs.push(pair);
                 }
             });
         }
-        // assume name matching if no filter key has been matched
-        if (this.nameMatching && !hasMatches && filterText.length > 0) {
-            result["name"] = filterText as T;
+        // fold unspecified text into the auto-filter key
+        if (this.autoFilterKey !== undefined && unstructuredPairs.length > 0) {
+            const unmatchedText = unstructuredPairs.join(" ");
+            const existing = result[this.autoFilterKey];
+            result[this.autoFilterKey] = (existing !== undefined ? `${existing} ${unmatchedText}` : unmatchedText) as T;
         }
         // check if any default filter keys have been used in the filter text
         if (this.defaultFilters !== undefined) {
@@ -512,7 +563,7 @@ export default class Filtering<T> {
         } else {
             validFilters = Object.assign(existingFilters, validFilters);
         }
-        return this.getFilterText(validFilters);
+        return this.getFilterText(validFilters, false, existingText);
     }
 
     /** Takes a filters object and returns a new object with only valid filters

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -170,6 +170,26 @@ export type HandlerReturn<T> = {
     handler: Handler<T>;
 };
 
+/** One parsed unit of a `filterText` string, produced by `Filtering.tokenize`.
+ * Everything the class needs downstream (quoted-ness, raw-text-ness, the typed operator) lives
+ * here, so `filterText` is only ever tokenized once per operation.
+ */
+interface FilterToken {
+    /** Normalized backend key (`create_time_gt`, not `create-time>`). `undefined` for raw text. */
+    key?: string;
+    /** The alias operator as typed (`:` / `>` / `<`), used to rebuild `filterText` exactly. */
+    op?: ":" | ">" | "<";
+    /** Value with surrounding quotes stripped (`quoteStrings`) or kept verbatim (`!quoteStrings`);
+     * original case is always preserved at this layer. */
+    value: string;
+    /** The value was wrapped in a matching quote pair (an exact, case-sensitive match request). */
+    quoted: boolean;
+    /** The token had no `key:value` shape -- unspecified text destined for `autoFilterKey`. */
+    isRawText: boolean;
+    /** The token used `is:key` syntax (means the boolean filter `key` is `true`). */
+    isBool: boolean;
+}
+
 /**
  * Checks if a query value is equal to the item value
  * @param attribute of the content item
@@ -362,94 +382,143 @@ export default class Filtering<T> {
         );
     }
 
-    /**
-     * Returns `autoFilterKey`, unless it appears in `filterText` as an explicit
-     * `autoFilterKey:value` token (i.e. the user typed it themselves).
-     *
-     * @param filterText Raw filter text string
-     * @returns `autoFilterKey` if not explicitly typed, else `undefined`
-     * @example
-     * // autoFilterKey = "name"
-     * getUnspecifiedTextKey("foo") // returns "name"
-     * getUnspecifiedTextKey("name:foo") // returns undefined
+    /** Splits a whitespace-trimmed `filterText` into its `key:value` (and raw-text) chunks.
+     * The two `quoteStrings` modes tokenize incompatibly: `true` groups spaces with quotes and
+     * allows bare raw text; `false` lets a value run unquoted up to the next `key:` token.
      */
-    private getUnspecifiedTextKey(filterText: string): string | undefined {
-        if (this.autoFilterKey === undefined) {
-            return undefined;
-        }
+    private splitPairs(filterText: string): { pairs: string[]; leadingText?: string } {
         filterText = filterText.trim();
-        const pairSplitRE = this.quoteStrings
-            ? /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g
-            : /(\S+):(.*?)(?=\s+\S+:|$)/g;
-        const matches = filterText.match(pairSplitRE) || [];
-        for (const pair of matches) {
-            const elgRE = /(\S+)([:><])(.+)/g;
-            const elgMatch = elgRE.exec(pair);
-            if (!elgMatch) {
-                continue;
-            }
-            let field = elgMatch[1];
-            const elg = elgMatch[2];
-            for (const [alias, substitute] of this.validAliases) {
-                if (elg === alias) {
-                    field = `${field}${substitute}`;
-                    break;
-                }
-            }
-            const normalizedField = field?.split("-").join("_");
-            if (normalizedField === this.autoFilterKey) {
-                // an explicit `autoFilterKey:value` token exists -- the user typed it themselves
-                return undefined;
-            }
+        if (this.quoteStrings) {
+            const re = /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g;
+            return { pairs: filterText.match(re) || [] };
         }
-        return this.autoFilterKey;
+        const re = /(\S+):(.*?)(?=\s+\S+:|$)/g;
+        const pairs = filterText.match(re) || [];
+        // this regex only matches from the first `key:` onward, so any leading text is separate
+        const firstMatchStart = pairs.length ? filterText.indexOf(pairs[0]!) : filterText.length;
+        const leadingText = filterText.slice(0, firstMatchStart).trim();
+        return { pairs, leadingText: leadingText || undefined };
     }
 
-    /**
-     * Re-scans `filterText` for `key:'value'` tokens whose value is quoted. `getFiltersForText`
-     * strips the quotes from the stored value, so `getQueryDict`/`getFilterText` call this to
-     * learn which filters the user quoted (an exact, case-sensitive match request).
-     *
-     * @param filterText Raw filter text string
-     * @returns Set of normalized field names (`create_time_gt`, not `create-time>`) with quoted values
+    /** Splits one `key:value` / `key>value` / `key<value` chunk into its parts, or `null` if it
+     * has no such shape (i.e. it is raw text).
      */
-    private getQuotedFilterKeys(filterText: string): Set<string> {
-        const quotedKeys = new Set<string>();
-        if (!this.quoteStrings) {
-            return quotedKeys;
+    private splitKeyOpValue(pair: string): { field: string; op: ":" | ">" | "<"; value: string } | null {
+        const match = /(\S+)([:><])(.+)/g.exec(pair);
+        if (!match) {
+            return null;
         }
-        const pairSplitRE = /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g;
-        const matches = filterText.trim().match(pairSplitRE) || [];
+        return { field: match[1]!, op: match[2] as ":" | ">" | "<", value: match[3]! };
+    }
 
-        /**
-         * Tokens with no `key:value` shape at all, i.e. unspecified text; folded into
-         * `autoFilterKey`, collected so a *single*, quoted bare token (e.g. `'Grep1'` on its own)
-         * can count as quoted below.
-         */
-        const unstructuredPairs: string[] = [];
-        for (const pair of matches) {
-            const elgMatch = /(\S+)([:><])(.+)/g.exec(pair);
-            if (!elgMatch) {
-                unstructuredPairs.push(pair);
+    /** Applies an alias substitution (`>` -> `_gt`) and normalizes dashes to underscores, turning a
+     * typed field + operator into its normalized backend key (`create-time` + `>` -> `create_time_gt`).
+     */
+    private normalizeFieldKey(field: string, op: string): string {
+        for (const [alias, substitute] of this.validAliases) {
+            if (op === alias) {
+                field = `${field}${substitute}`;
+                break;
+            }
+        }
+        return field.split("-").join("_");
+    }
+
+    /** Parses `filterText` into a flat token list, once. Preserves quoted-ness, raw-text-ness, and
+     * the typed operator so no downstream method has to re-scan the source text.
+     */
+    private tokenize(filterText: string): FilterToken[] {
+        const { pairs, leadingText } = this.splitPairs(filterText);
+        const tokens: FilterToken[] = [];
+        if (leadingText) {
+            tokens.push({ value: leadingText, quoted: false, isRawText: true, isBool: false });
+        }
+        for (const pair of pairs) {
+            const parts = this.splitKeyOpValue(pair);
+            if (!parts) {
+                tokens.push({ value: pair, quoted: false, isRawText: true, isBool: false });
                 continue;
             }
-            let field = elgMatch[1]!;
-            const elg = elgMatch[2];
-            const value = elgMatch[3]!;
-            for (const [alias, substitute] of this.validAliases) {
-                if (elg === alias) {
-                    field = `${field}${substitute}`;
-                    break;
+            const { field, op, value } = parts;
+            if (field === "is" && op === ":") {
+                // `is:key` syntax -- the value names the boolean filter being set to true
+                tokens.push({ key: value, op, value, quoted: false, isRawText: false, isBool: true });
+                continue;
+            }
+            tokens.push({
+                key: this.normalizeFieldKey(field, op),
+                op,
+                value,
+                quoted: this.quoteStrings && isQuoted(value),
+                isRawText: false,
+                isBool: false,
+            });
+        }
+        // A lone quoted bare token (e.g. `'Grep1'` typed on its own) is an exact-match request for
+        // `autoFilterKey`: tag it with that key + `quoted` so it routes like a keyed quoted value.
+        const rawTokens = tokens.filter((t) => t.isRawText);
+        if (
+            this.quoteStrings &&
+            this.autoFilterKey !== undefined &&
+            rawTokens.length === 1 &&
+            isQuoted(rawTokens[0]!.value)
+        ) {
+            rawTokens[0]!.key = this.autoFilterKey;
+            rawTokens[0]!.quoted = true;
+        }
+        return tokens;
+    }
+
+    /** Folds a token list into a `{key: value}` dict (the shape `getFiltersForText` returns before
+     * default handling). Applies validity filtering, MultiTags array accumulation, the
+     * `quoteStrings` quote-strip/lowercase rule, and `autoFilterKey` raw-text folding.
+     */
+    private parseTokensToDict(tokens: FilterToken[], validate: boolean): Record<string, T> {
+        const result: Record<string, T> = {};
+        const rawText: string[] = [];
+        for (const token of tokens) {
+            if (token.isRawText) {
+                // a lone quoted bare token folds in with its quotes stripped (see `tokenize`)
+                rawText.push(token.quoted ? stripQuotes(token.value) : token.value);
+                continue;
+            }
+            if (token.isBool) {
+                // `is:key` -- keep only if the named filter is really a `boolType: "is"` filter
+                if (!validate || this.validFilters[token.value]?.boolType === "is") {
+                    result[token.value] = true as T;
                 }
+                continue;
             }
-            if (isQuoted(value)) {
-                quotedKeys.add(field.split("-").join("_"));
+            const key = token.key!;
+            const isValid =
+                this.validFilters[key]?.boolType !== "is" &&
+                ((!validate && key !== "is") || this.validFilters[key] !== undefined);
+            if (!isValid) {
+                continue;
+            }
+            // A quoted value keeps its original case (exact, case-sensitive match); an unquoted
+            // value is folded to lower case. Either way surrounding quotes are stripped here --
+            // `getQueryDict`/`getFilterText` recover quoted-ness from the source text.
+            const value = this.quoteStrings
+                ? ((token.quoted ? stripQuotes(token.value) : toLowerNoQuotes(token.value)) as T)
+                : (token.value as T);
+            if (this.validFilters[key]?.type === "MultiTags") {
+                if (result[key] === undefined) {
+                    result[key] = [value] as T;
+                } else {
+                    (result[key] as T[]).push(value);
+                }
+            } else {
+                result[key] = value;
             }
         }
-        if (this.autoFilterKey !== undefined && unstructuredPairs.length === 1 && isQuoted(unstructuredPairs[0]!)) {
-            quotedKeys.add(this.autoFilterKey);
+        // fold unspecified text into the auto-filter key
+        if (this.autoFilterKey !== undefined && rawText.length > 0) {
+            const unmatchedText = rawText.join(" ");
+            const existing = result[this.autoFilterKey];
+            result[this.autoFilterKey] = (existing !== undefined ? `${existing} ${unmatchedText}` : unmatchedText) as T;
         }
-        return quotedKeys;
+        return result;
     }
 
     /**
@@ -464,19 +533,26 @@ export default class Filtering<T> {
     /** Build a text filter from filters {filter: "value", ...} => "filter:value"
      * @param filters Object containing filters
      * @param backendFormatted If true, returns a string formatted for the backend
-     * @param sourceFilterText The filterText `filters` came from, if any. Used to tell whether
-     *                      `autoFilterKey`'s value was unspecified text (write back as plain text)
-     *                      or an explicit `key:value` token (write back as `key:value`).
+     * @param sourceFilterText The filterText `filters` came from, if any. Tokenized once to recover
+     *                      intent `getFiltersForText` discards: whether `autoFilterKey`'s value was
+     *                      unspecified text (write back as plain text) vs an explicit `key:value`
+     *                      token, and which values the user quoted (re-emit quoted).
      * @returns Parsed filter text string
      * */
     getFilterText(filters: Record<string, T>, backendFormatted = false, sourceFilterText?: string): string {
         filters = this.getValidFilters(filters, backendFormatted).validFilters;
         const hasDefaults = this.containsDefaults(filters);
+        // Tokenize the source text once to recover intent that `getFiltersForText` discards:
+        // whether `autoFilterKey`'s value was unspecified text (write it back as plain text) and
+        // which keys the user quoted (re-emit them quoted so the exact-match intent survives).
+        const sourceTokens = sourceFilterText !== undefined ? this.tokenize(sourceFilterText) : [];
         const unspecifiedTextKey =
-            sourceFilterText !== undefined ? this.getUnspecifiedTextKey(sourceFilterText) : undefined;
-        // keys the user quoted in the source text -- re-emitted quoted so the exact-match intent survives
-        const quotedKeys =
-            sourceFilterText !== undefined ? this.getQuotedFilterKeys(sourceFilterText) : new Set<string>();
+            sourceFilterText !== undefined &&
+            this.autoFilterKey !== undefined &&
+            !sourceTokens.some((t) => !t.isRawText && !t.isBool && t.key === this.autoFilterKey)
+                ? this.autoFilterKey
+                : undefined;
+        const quotedKeys = new Set(sourceTokens.filter((t) => t.quoted && t.key !== undefined).map((t) => t.key!));
 
         let newFilterText = "";
         Object.entries(filters).forEach(([key, value]) => {
@@ -534,87 +610,15 @@ export default class Filtering<T> {
      * @returns Filters as 2D array of of [field, value] pairs
      * */
     getFiltersForText(filterText: string, removeAny = true, validate = true): [string, T][] {
-        filterText = filterText.trim();
-        const pairSplitRE = this.quoteStrings
-            ? /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g
-            : /(\S+):(.*?)(?=\s+\S+:|$)/g;
-        const matches = filterText.match(pairSplitRE);
-        let result: Record<string, T> = {};
-        /** Tokens with no `key:value` shape at all, i.e. unspecified text; folded into
-         * `autoFilterKey` below, alongside any other filters matched in the same filterText
-         */
-        const unstructuredPairs: string[] = [];
-        if (!this.quoteStrings) {
-            // this regex only matches from the first `key:` onward, so grab any leading text separately
-            const firstMatchStart = matches?.length ? filterText.indexOf(matches[0]!) : filterText.length;
-            const leadingText = filterText.slice(0, firstMatchStart).trim();
-            if (leadingText) {
-                unstructuredPairs.push(leadingText);
-            }
-        }
-        if (matches) {
-            matches.forEach((pair) => {
-                const elgRE = /(\S+)([:><])(.+)/g;
-                const elgMatch = elgRE.exec(pair);
-                if (elgMatch) {
-                    let field = elgMatch[1];
-                    const elg = elgMatch[2];
-                    const value = elgMatch[3];
-                    // replace alias for less and greater symbol
-                    for (const [alias, substitute] of this.validAliases) {
-                        if (elg === alias) {
-                            field = `${field}${substitute}`;
-                            break;
-                        }
-                    }
-                    // replaces dashes with underscores in query field names
-                    const normalizedField = field?.split("-").join("_");
-                    if (
-                        normalizedField &&
-                        this.validFilters[normalizedField]?.boolType !== "is" &&
-                        ((!validate && normalizedField !== "is") || this.validFilters[normalizedField])
-                    ) {
-                        // A quoted value keeps its original case (exact, case-sensitive match);
-                        // an unquoted value is folded to lower case (case-insensitive match).
-                        // Either way the surrounding quotes are stripped from the stored value —
-                        // `getQueryDict`/`getFilterText` re-derive quoted-ness from the source text.
-                        const newVal = this.quoteStrings
-                            ? ((isQuoted(value) ? stripQuotes(value) : toLowerNoQuotes(value)) as T)
-                            : (value as T);
-                        // if the field is a MultiTags field, we need to push each value to an array
-                        if (this.validFilters[normalizedField]?.type === "MultiTags") {
-                            if (result[normalizedField] === undefined) {
-                                result[normalizedField] = [newVal] as T;
-                            } else {
-                                (result[normalizedField] as T[]).push(newVal);
-                            }
-                        } else {
-                            result[normalizedField] = newVal;
-                        }
-                    } else if (
-                        value &&
-                        field === "is" &&
-                        elg === ":" &&
-                        (!validate || this.validFilters[value]?.boolType === "is")
-                    ) {
-                        // handle `is:filter` syntax
-                        result[value] = true as T;
-                    }
-                } else {
-                    unstructuredPairs.push(pair);
-                }
-            });
-        }
-        // fold unspecified text into the auto-filter key (make sure quoted tokens are stripped of quotes)
-        if (this.autoFilterKey !== undefined && unstructuredPairs.length > 0) {
-            const unmatchedText =
-                unstructuredPairs.length === 1 && isQuoted(unstructuredPairs[0]!)
-                    ? stripQuotes(unstructuredPairs[0]!)
-                    : unstructuredPairs.join(" ");
-            const existing = result[this.autoFilterKey];
-            result[this.autoFilterKey] = (existing !== undefined ? `${existing} ${unmatchedText}` : unmatchedText) as T;
-        }
-        // check if any default filter keys have been used in the filter text
+        return Object.entries(this.parseFilterText(this.tokenize(filterText), removeAny, validate));
+    }
+
+    /** Tokens -> `{key: value}` dict, applying validity, MultiTags, `autoFilterKey` folding, and
+     * default-filter handling (`removeAny` and "inject defaults if none were specified"). This is
+     * the single parse pass `getFiltersForText` and `getQueryDict` share.
+     */
+    private parseFilterText(tokens: FilterToken[], removeAny: boolean, validate: boolean): Record<string, T> {
+        let result = this.parseTokensToDict(tokens, validate);
         if (this.defaultFilters !== undefined) {
             let hasDefaults = false;
             Object.keys(this.defaultFilters).forEach((defaultKey) => {
@@ -631,8 +635,7 @@ export default class Filtering<T> {
                 result = { ...result, ...this.defaultFilters };
             }
         }
-
-        return Object.entries(result);
+        return result;
     }
 
     /**
@@ -713,16 +716,18 @@ export default class Filtering<T> {
      * A quoted filter value (`name:'GREP'`) is an exact, case-sensitive match: it is routed
      * through the filter's sibling `${key}_eq` handler if one exists (`name-eq`, which the
      * backend compares with `==`), rather than the default (`name-contains`, a case-insensitive
-     * substring match). The value keeps its original case; `getFiltersForText` has already
-     * stripped the surrounding quotes.
+     * substring match). The parsed value keeps its original case with the quotes stripped.
      *
      * @param filterText Raw filter text string
      * @returns Dictionary with query key and values
      */
     getQueryDict(filterText: string) {
         const queryDict: Record<string, T> = {};
-        const filters = this.getFiltersForText(filterText);
-        const quotedKeys = this.getQuotedFilterKeys(filterText);
+        const tokens = this.tokenize(filterText);
+        const quotedKeys = new Set(
+            tokens.filter((token) => token.quoted && token.key !== undefined).map((token) => token.key!),
+        );
+        const filters = Object.entries(this.parseFilterText(tokens, true, true));
         for (const [key, value] of filters) {
             const queryKey = quotedKeys.has(key) ? this.exactMatchKeyFor(key) : key;
             const handler = this.validFilters[queryKey]?.handler;

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -182,8 +182,11 @@ interface FilterToken {
     /** Value with surrounding quotes stripped (`quoteStrings`) or kept verbatim (`!quoteStrings`);
      * original case is always preserved at this layer. */
     value: string;
-    /** The value was wrapped in a matching quote pair (an exact, case-sensitive match request). */
+    /** The value was wrapped in a matching quote pair. The token's case should be preserved and
+     * not lower cased. It does NOT by itself mean an exact match; see `exactMatch`. */
     quoted: boolean;
+    /** An exact match request: the value was quoted AND has no whitespace (is single-word). */
+    exactMatch: boolean;
     /** The token had no `key:value` shape -- unspecified text destined for `autoFilterKey`. */
     isRawText: boolean;
     /** The token used `is:key` syntax (means the boolean filter `key` is `true`). */
@@ -431,31 +434,42 @@ export default class Filtering<T> {
         const { pairs, leadingText } = this.splitPairs(filterText);
         const tokens: FilterToken[] = [];
         if (leadingText) {
-            tokens.push({ value: leadingText, quoted: false, isRawText: true, isBool: false });
+            tokens.push({ value: leadingText, quoted: false, exactMatch: false, isRawText: true, isBool: false });
         }
         for (const pair of pairs) {
             const parts = this.splitKeyOpValue(pair);
             if (!parts) {
-                tokens.push({ value: pair, quoted: false, isRawText: true, isBool: false });
+                tokens.push({ value: pair, quoted: false, exactMatch: false, isRawText: true, isBool: false });
                 continue;
             }
             const { field, op, value } = parts;
             if (field === "is" && op === ":") {
                 // `is:key` syntax -- the value names the boolean filter being set to true
-                tokens.push({ key: value, op, value, quoted: false, isRawText: false, isBool: true });
+                tokens.push({
+                    key: value,
+                    op,
+                    value,
+                    quoted: false,
+                    exactMatch: false,
+                    isRawText: false,
+                    isBool: true,
+                });
                 continue;
             }
+            const quoted = this.quoteStrings && isQuoted(value);
             tokens.push({
                 key: this.normalizeFieldKey(field, op),
                 op,
                 value,
-                quoted: this.quoteStrings && isQuoted(value),
+                quoted,
+                // a quoted *multi-word* value is ambiguous -- see `FilterToken.exactMatch`
+                exactMatch: quoted && !stripQuotes(value).includes(" "),
                 isRawText: false,
                 isBool: false,
             });
         }
         // A lone quoted bare token (e.g. `'Grep1'` typed on its own) is an exact-match request for
-        // `autoFilterKey`: tag it with that key + `quoted` so it routes like a keyed quoted value.
+        // `autoFilterKey`: tag it with that key so it routes like a keyed quoted value.
         const rawTokens = tokens.filter((t) => t.isRawText);
         if (
             this.quoteStrings &&
@@ -465,6 +479,7 @@ export default class Filtering<T> {
         ) {
             rawTokens[0]!.key = this.autoFilterKey;
             rawTokens[0]!.quoted = true;
+            rawTokens[0]!.exactMatch = !stripQuotes(rawTokens[0]!.value).includes(" ");
         }
         return tokens;
     }
@@ -522,6 +537,34 @@ export default class Filtering<T> {
     }
 
     /**
+     * The set of keys whose *surviving* value came from an `FilterToken.exactMatch`.
+     * For a repeated key (`name:'Exact' name:partial`) only the last occurrence wins the value in
+     * `parseTokensToDict`, so its exact-match status must win here too as an earlier quoted
+     * occurrence must not leak exact-match routing onto a later, unquoted value for the same key.
+     * MultiTags keys accumulate instead of overwriting, so every occurrence contributes
+     * independently there, same as today.
+     */
+    private exactMatchByKey(tokens: FilterToken[]): Set<string> {
+        const exactMatch = new Map<string, boolean>();
+        for (const token of tokens) {
+            // a raw-text token is only relevant here if `tokenize` tagged it with `autoFilterKey`
+            // (a lone quoted bare token); an untagged raw-text token has no `key` and is skipped
+            if (token.isBool || token.key === undefined) {
+                continue;
+            }
+            const isMultiTags = this.validFilters[token.key]?.type === "MultiTags";
+            if (isMultiTags) {
+                exactMatch.set(token.key, (exactMatch.get(token.key) ?? false) || token.exactMatch);
+            } else {
+                // scalar key: the last token for this key determines both the value and its
+                // exact-match status, matching `parseTokensToDict`'s last-one-wins overwrite
+                exactMatch.set(token.key, token.exactMatch);
+            }
+        }
+        return new Set([...exactMatch.entries()].filter(([, v]) => v).map(([k]) => k));
+    }
+
+    /**
      * The valid filter key whose backend query should be used for an exact, case-sensitive match
      * of `key` — a sibling `${key}_eq` filter if one is declared (e.g. `name` -> `name_eq`),
      * otherwise `key` itself.
@@ -544,7 +587,7 @@ export default class Filtering<T> {
         const hasDefaults = this.containsDefaults(filters);
         // Tokenize the source text once to recover intent that `getFiltersForText` discards:
         // whether `autoFilterKey`'s value was unspecified text (write it back as plain text) and
-        // which keys the user quoted (re-emit them quoted so the exact-match intent survives).
+        // which keys the user quoted for an exact match (re-emit them quoted so the intent survives).
         const sourceTokens = sourceFilterText !== undefined ? this.tokenize(sourceFilterText) : [];
         const unspecifiedTextKey =
             sourceFilterText !== undefined &&
@@ -552,7 +595,10 @@ export default class Filtering<T> {
             !sourceTokens.some((t) => !t.isRawText && !t.isBool && t.key === this.autoFilterKey)
                 ? this.autoFilterKey
                 : undefined;
-        const quotedKeys = new Set(sourceTokens.filter((t) => t.quoted && t.key !== undefined).map((t) => t.key!));
+        // Only an unambiguous exact-match quoting (single word, see `FilterToken.exactMatch`) is
+        // re-emitted as quoted here -- a multi-word value gets re-quoted anyway below because it
+        // has a space, but that quoting is purely syntactic and must not imply exact match.
+        const exactMatchKeys = this.exactMatchByKey(sourceTokens);
 
         let newFilterText = "";
         Object.entries(filters).forEach(([key, value]) => {
@@ -563,8 +609,9 @@ export default class Filtering<T> {
                     newFilterText += " ";
                 }
                 if (key === unspecifiedTextKey) {
-                    // write unspecified text back as plain text, not `key:value`
-                    newFilterText += `${value}`;
+                    // write unspecified text back as plain text, not `key:value` -- but keep it
+                    // quoted if it was an unambiguous exact-match request (a lone quoted bare token)
+                    newFilterText += exactMatchKeys.has(key) ? `'${stripQuotes(value)}'` : `${value}`;
                 } else if (this.validFilters[key]?.type === Boolean && this.validFilters[key]?.boolType === "is") {
                     if (value === true) {
                         newFilterText += `is:${key}`;
@@ -576,10 +623,12 @@ export default class Filtering<T> {
                     newFilterText += `${convertedValues.map((v) => `${this.toAliasKey(key)}${v}`).join(" ")}`;
                 } else if (
                     this.quoteStrings &&
-                    (quotedKeys.has(key) || isQuoted(value) || String(value).includes(" "))
+                    (exactMatchKeys.has(key) || isQuoted(value) || String(value).includes(" "))
                 ) {
-                    // re-emit quoted: the user quoted it in the source text, it's already a
-                    // quoted literal (e.g. from setFilterValue), or it contains a space
+                    // re-emit quoted: the user quoted it in the source text for an exact match,
+                    // it's already a quoted literal (e.g. from setFilterValue), or it contains a
+                    // space and needs quoting to survive re-tokenizing (purely syntactic, no
+                    // exact-match intent implied by this branch alone)
                     newFilterText += `${this.toAliasKey(key)}'${stripQuotes(value)}'`;
                 } else {
                     newFilterText += `${this.toAliasKey(key)}${value}`;
@@ -713,10 +762,13 @@ export default class Filtering<T> {
 
     /** Returns a dictionary with query key and values.
      *
-     * A quoted filter value (`name:'GREP'`) is an exact, case-sensitive match: it is routed
-     * through the filter's sibling `${key}_eq` handler if one exists (`name-eq`, which the
-     * backend compares with `==`), rather than the default (`name-contains`, a case-insensitive
-     * substring match). The parsed value keeps its original case with the quotes stripped.
+     * An single-word, quoted filter value (`name:'GREP'`) is an exact, case-sensitive match: it
+     * is routed through the filter's sibling `${key}_eq` handler if one exists (`name-eq`, which
+     * the backend compares with `==`), rather than the default (`name-contains`, a case-insensitive
+     * substring match). A *multi-word* quoted value (`name:'foo bar'`) is NOT treated as an
+     * exact-match request, since quoting a value is also how `getFilterText` keeps a value with a
+     * space as one token, so quoting alone is ambiguous once whitespace is involved.
+     * The parsed value keeps its original case with the quotes stripped either way.
      *
      * @param filterText Raw filter text string
      * @returns Dictionary with query key and values
@@ -724,12 +776,10 @@ export default class Filtering<T> {
     getQueryDict(filterText: string) {
         const queryDict: Record<string, T> = {};
         const tokens = this.tokenize(filterText);
-        const quotedKeys = new Set(
-            tokens.filter((token) => token.quoted && token.key !== undefined).map((token) => token.key!),
-        );
+        const exactMatchKeys = this.exactMatchByKey(tokens);
         const filters = Object.entries(this.parseFilterText(tokens, true, true));
         for (const [key, value] of filters) {
-            const queryKey = quotedKeys.has(key) ? this.exactMatchKeyFor(key) : key;
+            const queryKey = exactMatchKeys.has(key) ? this.exactMatchKeyFor(key) : key;
             const handler = this.validFilters[queryKey]?.handler;
             const query = handler?.query;
             const converter = handler?.converter;


### PR DESCRIPTION
The `Filtering` class (used by `FilterMenu`) parses a filterText string like `name:foo tag:'bar baz' deleted:true` into filters. Over time it grew a few methods that each re-parsed that same string, with slightly different copies of the same regexes, mostly to answer questions the first parse had already thrown away.

This is a refactor:

- A single private `tokenize` now parses `filterText` once into a list of tokens that keep everything the rest of the class needs: the key, the operator, the value, and whether it was quoted.
- `getFiltersForText`, `getQueryDict`, and `getFilterText` are now thin wrappers over that token list instead of each re-parsing the string.
- The three tokenizing regexes each appear exactly once now instead of being copy-pasted across four methods.
- The "lone quoted bare token (`'Grep1'` on its own) routes `autoFilterKey` through exact match" case is now handled in `tokenize` (tag the token, everything downstream treats it like a keyed quoted value) instead of two separate special-cases.

Every public method keeps its signature and output; the full client test suite passes unchanged, and regression tests are added for the lone-quoted-bare-token case.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
