### PR TITLE
[26.1] Prevent `ScrollList` from doing infinite fetches on error

### DIFF
--- a/client/src/components/ScrollList/ScrollList.test.ts
+++ b/client/src/components/ScrollList/ScrollList.test.ts
@@ -141,6 +141,27 @@ describe("ScrollList with local loader and data", () => {
         expect(testLoader).toHaveBeenCalledTimes(Math.ceil(TOTAL_ITEMS / BUFFER_SIZE));
     });
 
+    it("stops auto-retrying on error until the user clicks Load More", async () => {
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(1);
+
+        // Next load fails
+        testLoader.mockRejectedValueOnce(new Error("Boom"));
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(2);
+
+        // Further scrolling must NOT retry automatically
+        await scrollOnce();
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(2);
+
+        // Clicking "Load More" clears the error and retries
+        await wrapper.find(LOAD_MORE_BUTTON).trigger("click");
+        await nextTick();
+        expect(testLoader).toHaveBeenCalledTimes(3);
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(BUFFER_SIZE * 2);
+    });
+
     it("shows item count and total items", async () => {
         await scrollOnce();
         expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE} out of ${TOTAL_ITEMS} ${ITEM_NAME_PLURAL}`);

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -2,15 +2,20 @@
 import { faArrowDown, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
-import { BAlert, BListGroup } from "bootstrap-vue";
+import { BListGroup } from "bootstrap-vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
+import { useToast } from "@/composables/toast";
+import { errorMessageAsString } from "@/utils/simple-error";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ScrollToTopButton from "@/components/ToolsList/ScrollToTopButton.vue";
+
+const CLICK_TO_RETRY_MSG = "Click on the button at the bottom of the list to retry." as const;
 
 interface LoaderResult<T> {
     items: T[];
@@ -70,6 +75,8 @@ const emit = defineEmits<{
     (e: "update:prop-scroll-top", value: number): void;
 }>();
 
+const Toast = useToast();
+
 const scrollableDiv = ref<HTMLElement | null>(null);
 
 // TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
@@ -124,8 +131,14 @@ const listEndText = computed<string>(() => {
 
 const allLoaded = computed(() => totalItemCount.value !== undefined && totalItemCount.value <= items.value.length);
 
-async function loadItems() {
-    if (!busy.value && !allLoaded.value && !props.loadDisabled) {
+async function loadItems(clearError = false) {
+    let msgCleared = false;
+    if (clearError) {
+        errorMessage.value = "";
+        msgCleared = true;
+    }
+
+    if (!busy.value && !allLoaded.value && !props.loadDisabled && !errorMessage.value) {
         try {
             if (props.loader === undefined && props.propItems === undefined) {
                 throw new Error("No loader function or propItems provided");
@@ -144,7 +157,12 @@ async function loadItems() {
             localTotalItemCount.value = total;
             errorMessage.value = "";
         } catch (e) {
-            errorMessage.value = `Failed to load items: ${e}`;
+            errorMessage.value = errorMessageAsString(e);
+            if (items.value.length > 0 || msgCleared) {
+                const errMsg = errorMessage.value;
+                const toastedMsg = `${errMsg}${errMsg.endsWith(".") ? "" : ". "}${CLICK_TO_RETRY_MSG}`;
+                Toast.error(toastedMsg, `Failed to load ${props.namePlural}`);
+            }
         } finally {
             localBusy.value = false;
         }
@@ -214,39 +232,42 @@ watch(
                     toolMenuContainer: inPanel,
                 }"
                 role="list">
-                <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
-                <template v-else>
-                    <slot v-if="items.length === 0" name="loading">
-                        <BAlert v-if="busy" variant="info" show>
+                <template v-if="items.length === 0">
+                    <GAlert v-if="errorMessage" variant="danger">
+                        <p>{{ errorMessage }}</p>
+                        <strong>{{ CLICK_TO_RETRY_MSG }}</strong>
+                    </GAlert>
+                    <slot name="loading">
+                        <GAlert v-if="busy" variant="info">
                             <LoadingSpan :message="`Loading ${props.namePlural}`" />
-                        </BAlert>
+                        </GAlert>
                     </slot>
-                    <component
-                        :is="props.gridView ? 'div' : BListGroup"
-                        class="pt-1"
-                        :class="{ 'card-list d-flex flex-wrap': props.gridView }">
-                        <!-- Use component wrapper with v-for to provide proper keying while avoiding layout interference -->
-                        <component
-                            :is="'div'"
-                            v-for="(item, index) in items"
-                            :key="itemKey(item)"
-                            style="display: contents">
-                            <slot name="item" :item="item" :index="index" />
-                        </component>
-
-                        <template v-if="!busy">
-                            <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
-                                <div class="list-end" data-description="no items found footer">
-                                    - No {{ props.namePlural }} found -
-                                </div>
-                            </slot>
-
-                            <slot v-else-if="allLoaded" name="all-loaded-footer">
-                                <div class="list-end">- {{ listEndText }} -</div>
-                            </slot>
-                        </template>
-                    </component>
                 </template>
+                <component
+                    :is="props.gridView ? 'div' : BListGroup"
+                    class="pt-1"
+                    :class="{ 'card-list d-flex flex-wrap': props.gridView }">
+                    <!-- Use component wrapper with v-for to provide proper keying while avoiding layout interference -->
+                    <component
+                        :is="'div'"
+                        v-for="(item, index) in items"
+                        :key="itemKey(item)"
+                        style="display: contents">
+                        <slot name="item" :item="item" :index="index" />
+                    </component>
+
+                    <template v-if="!busy">
+                        <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
+                            <div class="list-end" data-description="no items found footer">
+                                - No {{ props.namePlural }} found -
+                            </div>
+                        </slot>
+
+                        <slot v-else-if="allLoaded" name="all-loaded-footer">
+                            <div class="list-end">- {{ listEndText }} -</div>
+                        </slot>
+                    </template>
+                </component>
             </div>
             <ScrollToTopButton :offset="scrollTop" @click="scrollToTop" />
         </div>
@@ -264,7 +285,7 @@ watch(
                     :disabled="busy"
                     title="Load More"
                     transparent
-                    @click="loadItems()">
+                    @click="loadItems(true)">
                     <FontAwesomeIcon :icon="busy ? faSpinner : faArrowDown" :spin="busy" />
                 </GButton>
             </div>

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -276,7 +276,11 @@ watch(
                 v-if="!allLoaded"
                 class="mr-auto d-flex justify-content-center align-items-center"
                 :class="inPanel && 'mt-1'">
-                <i class="mr-1">Loaded {{ items.length }} out of {{ totalItemCount }} {{ props.namePlural }}</i>
+                <i class="mr-1">
+                    Loaded {{ items.length }}
+                    <span v-if="totalItemCount !== undefined">out of {{ totalItemCount }}</span>
+                    {{ props.namePlural }}
+                </i>
                 <GButton
                     v-if="!props.loadDisabled"
                     data-description="load more items button"


### PR DESCRIPTION
If the loader method throws an error, we would keep calling it over and	over since the scroll list attempts to fetch until a scrollbar renders.

This stops fetches once	an error message is stored, and	enforces the user to click on the Load More button at the bottom to try again.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
