### PR TITLE
Set Galaxy memory variables in GB and support memory overhead

### DIFF
--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -736,6 +736,30 @@ execution:
         # clusters. These don't need to be available on the Galaxy server
         # itself.
 
+    # Under most runners, Galaxy will set the `$GALAXY_SLOTS` environment variable in the
+    # tool execution environment to the number of cores allocated to the job by the
+    # scheduler. Tools can use this to control how many threads or processes they start.
+    #
+    # Under some runners, most notably Slurm and SGE, Galaxy will set environment
+    # variables related to the amount of memory allocated to the job by the scheduler, if
+    # possible. These are `$GALAXY_MEMORY_MB`, `$GALAXY_MEMORY_GB`,
+    # `$GALAXY_MEMORY_MB_PER_SLOT`, and `$GALAXY_MEMORY_GB_PER_SLOT`. You can override
+    # these on a per-environment basis as shown below.
+    #
+    # Additionally, you can specify two variables that will indicate a tool should use
+    # less memory than allocated. Typically some overhead is required or else the Linux
+    # OOM Killer will simply kill the job's processes if they exceed they amount of memory
+    # allocated by the scheduler.
+    job_vars_example:
+      runner: drmaa
+      env:
+        # Sets `$GALAXY_MEMORY_MB` to 2GB less than what has been allocated
+        - name: GALAXY_MEMORY_MB_OVERHEAD
+          value: "2048"
+        # Floor value for `$GALAXY_MEMORY_MB` if (allocated - overhead < floor)
+        - name: GALAXY_MEMORY_MB_FLOOR
+          value: "1024"
+
     # Following three environments demonstrate setting up per-job temp directory handling.
     # In these cases TEMP, TMP, and TMPDIR will be set for each job dispatched to these
     # environments.

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -743,12 +743,13 @@ execution:
     # Under some runners, most notably Slurm and SGE, Galaxy will set environment
     # variables related to the amount of memory allocated to the job by the scheduler, if
     # possible. These are `$GALAXY_MEMORY_MB`, `$GALAXY_MEMORY_GB`,
-    # `$GALAXY_MEMORY_MB_PER_SLOT`, and `$GALAXY_MEMORY_GB_PER_SLOT`. You can override
-    # these on a per-environment basis as shown below.
+    # `$GALAXY_MEMORY_MB_PER_SLOT`, and `$GALAXY_MEMORY_GB_PER_SLOT`. Derived GB
+    # variables are rounded down and are left unset when the corresponding allocation
+    # is less than 1 GB. You can override these on a per-environment basis as shown below.
     #
     # Additionally, you can specify two variables that will indicate a tool should use
     # less memory than allocated. Typically some overhead is required or else the Linux
-    # OOM Killer will simply kill the job's processes if they exceed they amount of memory
+    # OOM Killer will simply kill the job's processes if they exceed the amount of memory
     # allocated by the scheduler.
     job_vars_example:
       runner: drmaa
@@ -756,7 +757,8 @@ execution:
         # Sets `$GALAXY_MEMORY_MB` to 2GB less than what has been allocated
         - name: GALAXY_MEMORY_MB_OVERHEAD
           value: "2048"
-        # Floor value for `$GALAXY_MEMORY_MB` if (allocated - overhead < floor)
+        # Floor value for `$GALAXY_MEMORY_MB` if (allocated - overhead < floor).
+        # This defaults to 256 when an overhead is configured.
         - name: GALAXY_MEMORY_MB_FLOOR
           value: "1024"
 

--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
@@ -5,10 +5,27 @@ if [ -n "$SGE_HGR_h_vmem" ]; then
     GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
 fi
 
