### PR TITLE
Use TRS IDs as fallback names for GalaxyAI workflow suggestions

### DIFF
--- a/lib/galaxy/agents/tools.py
+++ b/lib/galaxy/agents/tools.py
@@ -546,7 +546,7 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
         if recommendation.recommended_workflows:
             top_wf = recommendation.recommended_workflows[0]
             trs_id = top_wf.get("trsID") or top_wf.get("trs_id")
-            wf_name = top_wf.get("name", "IWC workflow")
+            wf_name = top_wf.get("name") or top_wf.get("trsID") or top_wf.get("trs_id") or "IWC workflow"
             if trs_id:
                 suggestions.append(
                     ActionSuggestion(

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -1690,6 +1690,22 @@ class TestAgentUnitMocked:
         assert suggestion.parameters["name"] == "RNA-seq"
         assert suggestion.priority == 1  # promoted when no tool comes back
 
+    def test_tool_rec_uses_trs_id_as_workflow_name_fallback(self):
+        agent = self._make_tool_rec_agent()
+        trs_id = "#workflow/github.com/iwc-workflows/rna-seq/main"
+        recommendation = SimplifiedToolRecommendationResult(
+            primary_tools=[],
+            recommended_workflows=[{"trsID": trs_id}],
+            confidence="high",
+            reasoning="Multi-step analysis maps to a workflow.",
+        )
+
+        suggestions = agent._create_suggestions(recommendation)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].description == f"Import {trs_id} from IWC"
+        assert suggestions[0].parameters == {"trs_id": trs_id, "name": trs_id}
+
     def test_tool_rec_tool_budget_caps_then_returns_stop_message(self):
         # Past MAX_TOOL_CALLS the budget hands back a terminal "stop searching"
         # message instead of more data, so the model answers from what it already


### PR DESCRIPTION
# Use TRS IDs as fallback names for GalaxyAI workflow suggestions

Follow-up to #23294.

## Summary

GalaxyAI workflow recommendations do not always include a display name. The rendered
recommendation already falls back to the workflow's `trsID`, but the corresponding import
action used the generic `IWC workflow` label (or `None` when `name` was present but null).

This change applies the same fallback order to the import action:

1. workflow name;
2. `trsID` / `trs_id`;
3. `IWC workflow` as a last resort.

That keeps the action description and its `name` parameter useful for legacy TRS-only
results without changing the import identifier or API contract.

## Tests

- Added deterministic unit coverage for a recommendation containing only a `trsID`.
- `test/unit/app/test_agents.py::TestAgentUnitMocked::test_tool_rec_uses_trs_id_as_workflow_name_fallback` — passed.
