### PR TITLE
[26.1] Restore root path support for FTP file sources

### DIFF
--- a/lib/galaxy/files/sources/ftp.py
+++ b/lib/galaxy/files/sources/ftp.py
@@ -1,5 +1,8 @@
 import urllib.parse
-from typing import Union
+from typing import (
+    Optional,
+    Union,
+)
 
 try:
     from fs.ftpfs import FTPFS
@@ -12,11 +15,14 @@ from galaxy.files.models import (
     BaseFileSourceTemplateConfiguration,
     FilesSourceRuntimeContext,
 )
-from galaxy.util.config_templates import TemplateExpansion
+from galaxy.files.templates.models import FtpConfigMixin
+from galaxy.util.config_templates import (
+    TemplateExpansion,
+)
 from ._pyfilesystem2 import PyFilesystem2FilesSource
 
 
-class FTPFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+class FTPFileSourceTemplateConfiguration(FtpConfigMixin, BaseFileSourceTemplateConfiguration):
     host: Union[str, TemplateExpansion] = ""
     port: Union[int, TemplateExpansion] = 21
     user: Union[str, TemplateExpansion] = "anonymous"
@@ -25,9 +31,10 @@ class FTPFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
     timeout: Union[int, TemplateExpansion] = 10
     proxy: Union[str, TemplateExpansion, None] = None
     tls: Union[bool, TemplateExpansion] = False
+    root: Optional[Union[str, TemplateExpansion]] = None
 
 
-class FTPFileSourceConfiguration(BaseFileSourceConfiguration):
+class FTPFileSourceConfiguration(FtpConfigMixin, BaseFileSourceConfiguration):
     host: str = ""
     port: int = 21
     user: str = "anonymous"
@@ -36,6 +43,7 @@ class FTPFileSourceConfiguration(BaseFileSourceConfiguration):
     timeout: int = 10
     proxy: Union[str, None] = None
     tls: bool = False
+    root: Optional[str] = None
 
 
 class FtpFilesSource(PyFilesystem2FilesSource[FTPFileSourceTemplateConfiguration, FTPFileSourceConfiguration]):
