### PR TITLE
[25.1] Fix `base_image_for_targets()` for newer conda search output

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -179,7 +179,11 @@ def base_image_for_targets(targets: Iterable[CondaTarget], conda_context: CondaC
     hits = get_conda_hits_for_targets(targets, conda_context)
     for hit in hits:
         try:
-            content_dict = get_files_from_conda_package(hit["url"], ["info/about.json", "info/recipe/meta.yaml"])
+            # Since conda 26.7.0, `conda search --json` output no longer includes a
+            # "url" key for packages served from sharded repodata, so reconstruct it
+            # from "channel" and "fn" if needed.
+            url = hit.get("url") or f"{hit['channel']}/{hit['fn']}"
+            content_dict = get_files_from_conda_package(url, ["info/about.json", "info/recipe/meta.yaml"])
             if "info/about.json" in content_dict and json.loads(unicodify(content_dict["info/about.json"])).get(
                 "extra", {}
             ).get("container", {}).get("extended-base", False):


### PR DESCRIPTION
Since conda 26.7.0 (https://github.com/conda/conda/pull/16149), `conda search --json` results for packages served from sharded repodata no longer include a `url` key, causing `KeyError: 'url'` in `get_files_from_conda_package()` and making `base_image_for_targets()` silently fall back to the default (non-extended) base image.

Reconstruct the URL from the `channel` and `fn` keys, which are still present, falling back to the old `url` key for older conda versions.

Failure seen in CI:

```
=================================== FAILURES ===================================
_ test_base_image_for_targets[mzmine-None-quay.io/bioconda/base-glibc-debian-bash:latest] _

target = CondaTarget[package=mzmine], version = None
base_image = 'quay.io/bioconda/base-glibc-debian-bash:latest'

    @pytest.mark.parametrize(
        "target,version,base_image",
        [
            ("mzmine", None, DEFAULT_EXTENDED_BASE_IMAGE),
            ("qiime", "1.9.1", DEFAULT_EXTENDED_BASE_IMAGE),
            ("samtools", None, DEFAULT_BASE_IMAGE),
        ],
    )
    @external_dependency_management
    def test_base_image_for_targets(target, version, base_image):
        target = build_target(target, version=version)
        conda_context = CondaInDockerContext()
>       assert base_image_for_targets([target], conda_context) == base_image
E       AssertionError: assert 'quay.io/bioconda/base-glibc-busybox-bash:latest' == 'quay.io/bioconda/base-glibc-debian-bash:latest'
E
E         - quay.io/bioconda/base-glibc-debian-bash:latest
E         ?                             -- ^^^
E         + quay.io/bioconda/base-glibc-busybox-bash:latest
E         ?                              ^^^^^^

base_image = 'quay.io/bioconda/base-glibc-debian-bash:latest'
conda_context = <galaxy.tool_util.deps.mulled.util.CondaInDockerContext object at 0x7fe63673c790>
target     = CondaTarget[package=mzmine]
version    = None

test/unit/tool_util/mulled/test_mulled_build.py:41: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  galaxy.tool_util.deps.mulled.mulled_build:mulled_build.py:292 Could not load metadata.yaml for 'mzmine', version '4.7.29'
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/tool_util/deps/mulled/mulled_build.py", line 279, in base_image_for_targets
    content_dict = get_files_from_conda_package(hit["url"], ["info/about.json", "info/recipe/meta.yaml"])
KeyError: 'url'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
