### PR TITLE
Add the Galaxy Conda environment hash to `mulled-hash`

### DIFF
--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -71,7 +71,12 @@ Each mulled container is identified with a hash such as ``mulled-v2-8186960447c5
    $ mulled-hash samtools=1.3.1,bedtools=2.22
    mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:d52e471b5bfa168ac813d54fc5dfe7f96ade56e6
 
-The user can specify whether to generate hashes for either version 1 or version 2 containers with ``--hash``; version 2 is the default.
+The user can specify whether to generate hashes for either version 1 or version 2 containers with ``--hash``; version 2 is the default. Use ``--hash conda`` to calculate the distinct ``mulled-v1`` hash used for Galaxy's uncontainerized Conda environments:
+
+.. code-block:: bash
+
+   $ mulled-hash --hash conda bedtools=2.30.0,samtools=1.9
+   mulled-v1-ca195b12c14e35565e393a2d07f2deac7610d8126cc3460d217504efd11d4347
 
 
 Build all packages from bioconda from the last 24h
@@ -235,7 +240,8 @@ Options:
   e.g. ``samtools=1.3.1,bedtools=2.22``.
 
 ``--hash``
-  Hash version. Choices: ``v1``, ``v2`` (default).
+  Hash type. Choices: ``conda``, ``v1``, ``v2`` (default). The ``conda`` type
+  calculates Galaxy's uncontainerized Conda environment hash.
 
 
 mulled-build-channel

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 """Produce a mulled hash for specified conda targets.
 
-Galaxy does not use the "v1" hash format for uncontainerized conda dependencies. For the mulled hash for conda
-dependencies, use `--hash conda`
+Use ``--hash conda`` to calculate the hash used for Galaxy's uncontainerized
+Conda environments. Despite sharing the ``mulled-v1`` prefix, that hash differs
+from the version 1 container hash.
 
 Examples
 
@@ -14,30 +15,32 @@ Produce a mulled hash with:
 from typing import Literal
 
 from ._cli import arg_parser
-from ..conda_util import hash_conda_packages
 from .mulled_build import target_str_to_targets
 from .util import (
     v1_image_name,
     v2_image_name,
 )
+from ..conda_util import hash_conda_packages
+
+HashType = Literal["conda", "v1", "v2"]
+HASH_TYPES: tuple[HashType, ...] = ("conda", "v1", "v2")
 
 
-IMAGE_FUNCS = {
-    "conda": lambda x: f"mulled-v1-{hash_conda_packages(x)}",
-    "v1": v1_image_name,
-    "v2": v2_image_name,
-}
-
-
-def _mulled_hash(hash: Literal["conda", "v1", "v2"], targets_str: str):
+def _mulled_hash(hash_type: HashType, targets_str: str) -> str:
     """
+    >>> _mulled_hash("conda", "bedtools=2.30.0,samtools=1.9")
+    'mulled-v1-ca195b12c14e35565e393a2d07f2deac7610d8126cc3460d217504efd11d4347'
     >>> _mulled_hash("v2", "samtools=1.3.1,bedtools=2.26.0")
     'mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619'
     >>> _mulled_hash("v2", "samtools=1.3.1=h9071d68_10,bedtools=2.26.0=0")
     'mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619'
     """
     targets = target_str_to_targets(targets_str)
-    return IMAGE_FUNCS[hash](targets)
+    if hash_type == "conda":
+        return f"mulled-v1-{hash_conda_packages(targets)}"
+    if hash_type == "v1":
+        return v1_image_name(targets)
+    return v2_image_name(targets)
 
 
 def main(argv=None):
@@ -46,8 +49,8 @@ def main(argv=None):
     parser.add_argument(
         "targets", metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash."
     )
-    parser.add_argument("--hash", dest="hash", choices=IMAGE_FUNCS.keys(), default="v2")
-    args = parser.parse_args()
+    parser.add_argument("--hash", dest="hash", choices=HASH_TYPES, default="v2")
+    args = parser.parse_args(argv)
     print(_mulled_hash(args.hash, args.targets))
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 """Produce a mulled hash for specified conda targets.
 
