### PR TITLE
Prevent dependency cache failures from rolling back Tool Shed installs

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -28,6 +28,7 @@ from galaxy.tool_shed.util import (
     tool_util,
 )
 from galaxy.tool_util.deps import views
+from galaxy.tool_util.deps.resolvers import DependencyException
 from galaxy.util.tool_shed import (
     common_util,
     encoding_util,
@@ -643,16 +644,35 @@ class InstallRepositoryManager:
                 tool_shed_repository,
                 self.install_model.ToolShedRepository.installation_status.INSTALLING_TOOL_DEPENDENCIES,
             )
-            new_tools = [self.app.toolbox._tools_by_id.get(tool_d["guid"], None) for tool_d in metadata["tools"]]
-            new_requirements = {tool.requirements.packages for tool in new_tools if tool}
-            [self._view.install_dependencies(r) for r in new_requirements]
-            dependency_manager = self.app.toolbox.dependency_manager
-            if dependency_manager.cached:
-                [dependency_manager.build_cache(r) for r in new_requirements]
+            self._install_tool_dependencies(metadata)
 
         self.update_tool_shed_repository_status(
             tool_shed_repository, self.install_model.ToolShedRepository.installation_status.INSTALLED
         )
+
+    def _install_tool_dependencies(self, metadata):
+        requirements_to_tool_ids = {}
+        for tool_dict in metadata["tools"]:
+            tool_id = tool_dict["guid"]
+            tool = self.app.toolbox._tools_by_id.get(tool_id)
+            if tool:
+                requirements_to_tool_ids.setdefault(tool.requirements.packages, []).append(tool_id)
+
+        for requirements in requirements_to_tool_ids:
+            self._view.install_dependencies(requirements)
+
+        dependency_manager = self.app.toolbox.dependency_manager
+        if dependency_manager.cached:
+            for requirements, tool_ids in requirements_to_tool_ids.items():
+                try:
+                    dependency_manager.build_cache(requirements)
+                except DependencyException:
+                    log.exception(
+                        "Failed to build dependency cache for requirements %s used by tools %s; "
+                        "repository installation will continue, but the affected tools may fail to execute",
+                        requirements.to_dict(),
+                        ", ".join(tool_ids),
+                    )
 
     def update_tool_shed_repository(
         self,

--- a/test/integration/test_repository_dependency_cache.py
+++ b/test/integration/test_repository_dependency_cache.py
@@ -1,5 +1,7 @@
 """Integration tests for dependency caching during Tool Shed installation."""
 
+from pathlib import Path
+
 from galaxy.tool_util.deps.resolvers import (
     Dependency,
     DependencyException,
@@ -80,8 +82,16 @@ class TestRepositoryDependencyCacheFailure(integration_util.IntegrationTestCase,
         repositories = response.json()
         assert len(repositories) == 1
         assert repositories[0]["status"] == "Installed"
-        assert not repositories[0]["deleted"]
         assert resolver.cache_build_attempts == 1
+        repository_path = (
+            Path(self._app.config.shed_tools_dir)
+            / "toolshed.g2.bx.psu.edu"
+            / "repos"
+            / "devteam"
+            / "fastqc"
+            / "e7b2202befea"
+        )
+        assert repository_path.is_dir()
         installed_repository = self.get_installed_repository_for("devteam", "fastqc", "e7b2202befea")
         assert installed_repository
         assert installed_repository["status"] == "Installed"

--- a/test/integration/test_repository_dependency_cache.py
+++ b/test/integration/test_repository_dependency_cache.py
@@ -1,0 +1,87 @@
+"""Integration tests for dependency caching during Tool Shed installation."""
+
+from galaxy.tool_util.deps.resolvers import (
+    Dependency,
+    DependencyException,
+    DependencyResolver,
+)
+from galaxy_test.base.uses_shed_api import DEFAULT_TOOL_SHED_URL
+from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
+
+
+class FailingCacheDependency(Dependency):
+    dependency_type = "test"
+    cacheable = True
+
+    def __init__(self, requirement, resolver):
+        self.name = requirement.name
+        self.version = requirement.version
+        self.resolver = resolver
+
+    @property
+    def exact(self):
+        return True
+
+    def build_cache(self, cache_path):
+        self.resolver.cache_build_attempts += 1
+        raise DependencyException("Controlled cache construction failure")
+
+    def shell_commands(self):
+        return ""
+
+
+class FailingCacheDependencyResolver(DependencyResolver):
+    resolver_type = "test"
+
+    def __init__(self):
+        self.cache_build_attempts = 0
+
+    def resolve(self, requirement, **kwds):
+        return FailingCacheDependency(requirement, self)
+
+
+class TestRepositoryDependencyCacheFailure(integration_util.IntegrationTestCase, UsesShed):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        cls.configure_shed(config)
+        config["use_cached_dependency_manager"] = True
+        config["conda_auto_init"] = False
+
+    def setUp(self):
+        super().setUp()
+        self.setup_shed_config()
+
+    def tearDown(self):
+        self.reset_shed_tools()
+        return super().tearDown()
+
+    def test_cache_failure_does_not_remove_installed_repository(self):
+        dependency_manager = self._app.toolbox.dependency_manager
+        assert dependency_manager.cached
+        resolver = FailingCacheDependencyResolver()
+        original_resolvers = dependency_manager.dependency_resolvers
+        dependency_manager.dependency_resolvers = [resolver]
+        try:
+            response = self.install_repo_request(
+                {
+                    "tool_shed_url": DEFAULT_TOOL_SHED_URL,
+                    "name": "fastqc",
+                    "owner": "devteam",
+                    "changeset_revision": "e7b2202befea",
+                    "install_resolver_dependencies": True,
+                }
+            )
+        finally:
+            dependency_manager.dependency_resolvers = original_resolvers
+
+        self._assert_status_code_is(response, 200)
+        repositories = response.json()
+        assert len(repositories) == 1
+        assert repositories[0]["status"] == "Installed"
+        assert not repositories[0]["deleted"]
+        assert resolver.cache_build_attempts == 1
+        installed_repository = self.get_installed_repository_for("devteam", "fastqc", "e7b2202befea")
+        assert installed_repository
+        assert installed_repository["status"] == "Installed"

--- a/test/unit/tool_shed/test_install_manager.py
+++ b/test/unit/tool_shed/test_install_manager.py
@@ -1,11 +1,19 @@
-"""Unit tests for install-time data table registration gating."""
+"""Unit tests for Tool Shed repository installation."""
 
+import logging
 from typing import (
     Any,
 )
 from unittest import mock
 
+import pytest
+
 from galaxy.tool_shed.galaxy_install import install_manager
+from galaxy.tool_util.deps.requirements import (
+    ToolRequirement,
+    ToolRequirements,
+)
+from galaxy.tool_util.deps.resolvers import DependencyException
 
 INSTALL_MANAGER_MODULE = "galaxy.tool_shed.galaxy_install.install_manager"
 
@@ -107,3 +115,58 @@ def test_data_manager_repo_invokes_handle_missing_data_table_entry():
     fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
     stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
     stdtm_instance.handle_missing_data_table_entry.assert_called_once()
+
+
+def _requirements(name: str) -> ToolRequirements:
+    return ToolRequirements([ToolRequirement(name=name, type="package", version="1.0")])
+
+
+def test_dependency_cache_failure_is_isolated_to_requirement_set(caplog):
+    irm, _ = _make_install_repository_manager()
+    first_requirements = _requirements("first")
+    second_requirements = _requirements("second")
+    first_tool = mock.MagicMock()
+    first_tool.requirements.packages = first_requirements
+    duplicate_tool = mock.MagicMock()
+    duplicate_tool.requirements.packages = first_requirements
+    second_tool = mock.MagicMock()
+    second_tool.requirements.packages = second_requirements
+    irm.app.toolbox._tools_by_id = {
+        "first/tool": first_tool,
+        "duplicate/tool": duplicate_tool,
+        "second/tool": second_tool,
+    }
+    irm._view = mock.MagicMock()
+    dependency_manager = irm.app.toolbox.dependency_manager
+    dependency_manager.cached = True
+    dependency_manager.build_cache.side_effect = [DependencyException("cache failed"), None]
+    metadata = {"tools": [{"guid": tool_id} for tool_id in irm.app.toolbox._tools_by_id]}
+
+    with caplog.at_level(logging.ERROR, logger=INSTALL_MANAGER_MODULE):
+        irm._install_tool_dependencies(metadata)
+
+    assert irm._view.install_dependencies.call_args_list == [
+        mock.call(first_requirements),
+        mock.call(second_requirements),
+    ]
+    assert dependency_manager.build_cache.call_args_list == [
+        mock.call(first_requirements),
+        mock.call(second_requirements),
+    ]
+    assert "first/tool, duplicate/tool" in caplog.text
+    assert "repository installation will continue" in caplog.text
+
+
+def test_unexpected_dependency_cache_failure_is_not_suppressed():
+    irm, _ = _make_install_repository_manager()
+    requirements = _requirements("package")
+    tool = mock.MagicMock()
+    tool.requirements.packages = requirements
+    irm.app.toolbox._tools_by_id = {"example/tool": tool}
+    irm._view = mock.MagicMock()
+    dependency_manager = irm.app.toolbox.dependency_manager
+    dependency_manager.cached = True
+    dependency_manager.build_cache.side_effect = RuntimeError("unexpected")
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        irm._install_tool_dependencies({"tools": [{"guid": "example/tool"}]})

--- a/test/unit/tool_shed/test_install_manager.py
+++ b/test/unit/tool_shed/test_install_manager.py
@@ -1,19 +1,11 @@
-"""Unit tests for Tool Shed repository installation."""
+"""Unit tests for install-time data table registration gating."""
 
-import logging
 from typing import (
     Any,
 )
 from unittest import mock
 
-import pytest
-
 from galaxy.tool_shed.galaxy_install import install_manager
-from galaxy.tool_util.deps.requirements import (
-    ToolRequirement,
-    ToolRequirements,
-)
-from galaxy.tool_util.deps.resolvers import DependencyException
 
 INSTALL_MANAGER_MODULE = "galaxy.tool_shed.galaxy_install.install_manager"
 
@@ -115,58 +107,3 @@ def test_data_manager_repo_invokes_handle_missing_data_table_entry():
     fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
     stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
     stdtm_instance.handle_missing_data_table_entry.assert_called_once()
-
-
-def _requirements(name: str) -> ToolRequirements:
-    return ToolRequirements([ToolRequirement(name=name, type="package", version="1.0")])
-
-
-def test_dependency_cache_failure_is_isolated_to_requirement_set(caplog):
-    irm, _ = _make_install_repository_manager()
-    first_requirements = _requirements("first")
-    second_requirements = _requirements("second")
-    first_tool = mock.MagicMock()
-    first_tool.requirements.packages = first_requirements
-    duplicate_tool = mock.MagicMock()
-    duplicate_tool.requirements.packages = first_requirements
-    second_tool = mock.MagicMock()
-    second_tool.requirements.packages = second_requirements
-    irm.app.toolbox._tools_by_id = {
-        "first/tool": first_tool,
-        "duplicate/tool": duplicate_tool,
-        "second/tool": second_tool,
-    }
-    irm._view = mock.MagicMock()
-    dependency_manager = irm.app.toolbox.dependency_manager
-    dependency_manager.cached = True
-    dependency_manager.build_cache.side_effect = [DependencyException("cache failed"), None]
-    metadata = {"tools": [{"guid": tool_id} for tool_id in irm.app.toolbox._tools_by_id]}
-
-    with caplog.at_level(logging.ERROR, logger=INSTALL_MANAGER_MODULE):
-        irm._install_tool_dependencies(metadata)
-
-    assert irm._view.install_dependencies.call_args_list == [
-        mock.call(first_requirements),
-        mock.call(second_requirements),
-    ]
-    assert dependency_manager.build_cache.call_args_list == [
-        mock.call(first_requirements),
-        mock.call(second_requirements),
-    ]
-    assert "first/tool, duplicate/tool" in caplog.text
-    assert "repository installation will continue" in caplog.text
-
-
-def test_unexpected_dependency_cache_failure_is_not_suppressed():
-    irm, _ = _make_install_repository_manager()
-    requirements = _requirements("package")
-    tool = mock.MagicMock()
-    tool.requirements.packages = requirements
-    irm.app.toolbox._tools_by_id = {"example/tool": tool}
-    irm._view = mock.MagicMock()
-    dependency_manager = irm.app.toolbox.dependency_manager
-    dependency_manager.cached = True
-    dependency_manager.build_cache.side_effect = RuntimeError("unexpected")
-
-    with pytest.raises(RuntimeError, match="unexpected"):
-        irm._install_tool_dependencies({"tools": [{"guid": "example/tool"}]})


### PR DESCRIPTION
A Tool Shed repository can contain tools with distinct dependency requirement sets. Previously, if cached environment construction raised `DependencyException` for any one of those sets, the exception reached the generic repository-install rollback handler. Galaxy then marked the entire repository installation as failed and removed every tool in it, including tools whose dependencies were unrelated to the failure.

This change isolates cached-environment construction failures to their owning requirement sets. Galaxy now:

- retains the tool IDs associated with each distinct requirement set;
- catches `DependencyException` around each individual cache build;
- logs the failed requirements and all tools that use them; and
- continues installing the repository and preparing other requirement sets.

Unexpected exceptions remain fatal. A tool whose cached environment could not be built may still fail when executed or retry cache construction; this change only prevents that failure from removing unrelated tools.

Fixes #23489.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

The integration test installs `devteam/fastqc` through the real Tool Shed API while a controlled dependency resolver raises `DependencyException` during cached-environment construction. It verifies that cache construction was attempted, the repository reaches `Installed`, its database record remains available, and its installation directory remains on disk.

Focused validation:

```shell
./run_tests.sh -integration test/integration/test_repository_dependency_cache.py
./run_tests.sh -unit test/unit/tool_shed/test_install_manager.py
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
