### PR TITLE
[26.1] Make Workflow Preview and Tool Source modal content fill the modal height

### DIFF
--- a/client/src/components/Tool/ToolSourceDisplay.vue
+++ b/client/src/components/Tool/ToolSourceDisplay.vue
@@ -62,6 +62,7 @@ export default {
 <style scoped>
 .editor-container {
     width: 100%;
-    height: 600px;
+    flex: 1 1 0;
+    min-height: 0;
 }
 </style>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -131,10 +131,8 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             :show.sync="showPreview"
             size="large"
             title="Workflow Preview"
-            hide-header
             fixed-height
-            class="workflow-card-preview-modal"
-            centered>
+            class="workflow-card-preview-modal">
             <template v-slot:header>
                 <WorkflowPublishedButtons
                     v-if="workflowPublished?.workflowInfo"
@@ -156,10 +154,6 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
 <style lang="scss">
 .workflow-card-preview-modal {
     max-width: min(1400px, calc(100% - 200px));
-
-    .modal-content {
-        height: min(800px, calc(100vh - 80px));
-    }
 }
 </style>
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -119,7 +119,7 @@ defineExpose({
     <div id="columns" class="workflow-published">
         <ActivityBar v-if="!props.embed && !props.quickView" />
 
-        <div id="center" class="container-root" :class="{ 'm-3': !props.quickView }">
+        <div id="center" class="container-root" :class="{ 'p-3': !props.quickView }">
             <div v-if="loading">
                 <Heading h1 separator size="lg">
                     <FontAwesomeIcon :icon="faSpinner" spin />

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -68,6 +68,8 @@ const initialPosition = computed(() => ({
 /** Workflow steps force typed as `Steps` from the `workflowStepStore` */
 const workflowSteps = computed(() => (workflow.value?.steps as unknown as Steps) ?? []);
 
+const showHeader = computed(() => props.showHeading || props.showButtons);
+
 async function load() {
     errorMessage.value = "";
 
@@ -131,8 +133,8 @@ defineExpose({
                     {{ errorMessage }}
                 </BAlert>
             </div>
-            <div v-else-if="workflowInfo" class="published-workflow">
-                <div v-if="props.showHeading || props.showButtons" class="workflow-header">
+            <div v-else-if="workflowInfo" class="published-workflow" :class="{ 'has-header': showHeader }">
+                <div v-if="showHeader" class="workflow-header">
                     <Heading v-if="props.showHeading" h1 separator inline size="lg" class="flex-grow-1 mb-0">
                         <span v-if="props.showAbout"> Workflow Preview </span>
                         <span v-else> {{ workflowInfo.name }} </span>
@@ -186,10 +188,14 @@ defineExpose({
         display: grid;
         gap: 0.5rem 1rem;
         grid-template-columns: minmax(0, 1fr) minmax(18rem, 30%);
-        grid-template-rows: auto minmax(0, 1fr);
+        grid-template-rows: minmax(0, 1fr);
 
         height: 100%;
         min-height: 0;
+
+        &.has-header {
+            grid-template-rows: auto minmax(0, 1fr);
+        }
 
         .workflow-header {
             grid-column: 1 / -1;


### PR DESCRIPTION
Follow-up to #23143 (which fixed #20563 on the published workflow page but introduced the first regression below).

The Workflow Preview modal (workflow list) and the Tool Source modal (tool form options menu) both leave a blank band at the bottom of their content instead of using the full modal height. Two separate causes, both on the consumer side; `GModal` itself is unchanged.

Also removes BootstrapVue leftovers on the preview modal: `hide-header` and `centered` are not `GModal` props, and the `.modal-content` height override targeted a class that `GModal` never renders.

Fixes a related clip on the full `/published/workflow` page: the page container is sized to 100% of its overflow-hidden parent and also carries an outer `m-3` margin, so the bottom of the graph card (its border and zoom controls) was cut off. It now uses padding instead of margin.

| | Before | After |
|---|---|---|
| Workflow Preview modal | <img width="2000" height="1160" alt="workflow-preview-before" src="https://github.com/user-attachments/assets/4c810bdb-81ce-45c6-b609-985aa3c46cf5" /> | <img width="2000" height="1160" alt="workflow-preview-after" src="https://github.com/user-attachments/assets/eef8522a-9b0b-4d4f-8f52-895c94928db5" /> |
| Tool Source modal | <img width="2000" height="1203" alt="tool-source-before" src="https://github.com/user-attachments/assets/0831eba5-f336-4819-8fc1-b98c5c8b1472" /> | <img width="2000" height="1160" alt="tool-source-after" src="https://github.com/user-attachments/assets/12bf68f8-c2b4-4ce7-9549-e5272bfc4133" /> |
| Tool Source modal, short viewport | <img width="1400" height="700" alt="tool-source-before-short-viewport" src="https://github.com/user-attachments/assets/54c1d8c9-5867-4b9e-9d11-b9e50adad761" /> | <img width="1400" height="700" alt="tool-source-after-short-viewport" src="https://github.com/user-attachments/assets/62f5ced4-da32-411a-9d0c-ab652bb9e157" /> |
| Published workflow page | <img width="2000" height="1160" alt="published-page-default-before" src="https://github.com/user-attachments/assets/bdd3daf1-913e-449b-a6a8-b104115706a0" /> | <img width="2000" height="1160" alt="published-page-default-after" src="https://github.com/user-attachments/assets/f4017f82-0bbd-406c-9027-d301f1064fb4" /> |
| Published workflow page (no header) | <img width="2000" height="1160" alt="published-page-no-header-before" src="https://github.com/user-attachments/assets/4fa65e2e-9d23-4976-8c5a-a8734a3bd4b5" /> | <img width="2000" height="1160" alt="published-page-no-header-after" src="https://github.com/user-attachments/assets/1f77f1c5-390f-4f3c-a632-57fd0a30e5dd" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open `/workflows/list` and click the preview (eye) button on a workflow that has a description and tags. The graph card and the "About This Workflow" sidebar must both reach the bottom of the modal; the sidebar scrolls if its content exceeds the modal height.
  2. Open `/published/workflow?id=<id>&heading=false&buttons=false`. The graph and sidebar must fill the page height. Without the query flags, the header row must still render above them as before, and in both cases, the graph card's bottom border and zoom controls must be fully visible (previously, the bottom 16px was clipped).
  3. Open any tool form (e.g., `/?tool_id=<tool_id>&version=latest`), open the options dropdown next to the favorite button, and choose "View Tool source". The source viewer must extend to the bottom edge of the modal. Resize the window to about 700px tall: the viewer must shrink with the modal and scroll internally, without a second scrollbar on the modal body.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).