+Galaxy does not use the "v1" hash format for uncontainerized conda dependencies. For the mulled hash for conda
+dependencies, use `--hash conda`
+
 Examples
 
 Produce a mulled hash with:
@@ -11,6 +14,7 @@ Produce a mulled hash with:
 from typing import Literal
 
 from ._cli import arg_parser
+from ..conda_util import hash_conda_packages
 from .mulled_build import target_str_to_targets
 from .util import (
     v1_image_name,
@@ -18,7 +22,14 @@ from .util import (
 )
 
 
-def _mulled_hash(hash: Literal["v1", "v2"], targets_str: str):
+IMAGE_FUNCS = {
+    "conda": lambda x: f"mulled-v1-{hash_conda_packages(x)}",
+    "v1": v1_image_name,
+    "v2": v2_image_name,
+}
+
+
+def _mulled_hash(hash: Literal["conda", "v1", "v2"], targets_str: str):
     """
     >>> _mulled_hash("v2", "samtools=1.3.1,bedtools=2.26.0")
     'mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619'
@@ -26,8 +37,7 @@ def _mulled_hash(hash: Literal["v1", "v2"], targets_str: str):
     'mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619'
     """
     targets = target_str_to_targets(targets_str)
-    image_name = v2_image_name if hash == "v2" else v1_image_name
-    return image_name(targets)
+    return IMAGE_FUNCS[hash](targets)
 
 
 def main(argv=None):
@@ -36,7 +46,7 @@ def main(argv=None):
     parser.add_argument(
         "targets", metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash."
     )
-    parser.add_argument("--hash", dest="hash", choices=["v1", "v2"], default="v2")
+    parser.add_argument("--hash", dest="hash", choices=["conda", "v1", "v2"], default="v2")
     args = parser.parse_args()
     print(_mulled_hash(args.hash, args.targets))
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -46,7 +46,7 @@ def main(argv=None):
     parser.add_argument(
         "targets", metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash."
     )
-    parser.add_argument("--hash", dest="hash", choices=["conda", "v1", "v2"], default="v2")
+    parser.add_argument("--hash", dest="hash", choices=IMAGE_FUNCS.keys(), default="v2")
     args = parser.parse_args()
     print(_mulled_hash(args.hash, args.targets))
 

--- a/test/unit/tool_util/mulled/test_mulled_hash.py
+++ b/test/unit/tool_util/mulled/test_mulled_hash.py
@@ -1,0 +1,9 @@
+from galaxy.tool_util.deps.mulled.mulled_hash import main
+
+
+def test_conda_hash_cli(capsys):
+    main(["--hash", "conda", "bedtools=2.30.0,samtools=1.9"])
+
+    assert (
+        capsys.readouterr().out.strip() == "mulled-v1-ca195b12c14e35565e393a2d07f2deac7610d8126cc3460d217504efd11d4347"
+    )


### PR DESCRIPTION
This supersedes #18938 and preserves Nate Coraor's authorship on the original commits.
It reapplies the feature after the #18522 hash refactor and incorporates the review
comments on the original pull request.

## Summary

Add `mulled-hash --hash conda` for calculating the `mulled-v1-...` hash Galaxy uses
for uncontainerized Conda environments. Despite the shared prefix, this is distinct
from the version 1 container-image hash.

For example:

```console
$ mulled-hash --hash conda bedtools=2.30.0,samtools=1.9
mulled-v1-ca195b12c14e35565e393a2d07f2deac7610d8126cc3460d217504efd11d4347
```

The existing `v1` and default `v2` modes are unchanged.

## Review follow-up

- Rebase the feature onto the typed `_mulled_hash()` helper introduced by #18522.
- Use an explicit typed conditional instead of a heterogeneous callable map, addressing
  the mypy problem identified during review.
- Add the requested doctest for the Conda hash and a CLI-level regression test.
- Make `main(argv)` pass its supplied arguments to `argparse`; this also lets the CLI
  path be tested without mutating process-global arguments.
- Document the new hash type in both `mulled-hash` sections of the administrator guide.

## How to test the changes?

- [x] I've included appropriate automated tests.

## License

- [x] I agree to license these and all my past contributions to the core Galaxy
  codebase under the MIT license.
