### PR TITLE
Document configuration schema and Python dependency workflows in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,10 @@ https://help.github.com/en/github/getting-started-with-github/git-and-github-lea
    If you are working on the Galaxy user interface (i.e. JavaScript,
    styles, etc.), see more information in the [client README](client/README.md).
 
+   If you need to modify Galaxy's or the Tool Shed's configuration schema, or
+   add or update a Python dependency, see the relevant entries in the
+   [Galaxy Development FAQ](doc/source/dev/faq.rst).
+
 5. Galaxy contains hundreds of tests of different types and complexity and
    running each is difficult and probably not reasonable on your workstation. So
    please review the [running tests documentation](test/TESTING.md) and run any

--- a/doc/source/dev/faq.rst
+++ b/doc/source/dev/faq.rst
@@ -28,14 +28,40 @@ Please see the ``Makefile`` itself for details and other options. There is also 
 ... rebuild the Galaxy configuration schema?
 -------------------------------------------
 
-Galaxy configurations have a schema that is used to validate configuration
-files. This schema is defined in
-``lib/galaxy/config/schemas/config_schema.yml``. If you make changes to the
-schema, to rebuild all sample YAML and RST files, source Galaxy's virtual
-environment and run the following command from Galaxy's root directory:
+Galaxy and the Tool Shed each have a schema that is used to validate their
+configuration files. These schemas are defined in
+``lib/galaxy/config/schemas/config_schema.yml`` (for ``galaxy.yml``) and
+``lib/galaxy/config/schemas/tool_shed_config_schema.yml`` (for ``tool_shed.yml``).
+If you need to add or modify a configuration option, edit the relevant schema
+file directly instead of the corresponding
+``lib/galaxy/config/sample/*.yml.sample`` file, then run the following
+command from Galaxy's root directory to regenerate the sample YAML files
+(and, for Galaxy, the RST documentation and type stubs):
 
 .. code-block:: bash
 
     make config-rebuild
 
-Then add updated files to your commit.
+Then add the regenerated files to your commit.
+
+... add or update a Galaxy Python dependency?
+----------------------------------------------
+
+Galaxy's Python dependencies are declared in the root ``pyproject.toml``
+file. Each subdirectory of ``packages/`` also corresponds to a package
+published on PyPI (e.g. ``packages/util/`` is ``galaxy-util``) and has its
+own ``pyproject.toml``. If a dependency is needed by the code of one or more
+of these packages, also add it to the ``dependencies`` list of the relevant
+``packages/<package>/pyproject.toml`` file(s).
+
+After editing the root ``pyproject.toml``, run the following command from
+Galaxy's root directory to update the pinned requirements files under
+``lib/galaxy/dependencies/`` (this also updates ``uv.lock``, which is not
+tracked in the repository):
+
+.. code-block:: bash
+
+    make update-dependencies
+
+Then add the updated ``pyproject.toml`` and pinned requirements files to
+your commit.


### PR DESCRIPTION
Expand the `doc/source/dev/faq.rst` entry on rebuilding the configuration schema (it previously omitted the Tool Shed schema) and add a new entry on adding or updating a Python dependency via `pyproject.toml` and `make update-dependencies`. `CONTRIBUTING.md` now points to both FAQ entries.

Fix https://github.com/galaxyproject/galaxy/issues/5483.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