+if [ -n "$GALAXY_MEMORY_MB" -a -n "${GALAXY_MEMORY_MB_OVERHEAD:-}" ]; then
+    GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB - GALAXY_MEMORY_MB_OVERHEAD))
+    [ "$GALAXY_MEMORY_MB" -gt "${GALAXY_MEMORY_MB_FLOOR:=256}" ] || GALAXY_MEMORY_MB=$GALAXY_MEMORY_MB_FLOOR
+fi
+
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then
     GALAXY_MEMORY_MB_PER_SLOT=$(($GALAXY_MEMORY_MB / $GALAXY_SLOTS))
 elif [ -z "$GALAXY_MEMORY_MB" -a -n "$GALAXY_MEMORY_MB_PER_SLOT" ]; then
     GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB_PER_SLOT * $GALAXY_SLOTS))
 fi
+
+if [ -n "$GALAXY_MEMORY_MB" -a -z "$GALAXY_MEMORY_GB" ]; then
+    GALAXY_MEMORY_GB=$(($GALAXY_MEMORY_MB / 1024))
+    [ "$GALAXY_MEMORY_GB" -gt 0 ] || GALAXY_MEMORY_GB=1
+fi
+if [ -n "$GALAXY_MEMORY_GB" -a -z "$GALAXY_MEMORY_GB_PER_SLOT" ]; then
+    GALAXY_MEMORY_GB_PER_SLOT=$(($GALAXY_MEMORY_GB / $GALAXY_SLOTS))
+    [ "$GALAXY_MEMORY_GB_PER_SLOT" -gt 0 ] || GALAXY_MEMORY_GB_PER_SLOT=1
+fi
+
 [ "${GALAXY_MEMORY_MB--1}" -gt 0 ] 2>>$metadata_directory/memory_statement.log && export GALAXY_MEMORY_MB || unset GALAXY_MEMORY_MB
 [ "${GALAXY_MEMORY_MB_PER_SLOT--1}" -gt 0 ] 2>>$metadata_directory/memory_statement.log && export GALAXY_MEMORY_MB_PER_SLOT || unset GALAXY_MEMORY_MB_PER_SLOT
+[ "${GALAXY_MEMORY_GB--1}" -gt 0 ] 2>>$metadata_directory/memory_statement.log && export GALAXY_MEMORY_GB || unset GALAXY_MEMORY_GB
+[ "${GALAXY_MEMORY_GB_PER_SLOT--1}" -gt 0 ] 2>>$metadata_directory/memory_statement.log && export GALAXY_MEMORY_GB_PER_SLOT || unset GALAXY_MEMORY_GB_PER_SLOT

--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
@@ -5,24 +5,29 @@ if [ -n "$SGE_HGR_h_vmem" ]; then
     GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
 fi
 
-if [ -n "$GALAXY_MEMORY_MB" -a -n "${GALAXY_MEMORY_MB_OVERHEAD:-}" ]; then
-    GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB - GALAXY_MEMORY_MB_OVERHEAD))
-    [ "$GALAXY_MEMORY_MB" -gt "${GALAXY_MEMORY_MB_FLOOR:=256}" ] || GALAXY_MEMORY_MB=$GALAXY_MEMORY_MB_FLOOR
-fi
-
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then
     GALAXY_MEMORY_MB_PER_SLOT=$(($GALAXY_MEMORY_MB / $GALAXY_SLOTS))
 elif [ -z "$GALAXY_MEMORY_MB" -a -n "$GALAXY_MEMORY_MB_PER_SLOT" ]; then
     GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB_PER_SLOT * $GALAXY_SLOTS))
 fi
 
+# Normalize total and per-slot memory first so the overhead also applies when a
+# runner, such as SGE, initially provides only per-slot memory.
+if [ -n "$GALAXY_MEMORY_MB" -a -n "${GALAXY_MEMORY_MB_OVERHEAD:-}" ]; then
+    GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB - GALAXY_MEMORY_MB_OVERHEAD))
+    if [ "$GALAXY_MEMORY_MB" -le "${GALAXY_MEMORY_MB_FLOOR:-256}" ]; then
+        GALAXY_MEMORY_MB=${GALAXY_MEMORY_MB_FLOOR:-256}
+    fi
+    GALAXY_MEMORY_MB_PER_SLOT=$(($GALAXY_MEMORY_MB / $GALAXY_SLOTS))
+fi
+
 if [ -n "$GALAXY_MEMORY_MB" -a -z "$GALAXY_MEMORY_GB" ]; then
     GALAXY_MEMORY_GB=$(($GALAXY_MEMORY_MB / 1024))
