### PR TITLE
Resolve the job handler on the instance that received the tool request

### DIFF
--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -55,7 +55,9 @@ class JobManager:
     def _message_callback(self, job):
         return JobHandlerMessage(task="setup", job_id=job.id)
 
-    def enqueue(self, job: "Job", tool: Union["Tool", None] = None, flush: bool = True) -> str:
+    def enqueue(
+        self, job: "Job", tool: Union["Tool", None] = None, flush: bool = True, handler: str | None = None
+    ) -> str:
         """Queue a job for execution.
 
         Due to the nature of some handler assignment methods which are wholly DB-based, the enqueue method will flush
@@ -70,10 +72,9 @@ class JobManager:
         :raises ToolExecutionError: if a handler was unable to be assigned.
         :returns: str or None -- Handler ID, tag, or pool assigned to the job.
         """
-        tool_id = None
-        configured_handler = None
-        if tool:
-            tool_id = tool.id
+        tool_id = tool.id if tool else None
+        configured_handler = handler
+        if tool and configured_handler is None:
             configured_handler = tool.get_configured_job_handler()
             if configured_handler is not None:
                 log.debug(

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2317,6 +2317,7 @@ class JobSubmitter:
             user,
             history=target_history,
             galaxy_session=galaxy_session,
+            origin_job_handler=request.handler,
         )
         return trans
 

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -196,3 +196,4 @@ class QueueJobs(Model):
     send_email_notification: bool = False
     credentials_context: list[dict] | None = None
     dynamic_tool_id: int | None = None  # link to DynamicTool for custom/user tools
+    handler: str | None = None

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -419,7 +419,9 @@ def _execute(
             )()
             job2.set_runner_external_id(async_result.task_id)
             continue
-        tool.app.job_manager.enqueue(job2, tool=tool, flush=False)
+        tool.app.job_manager.enqueue(
+            job2, tool=tool, flush=False, handler=getattr(trans, "origin_job_handler", None)
+        )
         trans.log_event(f"Added job to the job queue, id: {str(job2.id)}", tool_id=tool_id)
     trans.sa_session.commit()
 

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -294,6 +294,7 @@ class JobsService(ServiceBase):
             send_email_notification=job_request.send_email_notification,
             credentials_context=job_request.credentials_context,
             dynamic_tool_id=tool.dynamic_tool.id if tool.dynamic_tool else None,
+            handler=tool.get_configured_job_handler() or trans.app.job_config.default_handler_id,
         )
         result = queue_jobs.delay(request=task_request)
         return JobCreateResponse(

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -41,6 +41,7 @@ class WorkRequestContext(ProvidesHistoryContext):
         url_builder=None,
         galaxy_session: Optional["GalaxySession"] = None,
         short_term_cache: dict[tuple[Hashable, ...], Any] | None = None,
+        origin_job_handler: str | None = None,
     ):
         self._app = app
         self.__user = user
@@ -55,6 +56,7 @@ class WorkRequestContext(ProvidesHistoryContext):
         )
         self.workflow_building_mode = workflow_building_mode
         self.galaxy_session = galaxy_session
+        self.origin_job_handler = origin_job_handler
 
     @property
     def app(self):


### PR DESCRIPTION
Serves as starting point to work on, discuss and address a concern raised on #23329:

> we're still not respecting the origin of the request, stuff submitted on vgp goes to celery goes to main's job handler

`JobManager.enqueue` resolves the handler through `self.app.job_config`. On the sync path that is the webapp that received the request. On the tool request path the job is created inside the Celery worker, so it is the worker's config instead, and a job submitted to a subsite is handed to whichever handlers that worker knows about.

`QueueJobs` carries no origin, and `JobSubmitter._context` rebuilds `WorkRequestContext` from the worker's app, so the worker cannot re-derive it.

This resolves the handler where the request arrives, carries it on `QueueJobs`, and passes it to `enqueue` as the configured handler. Handler is the useful single lever: the handler runs the job with its own config, so destination selection and `galaxy_infrastructure_url` follow from it.

Draft, because two things are unconfirmed and both change the patch:

1. The resolution falls back to `job_config.default_handler_id`. On an instance using tag assignment with handler pools that can be unset, in which case this is a no-op on exactly the deployments in question. Worth confirming what the affected instances have.
2. Only `_assign_db_tag` writes a foreign tag as given. `_assign_db_preassign_handler` looks the tag up in `self.handlers` and raises `KeyError` for one the worker does not know, so `assign_handler` falls through to the next method rather than honouring the origin. Carrying the pool as well would be needed there.

Also unaddressed: whether handler assignment is the whole of respecting the origin, or only the part that surfaced first.
