### PR TITLE
[26.1] Fix truncated and empty S3 cache downloads

### DIFF
--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,11 +1,13 @@
 import logging
 import os
 import shutil
+import tempfile
 from contextlib import contextmanager
 from datetime import datetime
 from typing import (
     Any,
     Dict,
+    Iterator,
     Optional,
 )
 
@@ -121,8 +123,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         file_ok = self._download(rel_path)
         if file_ok:
             fix_permissions(self.config, self._get_cache_path(rel_path_dir))
-        else:
-            unlink(self._get_cache_path(rel_path), ignore_errors=True)
         return file_ok
 
     def _get_data(self, obj, start=0, count=-1, **kwargs):
@@ -397,26 +397,26 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         raise NotImplementedError()
 
     @contextmanager
-    def _atomic_download(self, cache_path):
-        """Download to a temp file then atomically rename to prevent serving partial files.
-
-        Usage::
-
-            with self._atomic_download(local_destination) as tmp_path:
-                do_download(tmp_path)
-        """
-        tmp_path = cache_path + ".tmp"
+    def _atomic_download(self, cache_path: str, expected_size: Optional[int] = None) -> Iterator[str]:
+        """Yield a unique temporary path and publish it atomically after optional size validation."""
+        fd, tmp_path = tempfile.mkstemp(
+            dir=os.path.dirname(cache_path),
+            prefix=f".{os.path.basename(cache_path)}.",
+            suffix=".tmp",
+        )
+        os.close(fd)
+        os.unlink(tmp_path)
         try:
             yield tmp_path
-            os.rename(tmp_path, cache_path)
-        except BaseException:
-            # Catch BaseException (not just Exception) so that KeyboardInterrupt
-            # and SystemExit also trigger cleanup — we re-raise immediately, so
-            # propagation is not blocked. Without this, interrupted downloads
-            # leave .tmp files that poison the cache on next startup.
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            raise
+            downloaded_size = os.path.getsize(tmp_path)
+            if expected_size is not None and expected_size >= 0 and downloaded_size != expected_size:
+                raise OSError(
+                    f"downloaded object size does not match remote size for {cache_path}: "
+                    f"expected {expected_size}, got {downloaded_size}"
+                )
+            os.replace(tmp_path, cache_path)
+        finally:
+            unlink(tmp_path, ignore_errors=True)
 
     def _download(self, rel_path: str) -> bool:
         raise NotImplementedError()

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -34,22 +34,6 @@ log = logging.getLogger(__name__)
 logging.getLogger("boto").setLevel(logging.INFO)  # Otherwise boto is quite noisy
 
 
-def download_directory(bucket, remote_folder, local_path):
-    objects = bucket.list(prefix=remote_folder)
-    for obj in objects:
-        remote_file_path = obj.key
-        local_file_path = os.path.join(local_path, os.path.relpath(remote_file_path, remote_folder))
-        os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-        tmp_file_path = local_file_path + ".tmp"
-        try:
-            obj.get_contents_to_filename(tmp_file_path)
-            os.rename(tmp_file_path, local_file_path)
-        except Exception:
-            if os.path.exists(tmp_file_path):
-                os.remove(tmp_file_path)
-            raise
-
-
 def parse_config_xml(config_xml):
     try:
         a_xml = config_xml.findall("auth")[0]
@@ -317,11 +301,14 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)
                 url = key.generate_url(7200)
-                return self._axel_download(url, local_destination)
+                with self._atomic_download(local_destination, remote_size) as tmp:
+                    if not self._axel_download(url, tmp):
+                        raise OSError(f"Failed to download key '{rel_path}' with axel")
+                return True
             else:
                 log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
                 self.transfer_progress = 0  # Reset transfer progress counter
-                with self._atomic_download(local_destination) as tmp:
+                with self._atomic_download(local_destination, remote_size) as tmp:
                     key.get_contents_to_filename(tmp, cb=self._transfer_cb, num_cb=10)
                 return True
         except S3ResponseError:
@@ -406,7 +393,11 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             return False
 
     def _download_directory_into_cache(self, rel_path, cache_path):
-        download_directory(self._bucket, rel_path, cache_path)
+        for obj in self._bucket.list(prefix=rel_path):
+            local_file_path = os.path.join(cache_path, os.path.relpath(obj.key, rel_path))
+            os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
+            with self._atomic_download(local_file_path, obj.size) as tmp:
+                obj.get_contents_to_filename(tmp)
 
     def _get_object_url(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -327,10 +327,11 @@ class S3ObjectStore(CachingConcreteObjectStore):
         local_destination = self._get_cache_path(rel_path)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path):
