### PR TITLE
Add Common Crawl file source

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -13271,7 +13271,8 @@ export interface components {
                 | "mavedb"
                 | "omero"
                 | "ssh"
-                | "ckan";
+                | "ckan"
+                | "commoncrawl";
             /** Variables */
             variables?:
                 | (
@@ -26037,7 +26038,8 @@ export interface components {
                 | "mavedb"
                 | "omero"
                 | "ssh"
-                | "ckan";
+                | "ckan"
+                | "commoncrawl";
             /** Uri Root */
             uri_root: string;
             /**

--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -1,5 +1,5 @@
 import { faAws, faDropbox, faGithub, faGoogleDrive, faHubspot } from "@fortawesome/free-brands-svg-icons";
-import { faCloud, faFolderTree, faNetworkWired, type IconDefinition } from "font-awesome-6";
+import { faCloud, faFolderTree, faGlobe, faNetworkWired, type IconDefinition } from "font-awesome-6";
 
 import type { components } from "@/api/schema";
 import { contains } from "@/utils/filtering";
@@ -110,6 +110,10 @@ export const templateTypes: FileSourceTypesDetail = {
     ckan: {
         icon: faNetworkWired,
         message: "This is a repository plugin that connects with a CKAN instance.",
+    },
+    commoncrawl: {
+        icon: faGlobe,
+        message: "This is a read-only file repository plugin that connects with the Common Crawl archive.",
     },
 };
 

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -390,6 +390,9 @@ class ConditionalDependencies(BaseConditionalDependencies):
     def check_mavedb_fsspec(self):
         return "mavedb" in self.file_sources
 
+    def check_commoncrawl_fsspec(self):
+        return "commoncrawl" in self.file_sources
+
 
 def strip_comment(line):
     # lifted from https://github.com/tox-dev/tox/commit/3c6b4f204e89852c4b7536b246a66d20be6d39ec

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -36,6 +36,7 @@ omero-py #type: omero
 iiif-fsspec # type: iiif
 fs-irods # type: irods, depends on python-irodsclient
 mavedb-fsspec>=0.1.0 # type: mavedb
+commoncrawl-fsspec # type: commoncrawl
 
 # Vault backend
 hvac

--- a/lib/galaxy/files/sources/commoncrawl.py
+++ b/lib/galaxy/files/sources/commoncrawl.py
@@ -1,0 +1,78 @@
+"""Common Crawl file source plugin using fsspec.
+
+This plugin wraps the ``commoncrawl-fsspec`` library's
+:class:`~commoncrawl_fsspec.filesystem.CommonCrawlFileSystem` to provide
+read-only access to the `Common Crawl <https://commoncrawl.org/>`_ archive
+through Galaxy's file source framework.
+
+Users can browse crawl releases, navigate segments, and download individual
+WARC, WET, or WAT files that can be imported into Galaxy histories.
+"""
+
+import logging
+
+from fsspec import AbstractFileSystem
+
+from galaxy.files.models import (
+    FilesSourceRuntimeContext,
+)
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+
+try:
+    from commoncrawl_fsspec import CommonCrawlFileSystem
+except ImportError:
+    CommonCrawlFileSystem = None  # type: ignore[assignment, misc, unused-ignore]
+
+
+REQUIRED_PACKAGE = "commoncrawl-fsspec"
+FS_PLUGIN_TYPE = "commoncrawl"
+
+log = logging.getLogger(__name__)
+
+
+class CommonCrawlFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    """Template configuration for the Common Crawl file source."""
+
+
+class CommonCrawlFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    """Resolved configuration for the Common Crawl file source."""
+
+
+class CommonCrawlFilesSource(
+    FsspecFilesSource[CommonCrawlFileSourceTemplateConfiguration, CommonCrawlFileSourceConfiguration]
+):
+    """File source plugin for browsing Common Crawl data.
+
+    The plugin is strictly read-only. It delegates to
+    :class:`~commoncrawl_fsspec.filesystem.CommonCrawlFileSystem` for all
+    filesystem operations (listing, file retrieval).
+    """
+
+    plugin_type = FS_PLUGIN_TYPE
+    required_module = CommonCrawlFileSystem
+    required_package = REQUIRED_PACKAGE
+
+    template_config_class = CommonCrawlFileSourceTemplateConfiguration
+    resolved_config_class = CommonCrawlFileSourceConfiguration
+
+    def get_writable(self) -> bool:
+        """Common Crawl is a public read-only dataset."""
+        return False
+
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[CommonCrawlFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ) -> AbstractFileSystem:
+        if CommonCrawlFileSystem is None:
+            raise self.required_package_exception
+
+        return CommonCrawlFileSystem(**cache_options)
+
+
+__all__ = ("CommonCrawlFilesSource",)

--- a/lib/galaxy/files/templates/examples/production_commoncrawl.yml
+++ b/lib/galaxy/files/templates/examples/production_commoncrawl.yml
@@ -1,0 +1,12 @@
+- id: commoncrawl
+  version: 0
+  name: Common Crawl
+  description: |
+      [Common Crawl](https://commoncrawl.org/) is an open repository of web crawl data
+      containing petabytes of web pages collected since 2008.
+
+      Use this plugin to browse archived crawl releases and navigate to individual
+      WARC, WET, or WAT files that can be imported into Galaxy histories.
+  configuration:
+      type: commoncrawl
+      writable: false

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -55,6 +55,7 @@ FileSourceTemplateType = Literal[
     "omero",
     "ssh",
     "ckan",
+    "commoncrawl",
 ]
 
 FileSourceTemplateAlertVariant = Literal[
@@ -542,6 +543,18 @@ class CKANFileSourceConfiguration(StrictModel):
     writable: bool = True
 
 
+class CommonCrawlFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["commoncrawl"]
+    writable: bool | TemplateExpansion = False
+    template_start: str | None = None
+    template_end: str | None = None
+
+
+class CommonCrawlFileSourceConfiguration(StrictModel):
+    type: Literal["commoncrawl"]
+    writable: bool = False
+
+
 FileSourceTemplateConfiguration = Annotated[
     PosixFileSourceTemplateConfiguration
     | S3FSFileSourceTemplateConfiguration
@@ -566,7 +579,8 @@ FileSourceTemplateConfiguration = Annotated[
     | MaveDBFileSourceTemplateConfiguration
     | OmeroFileSourceTemplateConfiguration
     | SshFileSourceTemplateConfiguration
-    | CKANFileSourceTemplateConfiguration,
+    | CKANFileSourceTemplateConfiguration
+    | CommonCrawlFileSourceTemplateConfiguration,
     Field(discriminator="type"),
 ]
 
@@ -594,7 +608,8 @@ FileSourceConfiguration = Annotated[
     | MaveDBFileSourceConfiguration
     | OmeroFileSourceConfiguration
     | SshFileSourceConfiguration
-    | CKANFileSourceConfiguration,
+    | CKANFileSourceConfiguration
+    | CommonCrawlFileSourceConfiguration,
     Field(discriminator="type"),
 ]
 
@@ -683,6 +698,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "omero": OmeroFileSourceConfiguration,
     "ssh": SshFileSourceConfiguration,
     "ckan": CKANFileSourceConfiguration,
+    "commoncrawl": CommonCrawlFileSourceConfiguration,
 }
 
 


### PR DESCRIPTION
This PR adds a new read-only file source plugin that integrates the [Common Crawl](https://commoncrawl.org/) archive — an open repository of petabytes of web crawl data collected since 2008 — into Galaxy's file source framework.

## What can users do with this?

- **Browse** Common Crawl releases directly from Galaxy's file browser
- **Navigate** crawl segments and file listings
- **Import** individual WARC, WET, or WAT files into Galaxy histories for analysis


<img width="1122" height="953" alt="Screenshot from 2026-09-11 17-44-53" src="https://github.com/user-attachments/assets/9645e34d-ba3a-4e1a-bf9b-9307779285c4" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Add `production_commoncrawl.yml` to your `config/file_source_templates.yml` config
  - Restart Galaxy
  - Create a connection to this new file source in Galaxy

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