-    [ "$GALAXY_MEMORY_GB" -gt 0 ] || GALAXY_MEMORY_GB=1
 fi
-if [ -n "$GALAXY_MEMORY_GB" -a -z "$GALAXY_MEMORY_GB_PER_SLOT" ]; then
+if [ -n "$GALAXY_MEMORY_MB_PER_SLOT" -a -z "$GALAXY_MEMORY_GB_PER_SLOT" ]; then
+    GALAXY_MEMORY_GB_PER_SLOT=$(($GALAXY_MEMORY_MB_PER_SLOT / 1024))
+elif [ -n "$GALAXY_MEMORY_GB" -a -z "$GALAXY_MEMORY_GB_PER_SLOT" ]; then
     GALAXY_MEMORY_GB_PER_SLOT=$(($GALAXY_MEMORY_GB / $GALAXY_SLOTS))
-    [ "$GALAXY_MEMORY_GB_PER_SLOT" -gt 0 ] || GALAXY_MEMORY_GB_PER_SLOT=1
 fi
 
 [ "${GALAXY_MEMORY_MB--1}" -gt 0 ] 2>>$metadata_directory/memory_statement.log && export GALAXY_MEMORY_MB || unset GALAXY_MEMORY_MB

--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2004,SC2006,SC2015,SC2086,SC2154,SC2166
+
 if [ -z "$GALAXY_MEMORY_MB" -a -n "$SLURM_JOB_ID" ]; then
     GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>$metadata_directory/memory_statement.log
 fi
@@ -14,9 +16,12 @@ fi
 # Normalize total and per-slot memory first so the overhead also applies when a
 # runner, such as SGE, initially provides only per-slot memory.
 if [ -n "$GALAXY_MEMORY_MB" -a -n "${GALAXY_MEMORY_MB_OVERHEAD:-}" ]; then
-    GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB - GALAXY_MEMORY_MB_OVERHEAD))
-    if [ "$GALAXY_MEMORY_MB" -le "${GALAXY_MEMORY_MB_FLOOR:-256}" ]; then
-        GALAXY_MEMORY_MB=${GALAXY_MEMORY_MB_FLOOR:-256}
+    # Never let the floor increase the memory advertised by the scheduler.
+    if [ "$GALAXY_MEMORY_MB" -gt "${GALAXY_MEMORY_MB_FLOOR:-256}" ]; then
+        GALAXY_MEMORY_MB=$(($GALAXY_MEMORY_MB - GALAXY_MEMORY_MB_OVERHEAD))
+        if [ "$GALAXY_MEMORY_MB" -le "${GALAXY_MEMORY_MB_FLOOR:-256}" ]; then
+            GALAXY_MEMORY_MB=${GALAXY_MEMORY_MB_FLOOR:-256}
+        fi
     fi
     GALAXY_MEMORY_MB_PER_SLOT=$(($GALAXY_MEMORY_MB / $GALAXY_SLOTS))
 fi

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -64,7 +64,13 @@ class ToolInfo:
         profile: float = -1,
     ):
         if env_pass_through is None:
-            env_pass_through = ["GALAXY_SLOTS", "GALAXY_MEMORY_MB", "GALAXY_MEMORY_MB_PER_SLOT"]
+            env_pass_through = [
+                "GALAXY_SLOTS",
+                "GALAXY_MEMORY_MB",
+                "GALAXY_MEMORY_MB_PER_SLOT",
+                "GALAXY_MEMORY_GB",
+                "GALAXY_MEMORY_GB_PER_SLOT",
+            ]
         if container_descriptions is None:
             container_descriptions = []
         if requirements is None:

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -268,6 +268,8 @@ class ToolSource(metaclass=ABCMeta):
             "GALAXY_SLOTS",
             "GALAXY_MEMORY_MB",
             "GALAXY_MEMORY_MB_PER_SLOT",