+            remote_size = self._get_remote_size(rel_path)
+            if not self._caching_allowed(rel_path, remote_size):
                 return False
             config = self._transfer_config("download")
-            with self._atomic_download(local_destination) as tmp:
+            with self._atomic_download(local_destination, remote_size) as tmp:
                 self._client.download_file(self.bucket, rel_path, tmp, Config=config)
             return True
         except ClientError:
@@ -380,11 +381,18 @@ class S3ObjectStore(CachingConcreteObjectStore):
             for content in page.get("Contents", ()):
                 yield content["Key"]
 
+    def _keys_with_sizes(self, prefix: str):
+        s3_paginator = self._client.get_paginator("list_objects_v2")
+        prefix = prefix.lstrip("/")
+        for page in s3_paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for content in page.get("Contents", ()):
+                yield content["Key"], content["Size"]
+
     def _download_directory_into_cache(self, rel_path, cache_path):
-        for key in self._keys(rel_path):
+        for key, size in self._keys_with_sizes(rel_path):
             local_file_path = os.path.join(cache_path, os.path.relpath(key, rel_path))
             os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-            with self._atomic_download(local_file_path) as tmp:
+            with self._atomic_download(local_file_path, size) as tmp:
                 self._client.download_file(self.bucket, key, tmp)
 
     def _get_object_url(self, obj, **kwargs):

