### PR TITLE
[26.1] Document unique server names for multi-instance Gunicorn deployments

### DIFF
--- a/doc/source/admin/config.rst
+++ b/doc/source/admin/config.rst
@@ -106,6 +106,22 @@ Configuration Basics
 .. _Gravity: https://github.com/galaxyproject/gravity
 
 
+Per-process configuration
+-------------------------
+
+Options in the ``galaxy`` section can also be supplied through environment variables with the
+``GALAXY_CONFIG_`` prefix and the option name in uppercase. For example,
+``GALAXY_CONFIG_SERVER_NAME=web_0`` sets the process's base server name when ``server_name`` is
+absent from the configuration file. File values take precedence over these environment variables.
+Use the ``GALAXY_CONFIG_OVERRIDE_`` prefix to override a file value, for example
+``GALAXY_CONFIG_OVERRIDE_SERVER_NAME=web_0``.
+
+This allows processes to share ``galaxy.yml`` while retaining distinct identities. Independent
+Gunicorn masters on the same hostname must use distinct base names; Galaxy appends the worker ID
+to each base name. Set these variables in the individual service's environment, rather than in an
+environment shared with job handlers and workflow schedulers. See
+:doc:`Scaling and Load Balancing <scaling>` for a systemd example and handler naming guidance.
+
 Configuration Options
 ----------------------------
 

--- a/doc/source/admin/config.rst
+++ b/doc/source/admin/config.rst
@@ -110,17 +110,12 @@ Per-process configuration
 -------------------------
 
 Options in the ``galaxy`` section can also be supplied through environment variables with the
-``GALAXY_CONFIG_`` prefix and the option name in uppercase. For example,
-``GALAXY_CONFIG_SERVER_NAME=web_0`` sets the process's base server name when ``server_name`` is
-absent from the configuration file. File values take precedence over these environment variables.
-Use the ``GALAXY_CONFIG_OVERRIDE_`` prefix to override a file value, for example
-``GALAXY_CONFIG_OVERRIDE_SERVER_NAME=web_0``.
+``GALAXY_CONFIG_`` prefix and the option name in uppercase. These values apply when the option
+is absent from the configuration file. Use the ``GALAXY_CONFIG_OVERRIDE_`` prefix to override
+a value set in the file.
 
-This allows processes to share ``galaxy.yml`` while retaining distinct identities. Independent
-Gunicorn masters on the same hostname must use distinct base names; Galaxy appends the worker ID
-to each base name. Set these variables in the individual service's environment, rather than in an
-environment shared with job handlers and workflow schedulers. See
-:doc:`Scaling and Load Balancing <scaling>` for a systemd example and handler naming guidance.
+Set environment variables in the service's environment to customize individual processes while
+sharing a common ``galaxy.yml``.
 
 Configuration Options
 ----------------------------

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1,3 +1,25 @@
+~~~~~~~~~~~~~~~
+``server_name``
+~~~~~~~~~~~~~~~
+
+:Description:
+    Base name of this Galaxy server process. Gunicorn appends a worker
+    ID (for example, ``web_0.1``). Control queues are named using the
+    resulting server name and hostname, so independent Gunicorn
+    instances on the same host must use distinct base names to avoid
+    sharing control queues. Shared queues can cause SSE events to
+    reach a worker that does not hold the intended browser connection.
+    When instances share galaxy.yml, leave this option unset in the
+    file and set ``GALAXY_CONFIG_SERVER_NAME`` separately for each
+    instance. For a systemd template service, use
+    ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
+    ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in
+    the file. Standalone job handlers and workflow schedulers can
+    instead use ``--server-name`` to assign their names.
+:Default: ``main``
+:Type: str
+
+
 ~~~~~~~~~~~~~~
 ``config_dir``
 ~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3,19 +3,11 @@
 ~~~~~~~~~~~~~~~
 
 :Description:
-    Base name of this Galaxy server process. Gunicorn appends a worker
-    ID (for example, ``web_0.1``). Control queues are named using the
-    resulting server name and hostname, so independent Gunicorn
-    instances on the same host must use distinct base names to avoid
-    sharing control queues. Shared queues can cause SSE events to
-    reach a worker that does not hold the intended browser connection.
-    When instances share galaxy.yml, leave this option unset in the
-    file and set ``GALAXY_CONFIG_SERVER_NAME`` separately for each
-    instance. For a systemd template service, use
-    ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
-    ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in
-    the file. Standalone job handlers and workflow schedulers can
-    instead use ``--server-name`` to assign their names.
+    Change this default when running independent Gunicorn instances on
+    the same hostname, assigning each instance a distinct base server
+    name to avoid sharing control queues. See the deployment guidance
+    at:
+    https://docs.galaxyproject.org/en/master/admin/scaling.html#unique-server-names-for-independent-gunicorn-instances
 :Default: ``main``
 :Type: str
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -275,6 +275,38 @@ To bind to ports < 1024 (e.g. if you want to bind to the standard HTTP/HTTPS por
 user and drop privileges to the Galaxy user. However you are strongly encouraged to setup a proxy server
 as described in the [production configuration](production.md) documentation.
 
+### Unique server names for independent Gunicorn instances
+
+When running multiple Gunicorn masters on the same host, give each master a distinct Galaxy
+`server_name`. Galaxy defaults to `main` and appends the worker ID within each master, producing
+names such as `main.1` and `main.2`. Increasing the worker count within one master already gives
+those workers distinct names; starting another master with the same base name does not.
+
+Control queues use the name `control.<server_name>@<hostname>`. Workers in independent masters
+that share both the base name and hostname consume from the same queues. An SSE event can then
+be consumed by a worker that does not hold the intended browser connection, leaving the browser
+without an update even though the queue has active consumers and no backlog.
+
+If the masters share `galaxy.yml`, leave `galaxy.server_name` unset in that file and set
+`GALAXY_CONFIG_SERVER_NAME` in each master's environment, for example `web_0` and `web_1`.
+For a systemd template unit such as `galaxy-gunicorn@.service`, add:
+
+```ini
+[Service]
+Environment=GALAXY_CONFIG_SERVER_NAME=web_%i
+```
+
+Systemd expands `%i` to the service instance number. Instances `galaxy-gunicorn@0` and
+`galaxy-gunicorn@1` will therefore have worker names such as `web_0.1` and `web_1.1`.
+This also works with Gunicorn's `--preload` option. Distinct hostnames already separate
+control queues, but containers that share a hostname need distinct server names too.
+
+A value in `galaxy.yml` takes precedence over `GALAXY_CONFIG_SERVER_NAME`; use
+`GALAXY_CONFIG_OVERRIDE_SERVER_NAME` if you need to override that value. Scope the environment
+setting to the Gunicorn service so job handlers and workflow schedulers retain their own names.
+After updating a systemd unit, reload the unit configuration and restart the affected services.
+See [SSE deployment verification](sse_updates.md#verifying-the-deployment) for queue checks.
+
 ### Job and Workflow Handling
 
 ```{warning}
@@ -349,6 +381,12 @@ $ ./scripts/galaxy-main -c config/galaxy.yml --server-name handler0 --daemonize
 $ ./scripts/galaxy-main -c config/galaxy.yml --server-name handler1 --daemonize
 $ ./scripts/galaxy-main -c config/galaxy.yml --server-name handler2 --daemonize
 ```
+
+Each standalone handler or workflow scheduler also needs a distinct server name on its host.
+The `--server-name` arguments above supply those names; for statically defined handlers they
+must match the handler IDs in `job_conf.xml`. Avoid setting a common `server_name` in the shared
+`galaxy.yml` or exporting the Gunicorn server-name environment setting to these services, since
+configuration values can override their command-line names.
 
 #### Dynamically defined handlers
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -283,9 +283,12 @@ names such as `main.1` and `main.2`. Increasing the worker count within one mast
 those workers distinct names; starting another master with the same base name does not.
 
 Control queues use the name `control.<server_name>@<hostname>`. Workers in independent masters
-that share both the base name and hostname consume from the same queues. An SSE event can then
-be consumed by a worker that does not hold the intended browser connection, leaving the browser
-without an update even though the queue has active consumers and no backlog.
+that share both the base name and hostname compete for messages on the same queues. Broadcast
+control tasks intended to execute in every worker may therefore execute in only some workers,
+and tasks addressed to a specific worker may execute in another worker sharing its queue.
+Active consumers and an empty queue do not establish that all intended workers executed a task.
+For example, an SSE event may be consumed by a worker that does not hold the intended browser
+connection, leaving the browser without an update.
 
 If the masters share `galaxy.yml`, leave `galaxy.server_name` unset in that file and set
 `GALAXY_CONFIG_SERVER_NAME` in each master's environment, for example `web_0` and `web_1`.

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -301,9 +301,9 @@ Systemd expands `%i` to the service instance number. Instances `galaxy-gunicorn@
 This also works with Gunicorn's `--preload` option. Distinct hostnames already separate
 control queues, but containers that share a hostname need distinct server names too.
 
-A value in `galaxy.yml` takes precedence over `GALAXY_CONFIG_SERVER_NAME`; use
-`GALAXY_CONFIG_OVERRIDE_SERVER_NAME` if you need to override that value. Scope the environment
-setting to the Gunicorn service so job handlers and workflow schedulers retain their own names.
+Scope the environment setting to the Gunicorn service so job handlers and workflow schedulers
+retain their own names. See [Per-process configuration](config.rst#per-process-configuration)
+for details on supplying configuration through environment variables.
 After updating a systemd unit, reload the unit configuration and restart the affected services.
 See [SSE deployment verification](sse_updates.md#verifying-the-deployment) for queue checks.
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -308,7 +308,8 @@ Scope the environment setting to the Gunicorn service so job handlers and workfl
 retain their own names. See [Per-process configuration](config.rst#per-process-configuration)
 for details on supplying configuration through environment variables.
 After updating a systemd unit, reload the unit configuration and restart the affected services.
-See [SSE deployment verification](sse_updates.md#verifying-the-deployment) for queue checks.
+Use the process manager and worker startup logs to verify that only one live Galaxy worker
+process uses each final `server_name` on a given hostname, regardless of the control-queue transport.
 
 ### Job and Workflow Handling
 

--- a/doc/source/admin/sse_updates.md
+++ b/doc/source/admin/sse_updates.md
@@ -143,6 +143,13 @@ This only matters when running on SQLite or in setups where PostgreSQL
 
 ## What to monitor
 
+In deployments with multiple independent Gunicorn masters on the same hostname, configure a
+distinct `server_name` for each master as described in
+[Scaling and Load Balancing](scaling.md#unique-server-names-for-independent-gunicorn-instances).
+Each worker holds its own browser connections in memory and needs its own control queue.
+Workers sharing a queue compete for messages instead of each receiving a copy, so SSE updates
+can disappear even when the broker reports healthy consumers and empty queues.
+
 When statsd is configured (via `statsd_host` and friends), the SSE
 plumbing emits the following metrics. Capture these on the same dashboard
 you use for Gunicorn worker health:
@@ -291,6 +298,22 @@ stream is healthy end-to-end:
    `galaxy.sse.connections.active` should reflect roughly one connection
    per open browser tab (summed across the reporting processes).
 
-If the connection opens but no events arrive, the most common causes
-are: a proxy buffering responses (revisit the NGINX section), or a
-producer that can't reach AMQP (see `galaxy.sse.dispatch.skipped_no_qw`).
+If the connection opens but no events arrive, check for proxy buffering (revisit the NGINX
+section), a producer that cannot reach AMQP (see `galaxy.sse.dispatch.skipped_no_qw`), and workers
+sharing control queues because their server names collide.
+
+For RabbitMQ, inspect the virtual host used by Galaxy's `amqp_internal_connection`, which may
+differ from the one used by Celery:
+
+```console
+rabbitmqctl list_queues -p '<vhost>' name messages messages_ready consumers
+rabbitmqctl list_consumers -p '<vhost>'
+```
+
+Check that every live web worker has a distinct `control.<server_name>@<hostname>` queue.
+Galaxy currently creates two subscriptions per control worker, so two consumers on a queue
+are expected. More consumers warrant checking which processes own their connections; the
+count alone does not establish a naming collision. A queue with no consumers may belong to
+a stopped worker, so correlate it with live processes before diagnosing a failed consumer.
+An empty queue alone does not establish successful SSE delivery: a worker without the user's
+browser connection can consume and acknowledge the event.

--- a/doc/source/admin/sse_updates.md
+++ b/doc/source/admin/sse_updates.md
@@ -299,21 +299,11 @@ stream is healthy end-to-end:
    per open browser tab (summed across the reporting processes).
 
 If the connection opens but no events arrive, check for proxy buffering (revisit the NGINX
-section), a producer that cannot reach AMQP (see `galaxy.sse.dispatch.skipped_no_qw`), and workers
+section), a producer unable to dispatch control tasks (see `galaxy.sse.dispatch.skipped_no_qw`), and workers
 sharing control queues because their server names collide.
 
-For RabbitMQ, inspect the virtual host used by Galaxy's `amqp_internal_connection`, which may
-differ from the one used by Celery:
-
-```console
-rabbitmqctl list_queues -p '<vhost>' name messages messages_ready consumers
-rabbitmqctl list_consumers -p '<vhost>'
-```
-
-Check that every live web worker has a distinct `control.<server_name>@<hostname>` queue.
-Galaxy currently creates two subscriptions per control worker, so two consumers on a queue
-are expected. More consumers warrant checking which processes own their connections; the
-count alone does not establish a naming collision. A queue with no consumers may belong to
-a stopped worker, so correlate it with live processes before diagnosing a failed consumer.
-An empty queue alone does not establish successful SSE delivery: a worker without the user's
-browser connection can consume and acknowledge the event.
+Use the process manager and worker startup logs to verify that only one live Galaxy worker
+process uses each `server_name` on a given hostname. For Gunicorn, check the final name including
+the worker ID, such as `web_0.1`. This requirement applies regardless of the control-queue
+transport. See [unique server names](scaling.md#unique-server-names-for-independent-gunicorn-instances)
+for configuration guidance.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -380,19 +380,11 @@ gravity:
   # handlers: {}
 galaxy:
 
-  # Base name of this Galaxy server process. Gunicorn appends a worker
-  # ID (for example, ``web_0.1``). Control queues are named using the
-  # resulting server name and hostname, so independent Gunicorn
-  # instances on the same host must use distinct base names to avoid
-  # sharing control queues. Shared queues can cause SSE events to reach
-  # a worker that does not hold the intended browser connection.
-  # When instances share galaxy.yml, leave this option unset in the file
-  # and set ``GALAXY_CONFIG_SERVER_NAME`` separately for each instance.
-  # For a systemd template service, use
-  # ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
-  # ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in
-  # the file. Standalone job handlers and workflow schedulers can
-  # instead use ``--server-name`` to assign their names.
+  # Change this default when running independent Gunicorn instances on
+  # the same hostname, assigning each instance a distinct base server
+  # name to avoid sharing control queues. See the deployment guidance
+  # at:
+  # https://docs.galaxyproject.org/en/master/admin/scaling.html#unique-server-names-for-independent-gunicorn-instances
   #server_name: main
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -380,6 +380,21 @@ gravity:
   # handlers: {}
 galaxy:
 
+  # Base name of this Galaxy server process. Gunicorn appends a worker
+  # ID (for example, ``web_0.1``). Control queues are named using the
+  # resulting server name and hostname, so independent Gunicorn
+  # instances on the same host must use distinct base names to avoid
+  # sharing control queues. Shared queues can cause SSE events to reach
+  # a worker that does not hold the intended browser connection.
+  # When instances share galaxy.yml, leave this option unset in the file
+  # and set ``GALAXY_CONFIG_SERVER_NAME`` separately for each instance.
+  # For a systemd template service, use
+  # ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
+  # ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in
+  # the file. Standalone job handlers and workflow schedulers can
+  # instead use ``--server-name`` to assign their names.
+  #server_name: main
+
   # The directory that will be prepended to relative paths in options
   # specifying other Galaxy config files (e.g. datatypes_config_file).
   # Defaults to the directory in which galaxy.yml is located.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -29,20 +29,11 @@ mapping:
         type: str
         default: main
         desc: |
-          Base name of this Galaxy server process. Gunicorn appends a worker ID
-          (for example, ``web_0.1``). Control queues are named using the resulting
-          server name and hostname, so independent Gunicorn instances on the same
-          host must use distinct base names to avoid sharing control queues.
-          Shared queues can cause SSE events to reach a worker that does not hold
-          the intended browser connection.
+          Change this default when running independent Gunicorn instances on the
+          same hostname, assigning each instance a distinct base server name to
+          avoid sharing control queues. See the deployment guidance at:
 
-          When instances share galaxy.yml, leave this option unset in the file and
-          set ``GALAXY_CONFIG_SERVER_NAME`` separately for each instance. For a
-          systemd template service, use
-          ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
-          ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in the file.
-          Standalone job handlers and workflow schedulers can instead use
-          ``--server-name`` to assign their names.
+          https://docs.galaxyproject.org/en/master/admin/scaling.html#unique-server-names-for-independent-gunicorn-instances
 
       config_dir:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -25,6 +25,25 @@ mapping:
     required: true
     mapping:
 
+      server_name:
+        type: str
+        default: main
+        desc: |
+          Base name of this Galaxy server process. Gunicorn appends a worker ID
+          (for example, ``web_0.1``). Control queues are named using the resulting
+          server name and hostname, so independent Gunicorn instances on the same
+          host must use distinct base names to avoid sharing control queues.
+          Shared queues can cause SSE events to reach a worker that does not hold
+          the intended browser connection.
+
+          When instances share galaxy.yml, leave this option unset in the file and
+          set ``GALAXY_CONFIG_SERVER_NAME`` separately for each instance. For a
+          systemd template service, use
+          ``Environment=GALAXY_CONFIG_SERVER_NAME=web_%i``. Use
+          ``GALAXY_CONFIG_OVERRIDE_SERVER_NAME`` to override a value set in the file.
+          Standalone job handlers and workflow schedulers can instead use
+          ``--server-name`` to assign their names.
+
       config_dir:
         type: str
         required: false


### PR DESCRIPTION
Independent Gunicorn masters on the same hostname default to the same Galaxy worker names (`main.1`, `main.2`, etc.), causing workers to share control queues. Workers then compete for control tasks: broadcasts may fail to execute in every intended worker, and tasks addressed to a specific worker may execute in another worker sharing its queue. SSE updates reaching a worker without the intended browser connection are one example.

Document `server_name` in the configuration schema, generated sample YAML and admin reference. Add deployment guidance for per-instance names (`GALAXY_CONFIG_SERVER_NAME=web_%i` in a systemd template), environment/file precedence, separate handler and scheduler names, and transport-independent verification of worker identities. No application logic or unit test changes.

## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. Run `make config-rebuild` and inspect the generated server-name documentation.
  2. Build the Sphinx HTML docs and check the configuration, scaling, and SSE pages.
  3. With a shared YAML file, run independent Gunicorn masters with distinct `GALAXY_CONFIG_SERVER_NAME` values and confirm distinct worker and control-queue names.

Validation: configuration regeneration and `git diff --check` passed. Real Gunicorn probes exercised Galaxy's configuration loader, post-fork hooks and queue naming with two workers, with and without `--preload`; both ordinary environment values and file/override precedence behaved as documented. The probe did not start a full Galaxy deployment. Sphinx generated HTML, with existing unrelated reference errors in the documentation.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).