@@ -51,7 +59,7 @@ class FtpFilesSource(PyFilesystem2FilesSource[FTPFileSourceTemplateConfiguration
             raise self.required_package_exception
 
         config = context.config
-        return FTPFS(
+        fs = FTPFS(
             host=config.host,
             port=config.port,
             user=config.user,
@@ -61,6 +69,7 @@ class FtpFilesSource(PyFilesystem2FilesSource[FTPFileSourceTemplateConfiguration
             tls=config.tls,
             proxy=config.proxy,
         )
+        return fs.opendir(config.root) if config.root else fs
 
     def _realize_to(
         self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[FTPFileSourceConfiguration]
@@ -87,6 +96,12 @@ class FtpFilesSource(PyFilesystem2FilesSource[FTPFileSourceTemplateConfiguration
             config.user = user or props["user"]
             config.passwd = passwd or props["passwd"]
             rel_path = props["path"] or url
+        if config.root:
+            root = config.root.rstrip("/")
+            if rel_path == root:
+                rel_path = "/"
+            elif rel_path.startswith(root + "/"):
+                rel_path = rel_path[len(root) :] or "/"
         return rel_path
 
     def _extract_url_props(self, url: str):
@@ -103,15 +118,20 @@ class FtpFilesSource(PyFilesystem2FilesSource[FTPFileSourceTemplateConfiguration
         # We need to use template_config here because this is called before the template is expanded.
         host = self.template_config.host
         port = self.template_config.port
+        root = self.template_config.root or ""
+        root = root.rstrip("/")
         if host and port and url.startswith(f"ftp://{host}:{port}"):
-            return len(f"ftp://{host}:{port}")
+            score = len(f"ftp://{host}:{port}")
         # For security, we need to ensure that a partial match doesn't work e.g. ftp://{host}something/myfiles
         elif host and (url.startswith(f"ftp://{host}/") or url == f"ftp://{host}"):
-            return len(f"ftp://{host}")
+            score = len(f"ftp://{host}")
         elif not host and url.startswith("ftp://"):
-            return len("ftp://")
+            score = len("ftp://")
         else:
             return super().score_url_match(url)
+        if root and url.startswith(f"ftp://{host}{root}/"):
+            score += len(root)
+        return score
 
 
 __all__ = ("FtpFilesSource",)

--- a/lib/galaxy/files/templates/examples/production_ftp.yml
+++ b/lib/galaxy/files/templates/examples/production_ftp.yml
@@ -10,6 +10,7 @@
     port: "{{ variables.port }}"
     passwd: "{{ secrets.password }}"
     writable: "{{ variables.writable }}"
+    root: "{{ variables.root }}"
   variables:
     host:
       label: FTP Host
@@ -34,6 +35,14 @@
       help: Port used to connect to the FTP server.
       optional: true
       default: 21
+    root:
+      label: Root Path
+      type: string
+      optional: true
+      help: |
+        Subdirectory on the FTP server to use as the root path. All file
+        operations will be relative to this path. Leave blank to use the
+        server's root directory.
   secrets:
     password:
       label: FTP Password
@@ -56,6 +65,7 @@
     passwd: "{{ secrets.password }}"
     writable: "{{ variables.writable }}"
     tls: "{{ variables.tls }}"
+    root: "{{ variables.root }}"
   variables:
     host:
       label: FTP Host
@@ -80,6 +90,14 @@
       help: Port used to connect to the FTP server.
       optional: true
       default: 21
+    root:
+      label: Root Path
+      type: string
+      optional: true
+      help: |
+        Subdirectory on the FTP server to use as the root path. All file
+        operations will be relative to this path. Leave blank to use the
+        server's root directory.
     tls:
       label: Use TLS (FTPS)?
       type: boolean

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -23,6 +23,7 @@ from galaxy.util.config_templates import (
     OAuth2Configuration,
     populate_default_variables,
     SecretsDict,
+    split_ftp_host_path,
     StrictModel,
     TemplateEnvironmentEntry,
     TemplateExpansion,
@@ -159,7 +160,14 @@ class S3FSFileSourceConfiguration(StrictModel):
     writable: bool = False
 
 
-class FtpFileSourceTemplateConfiguration(StrictModel):
+class FtpConfigMixin:
+    @model_validator(mode="before")
+    @classmethod
+    def split_host_path(cls, data: Any) -> Any:
+        return split_ftp_host_path(data)
+
+
+class FtpFileSourceTemplateConfiguration(FtpConfigMixin, StrictModel):
     type: Literal["ftp"]
     host: Union[str, TemplateExpansion]
     port: Union[int, TemplateExpansion] = 21
@@ -167,11 +175,12 @@ class FtpFileSourceTemplateConfiguration(StrictModel):
     passwd: Optional[Union[str, TemplateExpansion]] = None
     writable: Union[bool, TemplateExpansion] = False
     tls: Union[bool, TemplateExpansion] = False
+    root: Optional[Union[str, TemplateExpansion]] = None
     template_start: Optional[str] = None
     template_end: Optional[str] = None
 
 
-class FtpFileSourceConfiguration(StrictModel):
+class FtpFileSourceConfiguration(FtpConfigMixin, StrictModel):
     type: Literal["ftp"]
     host: str
     port: int = 21
@@ -179,6 +188,7 @@ class FtpFileSourceConfiguration(StrictModel):
     passwd: Optional[str] = None
     writable: bool = False
     tls: bool = False
+    root: Optional[str] = None
 
 
 class SshFileSourceTemplateConfiguration(StrictModel):

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -57,7 +57,10 @@ from galaxy.exceptions import (
     RequestParameterMissingException,
 )
 from galaxy.tool_util_models.parameter_validators import AnySafeValidatorModel
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    str_removeprefix,
+)
 
 log = logging.getLogger(__name__)
 
@@ -91,7 +94,7 @@ def split_ftp_host_path(data: Any) -> Any:
     host = data.get("host")
     if root is None and isinstance(host, str) and "/" in host:
         data = dict(data)
-        host = host.removeprefix("ftp://").removeprefix("ftps://")
+        host = str_removeprefix(str_removeprefix(host, "ftp://"), "ftps://")
         if "/" in host:
             host_part, _, path_part = host.partition("/")
             data["host"] = host_part

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -89,7 +89,7 @@ def split_ftp_host_path(data: Any) -> Any:
     if not isinstance(data, dict):
         return data
     root = data.get("root")
-    if not isinstance(root, str):
+    if not isinstance(root, str) or root == "":
         root = None
     host = data.get("host")
     if root is None and isinstance(host, str) and "/" in host:
@@ -101,6 +101,9 @@ def split_ftp_host_path(data: Any) -> Any:
             data["root"] = "/" + path_part
         else:
             data["host"] = host
+    if data.get("root") is not None and (not isinstance(data["root"], str) or data["root"] == ""):
+        data = dict(data)
+        data["root"] = None
     if isinstance(data.get("root"), str) and ".." in data["root"].split("/"):
         raise ValueError(f"FTP root must not contain '..' path segments: {data['root']!r}")
     return data

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -76,6 +76,33 @@ class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid", coerce_numbers_to_str=True)
 
 
+def split_ftp_host_path(data: Any) -> Any:
+    """Split a path embedded in an FTP ``host`` field into ``host`` + ``root``.
+
+    If ``root`` is already set, no splitting occurs.  A protocol prefix
+    (e.g. ``ftp://``) is stripped before splitting so that values like
+    ``ftp://ftp.gnu.org/gnu/`` are handled correctly.
+    """
+    if not isinstance(data, dict):
+        return data
+    root = data.get("root")
+    if not isinstance(root, str):
+        root = None
+    host = data.get("host")
+    if root is None and isinstance(host, str) and "/" in host:
+        data = dict(data)
+        host = host.removeprefix("ftp://").removeprefix("ftps://")
+        if "/" in host:
+            host_part, _, path_part = host.partition("/")
+            data["host"] = host_part
+            data["root"] = "/" + path_part
+        else:
+            data["host"] = host
+    if isinstance(data.get("root"), str) and ".." in data["root"].split("/"):
+        raise ValueError(f"FTP root must not contain '..' path segments: {data['root']!r}")
+    return data
+
+
 class BaseTemplateVariable(StrictModel):
     name: str
     label: Optional[str] = None

--- a/test/unit/files/ftp_file_sources_conf.yml
+++ b/test/unit/files/ftp_file_sources_conf.yml
@@ -6,3 +6,19 @@
 - type: ftp
   id: test2
   doc: A default ftp handler, built-in and not needed other than for tests
+
+- type: ftp
+  id: test3
+  doc: An ftp handler with an explicit root path
+  host: "ftp.gnu.org"
+  root: "/gnu"
+
+- type: ftp
+  id: test4
+  doc: An ftp handler with a path embedded in host (backward compat)
+  host: "ftp.ensemblgenomes.org/vol1/pub/"
+
+- type: ftp
+  id: test5
+  doc: An ftp handler with a protocol-prefixed host with path
+  host: "ftp://ftp.ncbi.nlm.nih.gov/pub/"

--- a/test/unit/files/test_ftp.py
+++ b/test/unit/files/test_ftp.py
@@ -48,3 +48,60 @@ def test_file_source_ftp_generic():
         "Oregon State University",
         user_context=user_context,
     )
+
+
+def test_file_source_ftp_explicit_root():
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path("ftp://ftp.gnu.org/gnu/")
+
+    assert file_source_pair.file_source.id == "test3"
+
+    config = file_source_pair.file_source.template_config
+    assert config.host == "ftp.gnu.org"
+    assert config.root == "/gnu"
+
+
+def test_file_source_ftp_path_in_host_backward_compat():
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path("ftp://ftp.ensemblgenomes.org/vol1/pub/")
+
+    assert file_source_pair.file_source.id == "test4"
+
+    config = file_source_pair.file_source.template_config
+    assert config.host == "ftp.ensemblgenomes.org"
+    assert config.root == "/vol1/pub/"
+
+
+def test_file_source_ftp_protocol_prefixed_host():
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source_pair = file_sources.get_file_source_path("ftp://ftp.ncbi.nlm.nih.gov/pub/")
+
+    assert file_source_pair.file_source.id == "test5"
+
+    config = file_source_pair.file_source.template_config
+    assert config.host == "ftp.ncbi.nlm.nih.gov"
+    assert config.root == "/pub/"
+
+
+def test_file_source_ftp_root_path_boundary():
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    file_source = file_sources.get_file_source_path("ftp://ftp.gnu.org/gnu/").file_source
+    config = file_source._evaluate_template_config()
+
+    assert file_source._parse_url_and_get_path("ftp://ftp.gnu.org/gnu/file.txt", config) == "/file.txt"
+    assert file_source._parse_url_and_get_path("ftp://ftp.gnu.org/gnu", config) == "/"
+    # A path that starts with the root as a string prefix but not as a directory boundary
+    # must not be stripped.
+    assert file_source._parse_url_and_get_path("ftp://ftp.gnu.org/gnu-evil/file.txt", config) == "/gnu-evil/file.txt"
+
+
+def test_file_source_ftp_root_rejects_traversal():
+    from pydantic import ValidationError
+
+    from galaxy.files.models import FileSourcePluginsConfig
+    from galaxy.files.sources.ftp import FTPFileSourceConfiguration
+
+    with pytest.raises(ValidationError, match="must not contain '\\.\\.'"):
+        FTPFileSourceConfiguration(
+            id="test", type="ftp", host="ftp.gnu.org", root="/gnu/../etc", file_sources_config=FileSourcePluginsConfig()
+        )

--- a/test/unit/files/test_template_models.py
+++ b/test/unit/files/test_template_models.py
@@ -292,6 +292,103 @@ def test_production_aws_public_bucket():
     assert configuration_obj.bucket == "encode-public"
 
 
+def _ftp_production_template_variables(host, root=None, **extra):
+    variables = {
+        "host": host,
+        "user": "anonymous",
+        "port": 21,
+        "writable": False,
+    }
+    if root is not None:
+        variables["root"] = root
+    variables.update(extra)
+    return variables
+
+
+def test_production_ftp_plain_host_no_root_v0():
+    template = _get_example_template_by_version("production_ftp.yml", 0)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org"),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root is None
+
+
+def test_production_ftp_plain_host_no_root_v1():
+    template = _get_example_template_by_version("production_ftp.yml", 1)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org", tls=False),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root is None
+
+
+def test_production_ftp_host_with_path_no_root_v0():
+    template = _get_example_template_by_version("production_ftp.yml", 0)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org/pub/"),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root == "/pub/"
+
+
+def test_production_ftp_host_with_path_no_root_v1():
+    template = _get_example_template_by_version("production_ftp.yml", 1)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org/pub/", tls=False),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root == "/pub/"
+
+
+def test_production_ftp_host_with_path_blank_root():
+    template = _get_example_template_by_version("production_ftp.yml", 0)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org/pub/", root=""),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root == "/pub/"
+
+
+def test_production_ftp_plain_host_blank_root():
+    template = _get_example_template_by_version("production_ftp.yml", 0)
+    configuration_obj = template_to_configuration(
+        template,
+        _ftp_production_template_variables("ftp.example.org", root=""),
+        {"password": ""},
+        user_details={},
+        environment={},
+    )
+    assert isinstance(configuration_obj, FtpFileSourceConfiguration)
+    assert configuration_obj.host == "ftp.example.org"
+    assert configuration_obj.root is None
+
+
 def test_examples_parse():
     # Ensure every YAML example in `lib/galaxy/files/templates/examples/` parses without error
     examples_dir = Path(__file__).resolve().parents[3] / "lib" / "galaxy" / "files" / "templates" / "examples"
@@ -307,6 +404,14 @@ def _assert_example_parses(filename: str):
 
 def _get_example_template(filename: str) -> FileSourceTemplate:
     return _assert_has_one_template(_get_example_library(filename))
+
+
+def _get_example_template_by_version(filename: str, version: int) -> FileSourceTemplate:
+    catalog = _get_example_library(filename)
+    for template in catalog.root:
+        if template.version == version:
+            return template
+    raise AssertionError(f"No template with version {version} in {filename}")
 
 
 def _get_example_library(filename: str) -> FileSourceTemplateCatalog:

--- a/test/unit/util/test_config_template_validation.py
+++ b/test/unit/util/test_config_template_validation.py
@@ -339,12 +339,18 @@ def test_split_ftp_host_path(data, expected_host, expected_root):
 
 @pytest.mark.parametrize(
     "root_value",
-    ["/custom", ""],
+    ["/custom"],
 )
 def test_split_ftp_host_path_explicit_root_not_overridden(root_value):
     result = split_ftp_host_path({"host": "ftp.gnu.org/gnu/", "root": root_value})
     assert result["host"] == "ftp.gnu.org/gnu/"
     assert result["root"] == root_value
+
+
+def test_split_ftp_host_path_blank_root_treated_as_unset():
+    result = split_ftp_host_path({"host": "ftp.gnu.org/gnu/", "root": ""})
+    assert result["host"] == "ftp.gnu.org"
+    assert result["root"] == "/gnu/"
 
 
 def test_split_ftp_host_path_preserves_other_keys():

--- a/test/unit/util/test_config_template_validation.py
+++ b/test/unit/util/test_config_template_validation.py
@@ -5,6 +5,8 @@ from typing import (
     Optional,
 )
 
+import pytest
+
 from galaxy.exceptions import (
     RequestParameterInvalidException,
     RequestParameterMissingException,
@@ -15,6 +17,7 @@ from galaxy.tool_util_models.parameter_validators import (
     RegexParameterValidatorModel,
 )
 from galaxy.util.config_templates import (
+    split_ftp_host_path,
     StrictModel,
     TemplateEnvironmentEntry,
     TemplateSecret,
@@ -297,6 +300,84 @@ def test_length_validator_min_only():
     instance = _test_instance_with_variables({"description": "test"})
     e = assert_validation_throws(instance, template)
     assert isinstance(e, RequestParameterInvalidException)
+
+
+# --- split_ftp_host_path tests ---
+
+
+@pytest.mark.parametrize(
+    "data, expected_host, expected_root",
+    [
+        # Plain host, no path
+        ({"host": "ftp.gnu.org"}, "ftp.gnu.org", None),
+        # Host with path
+        ({"host": "ftp.gnu.org/gnu/"}, "ftp.gnu.org", "/gnu/"),
+        ({"host": "ftp.ensemblgenomes.org/pub/version/"}, "ftp.ensemblgenomes.org", "/pub/version/"),
+        # Protocol prefix
+        ({"host": "ftp://ftp.gnu.org/gnu/"}, "ftp.gnu.org", "/gnu/"),
+        ({"host": "ftps://ftp.gnu.org/gnu/"}, "ftp.gnu.org", "/gnu/"),
+        ({"host": "ftp://ftp.gnu.org"}, "ftp.gnu.org", None),
+        # Trailing slash only
+        ({"host": "ftp.gnu.org/"}, "ftp.gnu.org", "/"),
+        # Host with port and path
+        ({"host": "ftp.gnu.org:2121/gnu/"}, "ftp.gnu.org:2121", "/gnu/"),
+        # No host
+        ({"port": 21}, None, None),
+    ],
+)
+def test_split_ftp_host_path(data, expected_host, expected_root):
+    result = split_ftp_host_path(data)
+    if expected_host is None:
+        assert "host" not in result or result.get("host") == data.get("host")
+    else:
+        assert result["host"] == expected_host
+    if expected_root is None:
+        assert "root" not in result
+    else:
+        assert result["root"] == expected_root
+
+
+@pytest.mark.parametrize(
+    "root_value",
+    ["/custom", ""],
+)
+def test_split_ftp_host_path_explicit_root_not_overridden(root_value):
+    result = split_ftp_host_path({"host": "ftp.gnu.org/gnu/", "root": root_value})
+    assert result["host"] == "ftp.gnu.org/gnu/"
+    assert result["root"] == root_value
+
+
+def test_split_ftp_host_path_preserves_other_keys():
+    result = split_ftp_host_path({"host": "ftp.gnu.org/gnu/", "user": "anon", "port": 21})
+    assert result["host"] == "ftp.gnu.org"
+    assert result["root"] == "/gnu/"
+    assert result["user"] == "anon"
+    assert result["port"] == 21
+
+
+@pytest.mark.parametrize("non_dict", [None, "ftp://ftp.gnu.org", 42, []])
+def test_split_ftp_host_path_non_dict_input(non_dict):
+    assert split_ftp_host_path(non_dict) == non_dict
+
+
+def test_split_ftp_host_path_does_not_mutate_input():
+    original = {"host": "ftp.gnu.org/gnu/"}
+    split_ftp_host_path(original)
+    assert original == {"host": "ftp.gnu.org/gnu/"}
+
+
+@pytest.mark.parametrize(
+    "root",
+    ["../etc", "/gnu/../etc", "/..", "foo/../bar", "/gnu/../../etc"],
+)
+def test_split_ftp_host_path_rejects_traversal_in_explicit_root(root):
+    with pytest.raises(ValueError, match="must not contain '\\.\\.'"):
+        split_ftp_host_path({"host": "ftp.gnu.org", "root": root})
+
+
+def test_split_ftp_host_path_rejects_traversal_in_host_derived_root():
+    with pytest.raises(ValueError, match="must not contain '\\.\\.'"):
+        split_ftp_host_path({"host": "ftp.gnu.org/../etc"})
 
 
 def test_length_validator_max_only():


### PR DESCRIPTION
Fixes #23398

FTP file sources previously allowed specifying a path as part of the `host` field (e.g. `ftp://ftp.ensembl.org/pub/release-110/`). This was broken, making it impossible to connect to an FTP server at a sub-path.

This PR adds an explicit `root` field to the FTP file source configuration and automatically splits any path embedded in the `host` field into `host` + `root` via a `split_ftp_host_path` validator. The `root` path is used to open the FTP filesystem at the correct subdirectory (`fs.opendir(root)`) and is accounted for in URL scoring and path resolution so that file URLs resolve correctly relative to the root.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
