### PR TITLE
[25.1] Add zlib1g-dev to k8s image build deps

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -46,6 +46,7 @@ RUN set -xe; \
         libc-dev \
         bzip2 \
         gcc \
+        zlib1g-dev \
     && pip install --no-cache virtualenv ansible==11.11.0 \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
## What

Backport of #23381 (cherry-pick of 6e13671524) from `release_26.1`.

## Why

The container image build fails on every push to `release_25.1`: `uv pip install -r k8s-requirements.txt` dies compiling `bgzip==0.5.1` with `fatal error: zlib.h: No such file or directory` (e.g. run 34481410576). `bgzip` is pulled in transitively via `fs.anvilfs` -> `terra-notebook-utils` -> `bgzip` and only ships a source distribution, so it compiles its C extension against zlib headers the stage 1 build image does not have.

This was fixed on `release_26.1` by #23381 (and reached `dev` via #23423) but was never backported here.

## How to test the changes?

- [x] Instructions for manual testing are as follows: the Build Container Image workflow on this branch should go green again after merge.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).