### PR TITLE
Prevent mapper deferrals from starving later ready jobs

### DIFF
--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -57,3 +57,6 @@ jobs:
       - name: Run test migrate database
         run: ./run_tests.sh -unit test/unit/app/test_migrate_database.py
         working-directory: 'galaxy root'
+      - name: Run job handler ready window tests
+        run: ./run_tests.sh -unit test/unit/app/jobs/test_handler.py
+        working-directory: 'galaxy root'

--- a/doc/source/admin/jobs.md
+++ b/doc/source/admin/jobs.md
@@ -48,6 +48,31 @@ id
 tags
 : A comma-separated set of strings that optional define tags to which this handler belongs.
 
+#### Ready window size
+
+The ready window limits how many pending jobs each handler checks per user on each pass. It defaults to 100 and can be configured in `job_conf.yml`:
+
+```yaml
+handling:
+  ready_window_size: 100
+```
+
+The equivalent XML setting is the `ready_window_size` attribute on `<handlers>`:
+
+```xml
+<handlers ready_window_size="100">
+    <!-- Existing handler definitions go here. -->
+</handlers>
+```
+
+This setting limits the work spent checking pending jobs; concurrency limits separately control how many jobs may run. A smaller window can improve responsiveness for other users when one user has a large backlog. Each anonymous session has its own window, while authenticated sessions share their user's window. This setting does not apply to SQLite or in-memory job queues.
+
+When a dynamic destination rule defers a job, the handler continues checking later jobs for that user over subsequent passes. For example, with a window of two, five deferred jobs followed by a sixth runnable job are checked in three passes: jobs 1–2, then 3–4, then 5–6. The sixth job can run without waiting for the first five to become runnable, provided it meets the usual input and concurrency requirements.
+
+The handler then returns to the beginning to retry deferred jobs. This means an earlier job may wait for the handler to finish checking the existing backlog before it is checked again, even if its resources become available sooner. A smaller window can increase this delay. Jobs arriving during this traversal are considered on the next traversal, so new submissions cannot indefinitely postpone retries.
+
+For administrators writing dynamic destination rules, this behavior is triggered by `JobNotReadyException` when it leaves the job waiting; deferred jobs remain in the `new` state. Ordinary concurrency waits alone do not start a traversal, but an existing traversal continues through them. Progress is local to each handler and resets when the handler restarts.
+
 ### Job Destinations
 
 The `<destinations>` collection defines the parameters that should be used to run a job that is sent to the specified destination. This configuration element should define a ``default``

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -313,6 +313,8 @@ process uses each final `server_name` on a given hostname, regardless of the con
 
 ### Job and Workflow Handling
 