--- a/test/unit/objectstore/test_s3_cache_download.py
+++ b/test/unit/objectstore/test_s3_cache_download.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from galaxy.objectstore.examples import get_example
+from galaxy.objectstore.s3 import S3ObjectStore
+from galaxy.objectstore.s3_boto3 import S3ObjectStore as Boto3ObjectStore
+from galaxy.objectstore.unittest_utils import Config as StoreConfig
+
+REMOTE_CONTENT = b"remote object content"
+BOTO3_CONFIG = """
+type: boto3
+auth:
+  access_key: access_moo
+  secret_key: secret_cow
+bucket:
+  name: unique_bucket_name_all_lowercase
+"""
+
+
+class UninitializedS3ObjectStore(S3ObjectStore):
+    def _initialize(self):
+        pass
+
+
+class UninitializedBoto3ObjectStore(Boto3ObjectStore):
+    def _initialize(self):
+        pass
+
+
+class FailedDownloadBoto3ObjectStore(UninitializedBoto3ObjectStore):
+    def _download(self, rel_path: str) -> bool:
+        return False
+
+
+@pytest.fixture
+def legacy_store():
+    pytest.importorskip("boto")
+    with StoreConfig(get_example("s3_global_cache.yml"), clazz=UninitializedS3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        store.use_axel = False
+        store._bucket = MagicMock()
+        yield store
+
+
+@pytest.fixture
+def boto3_store():
+    with StoreConfig(BOTO3_CONFIG, clazz=UninitializedBoto3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        store._client = MagicMock()
+        yield store
+
+
+def _serve_legacy_object(store, downloaded_content):
+    key = store._bucket.get_key.return_value
+    key.size = len(REMOTE_CONTENT)
+    key.get_contents_to_filename.side_effect = lambda filename, **_: Path(filename).write_bytes(downloaded_content)
+
+
+def _serve_boto3_object(store, downloaded_content, remote_size=len(REMOTE_CONTENT)):
+    store._client.head_object.return_value = {"ContentLength": remote_size}
+    store._client.download_file.side_effect = lambda _bucket, _key, filename, **_: Path(filename).write_bytes(
+        downloaded_content
+    )
+
+
+def _cache(store) -> Path:
+    return Path(store.staging_path)
+
+
+def _assert_nothing_published(store, rel_path="object"):
+    assert not (_cache(store) / rel_path).exists()
+    assert not list(_cache(store).rglob("*.tmp"))
+
+
+def test_legacy_s3_does_not_publish_truncated_download(legacy_store):
+    _serve_legacy_object(legacy_store, REMOTE_CONTENT[:5])
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        legacy_store._download("object")
+
+    _assert_nothing_published(legacy_store)
+
+
+def test_boto3_does_not_publish_empty_download_for_nonempty_object(boto3_store):
+    _serve_boto3_object(boto3_store, b"")
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        boto3_store._download("object")
+
+    _assert_nothing_published(boto3_store)
+
+
+def test_boto3_preserves_legitimate_empty_remote_object(boto3_store):
+    _serve_boto3_object(boto3_store, b"", remote_size=0)
+
+    assert boto3_store._download("object")
+    assert (_cache(boto3_store) / "object").read_bytes() == b""
+
+
+def test_legacy_s3_axel_download_is_size_checked(legacy_store, monkeypatch):
+    legacy_store.use_axel = True
+    legacy_store._bucket.get_key.return_value.size = len(REMOTE_CONTENT)
+    legacy_store._bucket.get_key.return_value.generate_url.return_value = "https://example.org/object"
+
+    def axel_download_that_writes_nothing(_url, path):
+        Path(path).write_bytes(b"")
+        return True
+
+    monkeypatch.setattr(legacy_store, "_axel_download", axel_download_that_writes_nothing)
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        legacy_store._download("object")
+
+    _assert_nothing_published(legacy_store)
+
+
+def test_interrupted_download_cleans_temporary_file(boto3_store):
+    cache_path = str(_cache(boto3_store) / "object")
+
+    with pytest.raises(KeyboardInterrupt):
+        with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as tmp:
+            Path(tmp).write_bytes(REMOTE_CONTENT[:5])
+            raise KeyboardInterrupt()
+
+    _assert_nothing_published(boto3_store)
+
+
+def test_failed_download_does_not_remove_concurrently_published_file():
+    with StoreConfig(BOTO3_CONFIG, clazz=FailedDownloadBoto3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        (_cache(store) / "object").write_bytes(REMOTE_CONTENT)
+
+        assert not store._pull_into_cache("object")
+        assert (_cache(store) / "object").read_bytes() == REMOTE_CONTENT
+
+
+def test_concurrent_downloads_use_distinct_temp_files_and_failure_cannot_replace_success(boto3_store):
+    cache_path = str(_cache(boto3_store) / "object")
+
+    with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as first_tmp:
+        with pytest.raises(OSError, match="downloaded object size"):
+            with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as second_tmp:
+                assert second_tmp != first_tmp
+                Path(second_tmp).write_bytes(REMOTE_CONTENT[:5])
+        Path(first_tmp).write_bytes(REMOTE_CONTENT)
+
+    assert (_cache(boto3_store) / "object").read_bytes() == REMOTE_CONTENT
+    assert not list(_cache(boto3_store).rglob("*.tmp"))
+
+
+def test_boto3_directory_download_uses_listed_sizes_without_head_requests(boto3_store):
+    contents = {"dataset_1_files/a.txt": REMOTE_CONTENT, "dataset_1_files/sub/b.txt": b""}
+    boto3_store._client.get_paginator.return_value.paginate.return_value = [
+        {"Contents": [{"Key": key, "Size": len(content)} for key, content in contents.items()]}
+    ]
+    boto3_store._client.download_file.side_effect = lambda _bucket, key, filename, **_: Path(filename).write_bytes(
+        contents[key]
+    )
+    cache_dir = _cache(boto3_store) / "dataset_1_files"
+
+    boto3_store._download_directory_into_cache("dataset_1_files", str(cache_dir))
+
+    boto3_store._client.head_object.assert_not_called()
+    assert (cache_dir / "a.txt").read_bytes() == REMOTE_CONTENT
+    assert (cache_dir / "sub" / "b.txt").read_bytes() == b""
+    assert not list(_cache(boto3_store).rglob("*.tmp"))


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15283

Every download of an object wrote to the same temp file, `<cache_path>.tmp`. When two requests pulled the same uncached object at once the second `open()` truncated the file the first was still writing, and whichever finished first renamed a short or empty file into the cache, where it was served as complete. A failed pull also unlinked the cache path afterwards, which could remove a copy another request had just published.

`_atomic_download` now gives every download its own temp file in the cache directory, compares the downloaded size against the remote size before publishing, and publishes with `os.replace`. A failed or interrupted download removes only its own temp file. The legacy S3 store's axel path and both stores' directory downloads go through the same helper, so they are atomic and size checked too. The boto3 directory download takes sizes from the LIST response rather than a HEAD per key.

Behavioural changes:

- A size mismatch or an axel failure raises `OSError` out of `_download` instead of returning `False`, so the failure surfaces rather than turning into `ObjectNotFound`.
- `_pull_into_cache` no longer unlinks the cache path when a download returns `False`. A 0-byte entry left by a refused download stays until the next `_get_filename` re-pulls it.
- Axel can no longer resume an interrupted transfer, since the temp name differs per attempt.

Limitations:

- Concurrent pulls of one object still each download the full object; there is no coordination between them.
- Size validation is only wired into the two S3 stores. The other caching stores keep publishing whatever arrives.

Relation to dev: dev already uses a unique temp file per download (5b1d97dfe2a) and validates size on the tee-streaming path (2a96623062b), but still has the shared temp name in `download_directory`, the unlink on failed pull, an unchecked axel path, and no size check on the plain pull path. Those parts will need to be carried forward in the merge.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