+            "GALAXY_MEMORY_GB",
+            "GALAXY_MEMORY_GB_PER_SLOT",
             "HOME",
             "_GALAXY_JOB_HOME_DIR",
             "_GALAXY_JOB_TMP_DIR",

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4914,6 +4914,8 @@ Name | Description
 ``\${GALAXY_SLOTS:-4}`` | Number of cores/threads allocated by the job runner or resource manager to the tool for the given job (here 4 is the default number of threads to use if running via custom runner that does not configure GALAXY_SLOTS or in an older Galaxy runtime).
 ``\$GALAXY_MEMORY_MB`` | Total amount of memory in megabytes (1024^2 bytes) allocated by the administrator (via the resource manager) to the tool for the given job. If unset, tools should not attempt to limit memory usage.
 ``\$GALAXY_MEMORY_MB_PER_SLOT`` | Amount of memory per slot in megabytes (1024^2 bytes) allocated by the administrator (via the resource manager) to the tool for the given job. If unset, tools should not attempt to limit memory usage.
+``\$GALAXY_MEMORY_GB`` | Total amount of memory in whole gigabytes (1024^3 bytes) derived from ``\$GALAXY_MEMORY_MB``. If the derived value is less than one, this variable is unset.
+``\$GALAXY_MEMORY_GB_PER_SLOT`` | Amount of memory per slot in whole gigabytes (1024^3 bytes) derived from ``\$GALAXY_MEMORY_MB_PER_SLOT``. If the derived value is less than one, this variable is unset.
 ``\$_GALAXY_JOB_TMP_DIR`` | Path to an empty directory in the job's working directory that can be used as a temporary directory.
 
 See the [Planemo docs](https://planemo.readthedocs.io/en/latest/writing_advanced.html#cluster-usage)

--- a/test/unit/app/jobs/test_job_script.py
+++ b/test/unit/app/jobs/test_job_script.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+
+from galaxy.jobs.runners.util.job_script import MEMORY_STATEMENT_DEFAULT_TEMPLATE
+from galaxy.tool_util.deps.dependencies import ToolInfo
+
+MEMORY_VARIABLES = (
+    "GALAXY_MEMORY_MB",
+    "GALAXY_MEMORY_MB_PER_SLOT",
+    "GALAXY_MEMORY_GB",
+    "GALAXY_MEMORY_GB_PER_SLOT",
+)
+
+
+def _memory_environment(tmp_path, **values):
+    script = MEMORY_STATEMENT_DEFAULT_TEMPLATE.safe_substitute(metadata_directory=tmp_path)
+    script += "\n" + "\n".join(f'printf "{name}=%s\\n" "${{{name}-}}"' for name in MEMORY_VARIABLES)
+    environment = {"PATH": os.environ["PATH"], "GALAXY_SLOTS": "4", **values}
+
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        check=True,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+    return dict(line.split("=", 1) for line in completed.stdout.splitlines())
+
+
+def test_memory_gb_variables_are_derived_from_total_memory(tmp_path):
+    environment = _memory_environment(tmp_path, GALAXY_MEMORY_MB="8192")
+
+    assert environment == {
+        "GALAXY_MEMORY_MB": "8192",
+        "GALAXY_MEMORY_MB_PER_SLOT": "2048",
+        "GALAXY_MEMORY_GB": "8",
+        "GALAXY_MEMORY_GB_PER_SLOT": "2",
+    }
+
+
+def test_memory_overhead_applies_to_per_slot_input(tmp_path):
+    environment = _memory_environment(
+        tmp_path,
+        GALAXY_MEMORY_MB_PER_SLOT="4096",
+        GALAXY_MEMORY_MB_OVERHEAD="2048",
+        GALAXY_MEMORY_MB_FLOOR="1024",
+    )
+
+    assert environment == {
+        "GALAXY_MEMORY_MB": "14336",
+        "GALAXY_MEMORY_MB_PER_SLOT": "3584",
+        "GALAXY_MEMORY_GB": "14",
+        "GALAXY_MEMORY_GB_PER_SLOT": "3",
+    }
+
+
+def test_memory_floor_and_sub_gb_values(tmp_path):
+    environment = _memory_environment(
+        tmp_path,
+        GALAXY_MEMORY_MB="2048",
+        GALAXY_MEMORY_MB_OVERHEAD="1536",
+        GALAXY_MEMORY_MB_FLOOR="1024",
+    )
+
+    assert environment == {
+        "GALAXY_MEMORY_MB": "1024",
+        "GALAXY_MEMORY_MB_PER_SLOT": "256",
+        "GALAXY_MEMORY_GB": "1",
+        "GALAXY_MEMORY_GB_PER_SLOT": "",
+    }
+
+
+def test_memory_gb_variables_are_available_to_containers():
+    assert "GALAXY_MEMORY_GB" in ToolInfo().env_pass_through
+    assert "GALAXY_MEMORY_GB_PER_SLOT" in ToolInfo().env_pass_through

--- a/test/unit/app/jobs/test_job_script.py
+++ b/test/unit/app/jobs/test_job_script.py
@@ -70,6 +70,21 @@ def test_memory_floor_and_sub_gb_values(tmp_path):
     }
 
 