+To tune how many pending jobs each handler checks per user, see [Ready window size](jobs.md#ready-window-size), including the tradeoff between responsiveness for other users and retry delays for deferred jobs.
+
 ```{warning}
 In all strategies, once a handler has been assigned jobs, you cannot unconfigure that handler (e.g. to decrease the
 number of handlers) until it has finished processing all its assigned jobs, or else its jobs will never reach a

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -399,17 +399,12 @@ handling:
   # db-transaction-isolation) and the value is an integer > 0. Default is to grab as many jobs ready to run as possible.
   #max_grab: 8
 
-  # Handlers query for and dispatch jobs ready to run in a loop. If the number of jobs in the `new` state grows very
-  # large but they cannot be dispatched due to user concurrency limits, checking all of these jobs on every iteration
-  # can drastically slow down job throughput as each pending job is checked and then deferred due to limits. This option
-  # limits the number of jobs per user returned by the query on each iteration. By default it is set to 100. Setting
-  # this lower can improve throughput for other users when one user submits thousands of independent jobs.
+  # Limits the number of pending jobs each handler checks per user on each pass. Defaults to 100. Lower values can
+  # improve responsiveness for other users when one user has a large backlog, but may increase the time before deferred
+  # jobs are checked again. Anonymous sessions each have their own limit. This setting does not apply to SQLite or
+  # in-memory job queues.
   #
-  # Anonymous sessions have separate windows. This limit does not apply to SQLite or in-memory job queues.
-  # If a destination mapper raises JobNotReadyException to wait for resources, the handler advances through that user's
-  # input-ready jobs in windows of this size, then retries from the beginning. Jobs arriving during a sweep are considered
-  # on the next sweep so they cannot indefinitely delay retries. Ordinary concurrency waits alone do not start a sweep.
-  # Sweep progress is local to each handler and resets on restart; deferred jobs remain in the `new` state.
+  # See https://docs.galaxyproject.org/en/latest/admin/jobs.html#ready-window-size for details.
   #ready_window_size: 100
 
   # An ID or tag of the handler(s) that should handle any jobs not assigned to a specific handler (which is probably

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -402,10 +402,14 @@ handling:
   # Handlers query for and dispatch jobs ready to run in a loop. If the number of jobs in the `new` state grows very
   # large but they cannot be dispatched due to user concurrency limits, checking all of these jobs on every iteration
   # can drastically slow down job throughput as each pending job is checked and then deferred due to limits. This option
-  # limits the number of jobs per user are returned by the query on each iteration. By default it is set to 100. Setting
+  # limits the number of jobs per user returned by the query on each iteration. By default it is set to 100. Setting
   # this lower can improve throughput for other users when one user submits thousands of independent jobs.
   #
-  # Be aware that anonymous users are treated as a single user by this algorithm.
+  # Anonymous sessions have separate windows. This limit does not apply to SQLite or in-memory job queues.
+  # If a destination mapper raises JobNotReadyException to wait for resources, the handler advances through that user's
+  # input-ready jobs in windows of this size, then retries from the beginning. Jobs arriving during a sweep are considered
+  # on the next sweep so they cannot indefinitely delay retries. Ordinary concurrency waits alone do not start a sweep.
+  # Sweep progress is local to each handler and resets on restart; deferred jobs remain in the `new` state.
   #ready_window_size: 100
 
   # An ID or tag of the handler(s) that should handle any jobs not assigned to a specific handler (which is probably

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -428,19 +428,12 @@
                  (db-skip-locked, db-transaction-isolation) and the value is an integer > 0. Default is to grab as many
                  jobs ready to run as possible.
 
-               - `ready_window_size` - Handlers query for and dispatch jobs ready to run in a loop. If the number of
-                 jobs in the `new` state grows very large but they cannot be dispatched due to user concurrency limits,
-                 checking all of these jobs on every iteration can drastically slow down job throughput as each pending
-                 job is checked and then deferred due to limits. This option limits the number of jobs per user
-                 returned by the query on each iteration. By default it is set to 100. Setting this lower can improve
-                 throughput for other users when one user submits thousands of independent jobs.
+               - `ready_window_size` - Limits the number of pending jobs each handler checks per user on each pass.
+                 Defaults to 100. Lower values can improve responsiveness for other users when one user has a large
+                 backlog, but may increase the time before deferred jobs are checked again. Anonymous sessions each
+                 have their own limit. This setting does not apply to SQLite or in-memory job queues.
 
-                 Anonymous sessions have separate windows. This limit does not apply to SQLite or in-memory job queues.
-                 If a destination mapper raises JobNotReadyException to wait for resources, the handler advances through
-                 that user's input-ready jobs in windows of this size, then retries from the beginning. Jobs arriving
-                 during a sweep are considered on the next sweep so they cannot indefinitely delay retries. Ordinary
-                 concurrency waits alone do not start a sweep. Sweep progress is local to each handler and resets on
-                 restart; deferred jobs remain in the `new` state.
+                 See https://docs.galaxyproject.org/en/latest/admin/jobs.html#ready-window-size for details.
 
                - `default` - An ID or tag of the handler(s) that should handle any jobs not assigned to a specific
                  handler (which is probably most of them). If unset, the default is any untagged handlers plus any

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -431,11 +431,16 @@
                - `ready_window_size` - Handlers query for and dispatch jobs ready to run in a loop. If the number of
                  jobs in the `new` state grows very large but they cannot be dispatched due to user concurrency limits,
                  checking all of these jobs on every iteration can drastically slow down job throughput as each pending
-                 job is checked and then deferred due to limits. This option limits the number of jobs per user are
+                 job is checked and then deferred due to limits. This option limits the number of jobs per user
                  returned by the query on each iteration. By default it is set to 100. Setting this lower can improve
                  throughput for other users when one user submits thousands of independent jobs.
 
-                 Be aware that anonymous users are treated as a single user by this algorithm.
+                 Anonymous sessions have separate windows. This limit does not apply to SQLite or in-memory job queues.
+                 If a destination mapper raises JobNotReadyException to wait for resources, the handler advances through
+                 that user's input-ready jobs in windows of this size, then retries from the beginning. Jobs arriving
+                 during a sweep are considered on the next sweep so they cannot indefinitely delay retries. Ordinary
+                 concurrency waits alone do not start a sweep. Sweep progress is local to each handler and resets on
+                 restart; deferred jobs remain in the `new` state.
 
                - `default` - An ID or tag of the handler(s) that should handle any jobs not assigned to a specific
                  handler (which is probably most of them). If unset, the default is any untagged handlers plus any

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -19,6 +19,7 @@ from typing import (
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.sql.expression import (
     and_,
+    case,
     func,
     not_,
     null,
@@ -74,6 +75,8 @@ log = get_logger(__name__)
     "user_over_total_walltime",
 )
 DEFAULT_JOB_RUNNER_FAILURE_MESSAGE = "Unable to run job due to a misconfiguration of the Galaxy job running system.  Please contact a site administrator."
+
+ReadyJobPartition = tuple[int | None, int | None]
 
 
 class JobHandlerI:
@@ -268,6 +271,10 @@ class JobHandlerQueue(BaseJobHandlerQueue):
         self.waiting_jobs: list[int] = []
         # Contains wrappers of jobs that are limited or ready (so they aren't created unnecessarily/multiple times)
         self.job_wrappers: dict[int, JobWrapper] = {}
+        # A mapper deferral starts a bounded sweep of that user's ready jobs.
+        # Retain only (last selected id, sweep end id), never the deferred backlog.
+        self._ready_job_cursors: dict[ReadyJobPartition, tuple[int, int]] = {}
+        self._mapper_waiting_partitions: set[ReadyJobPartition] = set()
         name = "JobHandlerQueue.monitor_thread"
         self._init_monitor_thread(name, target=self.__monitor, config=app.config)
         self.job_grabber = None
@@ -440,70 +447,12 @@ class JobHandlerQueue(BaseJobHandlerQueue):
         # Pull all new jobs from the queue at once
         jobs_to_check: list[model.Job] = []
         resubmit_jobs = []
+        next_ready_job_cursors: dict[ReadyJobPartition, tuple[int, int]] = {}
+        self._mapper_waiting_partitions.clear()
         if self.track_jobs_in_database:
             # Clear the session so we get fresh states for job and all datasets
             self.sa_session.expunge_all()
-            # Fetch all new jobs
-            hda_not_ready = (
-                self.sa_session.query(model.Job.id)
-                .enable_eagerloads(False)
-                .join(model.JobToInputDatasetAssociation)
-                .join(model.HistoryDatasetAssociation)
-                .join(model.Dataset)
-                .filter(
-                    and_(
-                        model.Job.state == model.Job.states.NEW, model.Dataset.state.in_(model.Dataset.non_ready_states)
-                    )
-                )
-                .subquery()
-            )
-            ldda_not_ready = (
-                self.sa_session.query(model.Job.id)
-                .enable_eagerloads(False)
-                .join(model.JobToInputLibraryDatasetAssociation)
-                .join(model.LibraryDatasetDatasetAssociation)
-                .join(model.Dataset)
-                .filter(
-                    and_(
-                        model.Job.state == model.Job.states.NEW, model.Dataset.state.in_(model.Dataset.non_ready_states)
-                    )
-                )
-                .subquery()
-            )
-            coalesce_exp = func.coalesce(
-                model.Job.table.c.user_id, model.Job.table.c.session_id
-            )  # accommodate jobs by anonymous users
-            rank = func.rank().over(partition_by=coalesce_exp, order_by=model.Job.table.c.id).label("rank")
-            job_filter_conditions: tuple[ColumnExpressionArgument[bool], ...] = (
-                (model.Job.state == model.Job.states.NEW),
-                (model.Job.handler == self.app.config.server_name),
-                ~model.Job.table.c.id.in_(select(hda_not_ready)),
-                ~model.Job.table.c.id.in_(select(ldda_not_ready)),
-            )
-            if self.app.config.user_activation_on:
-                job_filter_conditions += (or_((model.Job.user_id == null()), (model.User.active == true())),)
-            assert self.sa_session.bind is not None
-            if self.sa_session.bind.dialect.name == "sqlite":
-                query_objects: tuple[_ColumnsClauseArgument, ...] = (model.Job,)
-            else:
-                query_objects = (model.Job, rank)
-            ready_query = (
-                self.sa_session.query(*query_objects)
-                .enable_eagerloads(False)
-                .outerjoin(model.User)
-                .filter(and_(*job_filter_conditions))
-                .order_by(model.Job.id)
-            )
-            if self.sa_session.bind.dialect.name == "sqlite":
-                jobs_to_check = ready_query.all()
-            else:
-                ranked = ready_query.subquery()
-                jobs_to_check = (
-                    self.sa_session.query(model.Job)
-                    .join(ranked, model.Job.id == ranked.c.id)
-                    .filter(ranked.c.rank <= self.app.job_config.handler_ready_window_size)
-                    .all()
-                )
+            jobs_to_check, next_ready_job_cursors = self._select_ready_jobs()
             # Filter jobs with invalid input states
             jobs_to_check = self.__filter_jobs_with_invalid_input_states(jobs_to_check)
             # Fetch all "resubmit" jobs
@@ -608,8 +557,117 @@ class JobHandlerQueue(BaseJobHandlerQueue):
         # Remove cached wrappers for any jobs that are no longer being tracked
         for id in set(self.job_wrappers.keys()) - set(new_waiting_jobs):
             del self.job_wrappers[id]
+        # Finish a started sweep even if its next window only contains ordinary
+        # concurrency waits. Reset at the end (or when no candidates remain) so
+        # deferred jobs are retried, and stale partitions are discarded each poll.
+        self._ready_job_cursors = {
+            partition: (after, end)
+            for partition, (after, end) in next_ready_job_cursors.items()
+            if after < end and (partition in self._ready_job_cursors or partition in self._mapper_waiting_partitions)
+        }
+        self._mapper_waiting_partitions.clear()
         # Commit updated state
         self.sa_session.commit()
+
+    def _select_ready_jobs(self) -> tuple[list[model.Job], dict[ReadyJobPartition, tuple[int, int]]]:
+        """Return this handler's input-ready NEW jobs and each partition's sweep cursor.
+
+        On PostgreSQL each user or anonymous session contributes at most
+        ``ready_window_size`` jobs. An active sweep cursor narrows a partition to
+        the IDs after its last selected job and up to its frozen sweep end.
+        """
+        jobs_to_check: list[model.Job] = []
+        next_ready_job_cursors: dict[ReadyJobPartition, tuple[int, int]] = {}
+        # Fetch all new jobs
+        hda_not_ready = (
+            self.sa_session.query(model.Job.id)
+            .enable_eagerloads(False)
+            .join(model.JobToInputDatasetAssociation)
+            .join(model.HistoryDatasetAssociation)
+            .join(model.Dataset)
+            .filter(
+                and_(model.Job.state == model.Job.states.NEW, model.Dataset.state.in_(model.Dataset.non_ready_states))
+            )
+            .subquery()
+        )
+        ldda_not_ready = (
+            self.sa_session.query(model.Job.id)
+            .enable_eagerloads(False)
+            .join(model.JobToInputLibraryDatasetAssociation)
+            .join(model.LibraryDatasetDatasetAssociation)
+            .join(model.Dataset)
+            .filter(
+                and_(model.Job.state == model.Job.states.NEW, model.Dataset.state.in_(model.Dataset.non_ready_states))
+            )
+            .subquery()
+        )
+        # User and anonymous session IDs have separate namespaces. Authenticated
+        # sessions share their user's window, regardless of the session ID.
+        partition = (
+            model.Job.user_id,
+            case((model.Job.user_id == null(), model.Job.session_id)),
+        )
+        rank = func.rank().over(partition_by=partition, order_by=model.Job.id).label("rank")
+        window_end = func.max(model.Job.id).over(partition_by=partition).label("window_end")
+        job_filter_conditions: tuple[ColumnExpressionArgument[bool], ...] = (
+            (model.Job.state == model.Job.states.NEW),
+            (model.Job.handler == self.app.config.server_name),
+            ~model.Job.table.c.id.in_(select(hda_not_ready)),
+            ~model.Job.table.c.id.in_(select(ldda_not_ready)),
+        )
+        if self.app.config.user_activation_on:
+            job_filter_conditions += (or_((model.Job.user_id == null()), (model.User.active == true())),)
+        if self._ready_job_cursors:
+            # Apply the cursor BEFORE ranking so each user still gets at most
+            # ready_window_size candidates. Freeze the sweep end so arrivals
+            # cannot indefinitely postpone retries of earlier deferred jobs.
+            job_filter_conditions += (
+                case(
+                    *(
+                        (
+                            (
+                                model.Job.user_id == user_id
+                                if user_id is not None
+                                else and_(model.Job.user_id == null(), model.Job.session_id == session_id)
+                            ),
+                            and_(model.Job.id > after, model.Job.id <= end),
+                        )
+                        for (user_id, session_id), (after, end) in self._ready_job_cursors.items()
+                    ),
+                    else_=true(),
+                ),
+            )
+        assert self.sa_session.bind is not None
+        if self.sa_session.bind.dialect.name == "sqlite":
+            query_objects: tuple[_ColumnsClauseArgument, ...] = (model.Job,)
+        else:
+            query_objects = (model.Job, rank, window_end)
+        ready_query = (
+            self.sa_session.query(*query_objects)
+            .enable_eagerloads(False)
+            .outerjoin(model.User)
+            .filter(and_(*job_filter_conditions))
+            .order_by(model.Job.id)
+        )
+        if self.sa_session.bind.dialect.name == "sqlite":
+            jobs_to_check = ready_query.all()
+        else:
+            ranked = ready_query.subquery()
+            candidates = (
+                self.sa_session.query(model.Job, ranked.c.window_end)
+                .join(ranked, model.Job.id == ranked.c.id)
+                .filter(ranked.c.rank <= self.app.job_config.handler_ready_window_size)
+                .order_by(model.Job.id)
+                .all()
+            )
+            for job, end in candidates:
+                jobs_to_check.append(job)
+                next_ready_job_cursors[self._ready_job_partition(job)] = (job.id, end)
+        return jobs_to_check, next_ready_job_cursors
+
+    @staticmethod
+    def _ready_job_partition(job: model.Job) -> ReadyJobPartition:
+        return job.user_id, job.session_id if job.user_id is None else None
 
     def __filter_jobs_with_invalid_input_states(self, jobs):
         """
@@ -749,6 +807,8 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             return JOB_ERROR, job_destination
         except JobNotReadyException as e:
             job_state = e.job_state or JOB_WAIT
+            if self.track_jobs_in_database and job_state == JOB_WAIT:
+                self._mapper_waiting_partitions.add(self._ready_job_partition(job))
             return job_state, None
         except Exception as e:
             failure_message = getattr(e, "failure_message", DEFAULT_JOB_RUNNER_FAILURE_MESSAGE)

--- a/test/unit/app/jobs/test_handler.py
+++ b/test/unit/app/jobs/test_handler.py
@@ -1,0 +1,404 @@
+"""Exercise handler polls against real databases, including PostgreSQL's ready window."""
+
+import math
+import os
+from collections import Counter
+from types import SimpleNamespace
+from typing import (
+    cast,
+    TYPE_CHECKING,
+)
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.engine import make_url
+
+from galaxy import model
+from galaxy.jobs import JobConfigurationLimits
+from galaxy.jobs.handler import (
+    JOB_ERROR,
+    JOB_USER_OVER_TOTAL_WALLTIME,
+    JOB_WAIT,
+    JobHandlerQueue,
+)
+from galaxy.jobs.job_destination import JobDestination
+from galaxy.jobs.mapper import (
+    JobNotReadyException,
+    JobRunnerMapper,
+    STOCK_RULES,
+)
+from galaxy.model.database_utils import DbUrl
+from galaxy.model.unittest_utils import GalaxyDataTestApp
+from galaxy.model.unittest_utils.model_testing_utils import create_and_drop_database
+
+if TYPE_CHECKING:
+    from galaxy.jobs import JobWrapper
+
+WINDOW = 2
+
+
+class HandlerJobWrapper:
+    """Keep destination mapping real; replace runner preparation and output handling."""
+
+    def __init__(self, job, queue, **kwds):
+        self.job_id = job.id
+        self.app = queue.app
+        self.tool = SimpleNamespace(
+            id="handler_test",
+            get_job_destination=lambda params: JobDestination(runner="dynamic", params={"type": "handler_test"}),
+        )
+        self.job_runner_mapper = JobRunnerMapper(cast("JobWrapper", self), Mock(), self.app.job_config)
+
+    def get_job(self):
+        return self.app.model.context.get(model.Job, self.job_id)
+
+    @property
+    def job_destination(self):
+        return self.job_runner_mapper.get_job_destination({})
+
+    def fail(self, message):
+        self.get_job().set_state(model.Job.states.ERROR)
+
+    def pause(self, job, message):
+        job.set_state(model.Job.states.PAUSED)
+
+    def is_ready_for_resubmission(self, job):
+        return True
+
+
+class HandlerHarness:
+    def __init__(self, app, monkeypatch):
+        self.app = app
+        self.attempts = []
+        self.dispatched = []
+        self.deferred = {}
+        self.selected: list[tuple[int | None, int | None]] = []
+        self.destination = JobDestination(id="local", runner="local")
+        app.job_config = SimpleNamespace(
+            limits=JobConfigurationLimits(),
+            handler_assignment_methods=[],
+            handler_ready_window_size=WINDOW,
+            dynamic_params=None,
+            get_destination=lambda id: self.destination,
+        )
+        app.config.track_jobs_in_database = True
+        app.config.cache_user_job_count = True
+        app.config.user_activation_on = False
+        app.config.monitor_thread_join_timeout = 0
+        app.execution_timer_factory = Mock()
+        monkeypatch.setitem(STOCK_RULES, "handler_test", self.map_destination)
+        self.queue = JobHandlerQueue(app, SimpleNamespace(put=self.dispatch, url_to_destination=Mock()))
+        monkeypatch.setattr(self.queue, "job_wrapper", lambda job, **kwds: HandlerJobWrapper(job, self.queue, **kwds))
+        select_ready_jobs = self.queue._select_ready_jobs
+
+        def record_candidates():
+            jobs, cursors = select_ready_jobs()
+            self.selected = [(job.user_id, job.session_id if job.user_id is None else None) for job in jobs]
+            return jobs, cursors
+
+        monkeypatch.setattr(self.queue, "_select_ready_jobs", record_candidates)
+
+    def map_destination(self, job_id):
+        self.attempts.append(job_id)
+        if job_id in self.deferred:
+            raise JobNotReadyException(job_state=self.deferred[job_id])
+        return self.destination
+
+    def dispatch(self, wrapper):
+        self.dispatched.append(wrapper.job_id)
+        job = wrapper.get_job()
+        job.set_state(model.Job.states.QUEUED)
+        job.destination_id = wrapper.job_destination.id
+
+    def user(self):
+        user = model.User(email=f"{uuid4()}@example.org")
+        user.password = "unused"
+        user.active = True
+        self.app.model.context.add(user)
+        self.app.model.context.commit()
+        return user.id
+
+    def session(self, user_id=None):
+        session = model.GalaxySession(user_id=user_id)
+        self.app.model.context.add(session)
+        self.app.model.context.commit()
+        return session.id
+
+    def update_job(self, job_id, **values):
+        job = self.app.model.context.get(model.Job, job_id)
+        for key, value in values.items():
+            setattr(job, key, value)
+        self.app.model.context.commit()
+
+    def job(self, user_id=None, session_id=None, handler="main", state="new", input_state="ok"):
+        session = self.app.model.context
+        dataset = model.Dataset(state=input_state)
+        hda = model.HistoryDatasetAssociation(dataset=dataset)
+        job = model.Job()
+        job.user_id = user_id
+        job.session_id = session_id
+        job.handler = handler
+        job.state = state
+        job.tool_id = "handler_test"
+        job.add_input_dataset("input", hda)
+        session.add_all([dataset, hda, job])
+        session.commit()
+        return job.id
+
+    def poll(self):
+        self.attempts.clear()
+        self.selected.clear()
+        self.queue._JobHandlerQueue__monitor_step()  # type: ignore[attr-defined]
+        if self.queue.track_jobs_in_database and self.app.model.engine.dialect.name == "postgresql":
+            per_partition = Counter(self.selected)
+            assert all(count <= WINDOW for count in per_partition.values()), f"ready window exceeded: {per_partition}"
+            assert len(self.queue.job_wrappers) <= len(self.selected), "wrappers cached for unselected jobs"
+        return self.attempts[:]
+
+
+@pytest.fixture
+def handler(request, tmp_path, monkeypatch):
+    backend = getattr(request, "param", "postgresql")
+    if backend == "postgresql":
+        connection = os.environ.get("GALAXY_TEST_DBURI") or os.environ.get("GALAXY_TEST_CONNECT_POSTGRES_URI")
+        if not connection or make_url(connection).get_backend_name() != "postgresql":
+            pytest.skip("Set GALAXY_TEST_DBURI to a PostgreSQL URL to exercise the production ranked query")
+        url = make_url(connection).set(database=f"galaxytest_handler_{uuid4().hex}")
+        connection = url.render_as_string(hide_password=False)
+    else:
+        connection = f"sqlite:///{tmp_path / 'handler.sqlite'}"
+    with create_and_drop_database(DbUrl(connection)):
+        app = GalaxyDataTestApp(root=str(tmp_path), database_connection=connection)
+        assert app.model.engine.dialect.name == backend
+        try:
+            yield HandlerHarness(app, monkeypatch)
+        finally:
+            app.model.context.remove()
+            app.model.engine.dispose()
+
+
+@pytest.mark.parametrize("backlog", [5, 21])
+def test_mapper_deferral_does_not_starve_later_jobs(handler, backlog):
+    user = handler.user()
+    deferred = [handler.job(user) for _ in range(backlog)]
+    handler.deferred.update(dict.fromkeys(deferred))
+    ready = handler.job(user)
+    other_user_job = handler.job(handler.user())
+
+    for poll in range(math.ceil(backlog / WINDOW) + 1):
+        attempts = handler.poll()
+        assert len(set(attempts) - {other_user_job}) <= WINDOW
+        if poll == 0:
+            assert attempts[:WINDOW] == deferred[:WINDOW]
+            assert other_user_job in handler.dispatched
+    assert ready in handler.dispatched
+    assert not set(deferred).intersection(handler.dispatched)
+
+    handler.deferred.clear()
+    for _ in range(backlog + 2):
+        handler.poll()
+    assert Counter(handler.dispatched) == Counter([*deferred, ready, other_user_job])
+
+
+def test_new_arrivals_do_not_postpone_retry(handler):
+    user = handler.user()
+    original = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(original))
+    assert handler.poll() == original[:WINDOW]
+    handler.deferred.clear()
+    # Grow the tail faster than it can be drained. The original sweep must end
+    # and retry the prefix anyway, without dispatching any job twice.
+    for _ in range(3):
+        for _ in range(3):
+            job = handler.job(user)
+            handler.deferred[job] = None
+        assert len(handler.poll()) <= WINDOW
+    assert Counter(handler.dispatched) == Counter(original)
+
+
+@pytest.mark.parametrize("change", ["deleted", "error", "ok", "move", "remove", "inactive", "input"])
+def test_sweep_cleans_up_unavailable_jobs(handler, change):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs))
+    handler.poll()
+    assert len(handler.queue._ready_job_cursors) == 1
+    session = handler.app.model.context
+    for job_id in jobs:
+        job = session.get(model.Job, job_id)
+        if change == "move":
+            job.handler = "other_handler"
+        elif change == "remove":
+            session.delete(job)
+        elif change == "inactive":
+            handler.app.config.user_activation_on = True
+            job.user.active = False
+        elif change == "input":
+            job.input_datasets[0].dataset.dataset.state = model.Dataset.states.NEW
+        else:
+            job.state = change
+    session.commit()
+    assert handler.poll() == []
+    assert handler.queue._ready_job_cursors == {}
+    assert handler.queue._mapper_waiting_partitions == set()
+    assert handler.queue.job_wrappers == {}
+    assert handler.dispatched == []
+
+
+def test_cancelling_sweep_tail_restarts_at_prefix(handler):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs))
+    handler.poll()
+    handler.deferred.clear()
+    for job in jobs[WINDOW:]:
+        handler.update_job(job, state=model.Job.states.DELETED)
+    assert handler.poll() == []
+    assert handler.poll() == jobs[:WINDOW]
+    assert handler.dispatched == jobs[:WINDOW]
+
+
+def test_anonymous_sessions_have_independent_windows(handler):
+    user = handler.user()
+    anonymous = handler.session()
+    assert anonymous == user  # Separate database sequences deliberately overlap.
+    other_anonymous = handler.session()
+    signed_in_sessions = [handler.session(user) for _ in range(2)]
+    user_jobs = [handler.job(user, signed_in_sessions[i % 2]) for i in range(6)]
+    anonymous_jobs = [handler.job(session_id=anonymous) for _ in range(6)]
+    other_jobs = [handler.job(session_id=other_anonymous) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys([*user_jobs, *anonymous_jobs]))
+    for i in range(3):
+        attempts = handler.poll()
+        window = slice(WINDOW * i, WINDOW * (i + 1))
+        assert attempts == user_jobs[window] + anonymous_jobs[window] + other_jobs[window]
+    assert handler.dispatched == other_jobs
+
+
+@pytest.mark.parametrize("limit", ["destination", "user"])
+def test_ordinary_limits_keep_front_window_and_cached_destinations(handler, limit):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(4)]
+    limits = handler.app.job_config.limits
+    if limit == "destination":
+        limits.destination_total_concurrent_jobs["local"] = 0
+    else:
+        handler.job(user, state="running")
+        limits.registered_user_concurrent_jobs = 1
+    assert handler.poll() == jobs[:WINDOW]
+    assert handler.poll() == []  # Successful mappings are cached during ordinary waits.
+    assert handler.queue._ready_job_cursors == {}
+    assert handler.dispatched == []
+    limits.destination_total_concurrent_jobs.clear()
+    limits.registered_user_concurrent_jobs = None
+    handler.poll()
+    assert handler.dispatched == jobs[:WINDOW]
+    handler.poll()
+    assert handler.dispatched == jobs
+
+
+def test_sweep_advances_through_ordinary_waits(handler):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs[:WINDOW]))
+    handler.app.job_config.limits.destination_total_concurrent_jobs["local"] = 0
+    assert handler.poll() == jobs[:WINDOW]
+    assert handler.poll() == jobs[WINDOW : 2 * WINDOW]
+    handler.app.job_config.limits.destination_total_concurrent_jobs.clear()
+    assert handler.poll() == jobs[2 * WINDOW :]
+    assert handler.dispatched == jobs[2 * WINDOW :]
+
+
+@pytest.mark.parametrize(
+    "state,expected", [(None, JOB_WAIT), (JOB_WAIT, JOB_WAIT), (JOB_ERROR, JOB_ERROR), ("custom", "custom")]
+)
+def test_exception_state_is_preserved(handler, state, expected):
+    job_id = handler.job(handler.user())
+    handler.deferred[job_id] = state
+    job = handler.app.model.context.get(model.Job, job_id)
+    wrapper = handler.queue.job_wrapper(job)
+    assert handler.queue._JobHandlerQueue__verify_job_ready(job, wrapper) == (expected, None)
+    assert bool(handler.queue._mapper_waiting_partitions) == (expected == JOB_WAIT)
+
+
+def test_nondefault_exception_state_uses_existing_poll_handling(handler):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(3)]
+    handler.deferred.update(dict.fromkeys(jobs[:WINDOW], JOB_USER_OVER_TOTAL_WALLTIME))
+    handler.poll()
+    session = handler.app.model.context
+    assert [session.get(model.Job, job).state for job in jobs] == ["paused", "paused", "new"]
+    assert handler.queue._ready_job_cursors == {}
+    handler.poll()
+    assert handler.dispatched == jobs[WINDOW:]
+
+
+def test_input_validity_activation_and_handler_ownership(handler):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs[:WINDOW]))
+    foreign = handler.job(user, handler="other_handler")
+    unready = handler.job(user, input_state="new")
+    invalid = handler.job(user, input_state="error")
+    inactive_user = handler.user()
+    inactive = handler.job(inactive_user)
+    handler.app.model.context.get(model.User, inactive_user).active = False
+    handler.app.model.context.commit()
+    handler.app.config.user_activation_on = True
+    for _ in range(5):
+        handler.poll()
+    assert handler.dispatched == jobs[WINDOW:]
+    session = handler.app.model.context
+    assert session.get(model.Job, invalid).state == "paused"
+    assert [session.get(model.Job, job).state for job in (foreign, unready, inactive)] == ["new"] * 3
+
+
+def test_resubmitted_jobs_bypass_ready_window(handler):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs))
+    handler.poll()
+    resubmit = handler.job(user, state="resubmitted")
+    handler.update_job(resubmit, destination_id="local", job_runner_name="local")
+    handler.poll()
+    assert handler.dispatched == [resubmit]
+
+
+def test_restart_retries_prefix_and_handler_transfer_starts_fresh(handler, monkeypatch):
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs[: 2 * WINDOW]))
+    handler.poll()
+    restarted = HandlerHarness(handler.app, monkeypatch)
+    restarted.deferred.update(handler.deferred)
+    assert restarted.poll() == jobs[:WINDOW]
+    for job in jobs:
+        restarted.update_job(job, handler="other_handler")
+    assert restarted.poll() == []
+    assert restarted.queue._ready_job_cursors == {}
+    other = HandlerHarness(handler.app, monkeypatch)
+    other.app.config.server_name = "other_handler"
+    other.deferred.update(handler.deferred)
+    assert other.poll() == jobs[:WINDOW]
+    assert other.poll() == jobs[WINDOW : 2 * WINDOW]
+    assert other.poll() == jobs[2 * WINDOW :]
+    assert other.dispatched == jobs[2 * WINDOW :]
+
+
+@pytest.mark.parametrize("handler", ["sqlite"], indirect=True)
+@pytest.mark.parametrize("database_queue", [True, False])
+def test_unwindowed_queues_still_retry_deferred_jobs(handler, database_queue):
+    handler.queue.track_jobs_in_database = database_queue
+    user = handler.user()
+    jobs = [handler.job(user) for _ in range(6)]
+    handler.deferred.update(dict.fromkeys(jobs[:5]))
+    if not database_queue:
+        for job in jobs:
+            handler.queue.put(job, "handler_test")
+    assert handler.poll() == jobs
+    assert handler.dispatched == jobs[5:]
+    handler.deferred.clear()
+    assert handler.poll() == jobs[:5]
+    assert Counter(handler.dispatched) == Counter(jobs)
+    assert handler.queue._ready_job_cursors == {}


### PR DESCRIPTION
`JobNotReadyException` normally leaves a job `NEW`. With PostgreSQL's per-user ready window, a deferred prefix can therefore be selected on every poll while later runnable jobs for the same user are never examined. For example, a window of 2 and five deferred jobs permanently hide a sixth job that could run.

After a mapper wait, advance through that user's input-ready jobs at the configured window size, then retry from the beginning. A bounded sweep endpoint prevents new arrivals from indefinitely delaying retries. This retains two IDs per active user/session, clears stale sweeps each poll, and separates anonymous session IDs from user IDs. Ordinary concurrency waits alone do not start a sweep; explicit exception states, resubmission, and SQLite/in-memory queues keep their existing handling. The tradeoff is that an earlier deferred job waits for the finite sweep to finish before being retried.

The regression executes real PostgreSQL handler polls and dynamic mapping. Add it to PostgreSQL CI because SQLite bypasses the ranked query. No schema migration, new persistent job state, or mapper-specific dependency is needed.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

Both starvation cases (window 2, deferred backlogs 5 and 21) fail against the unchanged base and pass with the fix. Locally, 96 handler/mapper/wrapper/queue/configuration tests passed; the 25 handler cases also passed using `GALAXY_TEST_DBURI`. Coverage includes bounded candidate selection, retries under continuous arrivals, cancellation/cleanup, user/session fairness, input validity, activation, handler transfer/restart, ordinary limits and cached destinations, explicit exception states, and resubmission.

`tox -e lint,format,mypy` passes in the repository's pinned environments, including type checking all 2,374 source files.

```sh
GALAXY_TEST_DBURI=postgresql+psycopg:///postgres pytest test/unit/app/jobs/test_handler.py
tox -e lint,format,mypy
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
