### PR TITLE
Return rate-limit rejections as Galaxy error responses

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -260,6 +260,13 @@ class DeprecatedMethod(MessageException):
     err_code = error_codes_by_name["DEPRECATED_API_CALL"]
 
 
+class TooManyRequestsException(MessageException):
+    status_code = 429
+    err_code = error_codes_by_name["TOO_MANY_REQUESTS"]
+    #: Seconds until the limit window resets; emitted as the ``Retry-After`` header.
+    retry_after: int | None = None
+
+
 class ConfigurationError(Exception):
     status_code = 500
     err_code = error_codes_by_name["CONFIG_ERROR"]

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -180,6 +180,11 @@
         "message": "This API method or call signature has been deprecated and is no longer available"
     },
     {
+        "name": "TOO_MANY_REQUESTS",
+        "code": 429001,
+        "message": "Too many requests, try again later."
+    },
+    {
         "name": "INTERNAL_SERVER_ERROR",
         "code": 500001,
         "message": "Internal server error."

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -1,4 +1,6 @@
 import logging
+import math
+import time
 from contextlib import asynccontextmanager
 from typing import (
     Any,
@@ -9,18 +11,17 @@ from a2wsgi import WSGIMiddleware
 from fastapi import (
     FastAPI,
     Request,
+    Response,
 )
 from fastapi.openapi.constants import REF_TEMPLATE
-from slowapi import (
-    _rate_limit_exceeded_handler,
-    Limiter,
-)
+from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from starlette.datastructures import MutableHeaders
 from starlette.middleware.cors import CORSMiddleware
 from tuspyserver import create_tus_router
 
+from galaxy.exceptions import TooManyRequestsException
 from galaxy.schema.generics import ref_to_name
 from galaxy.version import VERSION
 from galaxy.webapps.base.api import (
@@ -29,6 +30,7 @@ from galaxy.webapps.base.api import (
     add_request_id_middleware,
     build_route_name_index,
     GalaxyFileResponse,
+    get_error_response_for_request,
     include_all_package_routers,
 )
 from galaxy.webapps.base.webapp import (
@@ -299,6 +301,22 @@ def include_mcp(app: FastAPI, gx_app, mcp_app):
         log.error(f"Failed to mount MCP server: {e}")
 
 
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
+    """Report a hit rate limit as a regular Galaxy error response.
+
+    The client only surfaces ``err_msg``, so slowapi's default ``{"error": ...}``
+    body would show as a bare "Request failed". ``Retry-After`` is derived from
+    the limit window the same way slowapi's own header injection does it; that
+    injection is not enabled because it requires every limited route to take a
+    ``Response`` parameter.
+    """
+    error = TooManyRequestsException(f"Rate limit exceeded: {exc.detail}")
+    limit_item, identifiers = request.state.view_rate_limit
+    reset_time, _remaining = request.app.state.limiter.limiter.get_window_stats(limit_item, *identifiers)
+    error.retry_after = max(1, math.ceil(reset_time - time.time()))
+    return get_error_response_for_request(request, error)
+
+
 def initialize_fast_app(gx_wsgi_webapp, gx_app):
     """Build the FastAPI app that fronts the Galaxy web server."""
     root_path = "" if gx_app.config.galaxy_url_prefix == "/" else gx_app.config.galaxy_url_prefix
@@ -318,7 +336,7 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     add_exception_handler(app)
     add_galaxy_middleware(app, gx_app)
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)  # type: ignore[arg-type]
     if gx_app.config.use_access_logging_middleware:
         add_raw_context_middlewares(app)
     else:

--- a/test/unit/webapps/test_rate_limit_response.py
+++ b/test/unit/webapps/test_rate_limit_response.py
@@ -1,0 +1,36 @@
+"""A hit rate limit is reported as a regular Galaxy error response."""
+
+from fastapi import (
+    FastAPI,
+    Request,
+)
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+
+from galaxy.webapps.galaxy.fast_app import (
+    limiter,
+    rate_limit_exceeded_handler,
+)
+
+app = FastAPI()
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+
+@app.get("/limited")
+@limiter.limit("1/minute")
+async def limited(request: Request):
+    return {"ok": True}
+
+
+def test_rate_limited_request_is_a_galaxy_error_with_retry_after():
+    client = TestClient(app)
+    assert client.get("/limited").status_code == 200
+
+    response = client.get("/limited")
+
+    assert response.status_code == 429
+    body = response.json()
+    assert body["err_code"] == 429001
+    assert body["err_msg"] == "Rate limit exceeded: 1 per 1 minute"
+    assert 1 <= int(response.headers["Retry-After"]) <= 60


### PR DESCRIPTION
slowapi's default handler answers a hit rate limit with `{"error": "..."}`. The client only reads `err_msg`, so a rate-limited user currently sees "Request failed." with no hint why.

This registers a handler that maps `RateLimitExceeded` to a new `TooManyRequestsException` (HTTP 429, error code 429001) and sends it through the regular Galaxy error response path, so the body has the usual `err_msg` / `err_code` shape. `Retry-After` is computed from the limit window the same way slowapi's own header injection does. That injection stays off: it requires every limited route to declare a `Response` parameter, and enabling it turns a limited route that returns a model into a 500.

Split out of #22259, which adds a rate limit on `POST /api/notifications` and whose integration test currently asserts the old `error` key; that assertion will need to move to `err_msg` once this lands.

## How to test the changes?
- [x] Unit test added: `test/unit/webapps/test_rate_limit_response.py` builds a FastAPI app with a `1/minute` route and asserts the second call is a 429 with `err_code` 429001, an `err_msg` naming the limit, and a `Retry-After` header. It fails against slowapi's default handler with `KeyError: 'err_code'`.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