+def test_memory_floor_never_exceeds_allocation(tmp_path):
+    environment = _memory_environment(
+        tmp_path,
+        GALAXY_MEMORY_MB="128",
+        GALAXY_MEMORY_MB_OVERHEAD="64",
+    )
+
+    assert environment == {
+        "GALAXY_MEMORY_MB": "128",
+        "GALAXY_MEMORY_MB_PER_SLOT": "32",
+        "GALAXY_MEMORY_GB": "",
+        "GALAXY_MEMORY_GB_PER_SLOT": "",
+    }
+
+
 def test_memory_gb_variables_are_available_to_containers():
     assert "GALAXY_MEMORY_GB" in ToolInfo().env_pass_through
     assert "GALAXY_MEMORY_GB_PER_SLOT" in ToolInfo().env_pass_through


### PR DESCRIPTION
This supersedes #21735 and preserves Nate Coraor's authorship on the original commits.
It rebases the work onto current `dev` and incorporates the discussion on the original
pull request.

## Summary

Galaxy already exposes scheduler memory allocations as `GALAXY_MEMORY_MB` and
`GALAXY_MEMORY_MB_PER_SLOT`. This also derives `GALAXY_MEMORY_GB` and
`GALAXY_MEMORY_GB_PER_SLOT`, so tool wrappers do not each need their own conversion.

Destinations can configure an additive `GALAXY_MEMORY_MB_OVERHEAD` when the tool's
own memory limit must remain below the scheduler's hard allocation. An optional
`GALAXY_MEMORY_MB_FLOOR`, defaulting to 256 MB, prevents that subtraction from
producing an unusably small value without ever raising the advertised memory above
the scheduler's original allocation.

The additive model is intentional: a proportional overhead can waste very large
amounts of memory on high-memory jobs, while the usual requirement is to reserve a
small fixed amount for processes and runtime overhead outside the tool's own limit.

## Review follow-up

- Normalize total and per-slot MB values before applying overhead. This makes the
  feature work when a runner such as SGE initially supplies only per-slot memory.
- Recalculate per-slot memory after subtracting overhead so all derived variables remain
  internally consistent.
- Cap floor handling at the scheduler allocation so a low-memory job never receives
  a larger advertised limit.
- Derive per-slot GB directly from per-slot MB rather than from an already rounded
  total-GB value.
- Round derived GB values down and leave them unset below 1 GB instead of claiming a
  1 GB per-slot allocation that may exceed the scheduler limit.
- Pass both GB variables through to containerized tools as well as native jobs.
- Document both GB variables for wrapper authors and clarify the behavior and default
  floor in the sample job configuration.

## How to test the changes?

- [x] I've included appropriate automated tests.

## License

- [x] I agree to license these and all my past contributions to the core Galaxy
  codebase under the MIT license.
