### PR TITLE
Only run the GHCR container build job on forks

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -14,6 +14,14 @@ jobs:
   ghcrbuild:
     name: Build container image for GHCR
     runs-on: ubuntu-latest
+    # Fork enablement only: publishes an image to the fork's own GHCR
+    # namespace using just GITHUB_TOKEN, since forks cannot run the
+    # credential-gated build job below. The main repo publishes to Docker Hub
+    # and Quay.io instead and does not use GHCR images.
+    if: github.repository_owner != 'galaxyproject'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v7.0.1
         with:


### PR DESCRIPTION
## What

Gates the `ghcrbuild` job in `build_container_image.yaml` to `github.repository_owner != 'galaxyproject'` and grants it the job-level `permissions` (`contents: read`, `packages: write`) it needs now that the workflow declares top-level `permissions: {}`.

## Why

`ghcrbuild` has failed on every push to `dev` since #22827 added workflow-level `permissions: {}`.  The failure is silent: the Slack notify job only watches `build` and `smoke-test`.

The job exists purely for fork enablement (#18514) since forks cannot run the credential-gated `build` job. The main repo publishes to Docker Hub and Quay.io and does not use GHCR images.

The job was already removed from `release_26.1` (#22897), but that removal was lost on `dev` in the conflict resolution of the #22982 forward-merge. Gating it (rather than deleting it) preserves the fork use case while reducing CI/CD run time.

## How to test the changes?

- [x] Instructions for manual testing are as follows: push to a fork's `dev` branch and confirm ghcrbuild runs and publishes `ghcr.io/<owner>/galaxy:dev`; on `galaxyproject/galaxy` the job is skipped.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).