### PR TITLE
Keep collection input form state local until undo or redo

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -6,17 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useRefreshFromStore } from "@/stores/refreshFromStore";
 
+import FormCollectionType from "./FormCollectionType.vue";
 import FormDefault from "./FormDefault.vue";
 import FormInputCollection from "./FormInputCollection.vue";
 
-function stubComponent(name, props) {
-    return { default: { name, props, render: (h) => h("div") } };
-}
-
-vi.mock("./FormCollectionType.vue", () => stubComponent("FormCollectionType", ["value", "optional"]));
-vi.mock("./FormColumnDefinitions.vue", () => stubComponent("FormColumnDefinitions", ["value", "collectionType"]));
-vi.mock("./FormDatatype.vue", () => stubComponent("FormDatatype", ["id", "value", "datatypes"]));
-vi.mock("./FormRecordFieldDefinitions.vue", () => stubComponent("FormRecordFieldDefinitions", ["value"]));
+vi.mock("./FormDatatype.vue", () => ({ default: { render: (h) => h("div") } }));
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
@@ -54,7 +48,7 @@ describe("FormDefault", () => {
         });
     });
 
-    it("re-seeds the collection input form from the step on undo and redo", async () => {
+    it("re-seeds the collection input form from the step on refresh", async () => {
         const collectionStep = {
             id: 0,
             content_id: null,
@@ -70,25 +64,26 @@ describe("FormDefault", () => {
         const collectionWrapper = mount(FormDefault, {
             propsData: { datatypes: [], step: collectionStep },
             localVue,
-            pinia: createTestingPinia({ createSpy: vi.fn }),
+            pinia: createTestingPinia({ createSpy: vi.fn, stubActions: false }),
             provide: { workflowId: "mock-workflow" },
         });
         const collectionTypeField = () =>
-            collectionWrapper.findComponent(FormInputCollection).findComponent({ name: "FormCollectionType" });
+            collectionWrapper.findComponent(FormInputCollection).findComponent(FormCollectionType);
 
         collectionTypeField().vm.$emit("onChange", "paired");
         await collectionWrapper.vm.$nextTick();
         expect(collectionTypeField().props("value")).toBe("paired");
         expect(collectionWrapper.emitted("onSetData")).toHaveLength(1);
 
-        // An undo restores the step in the store and bumps the form key.
-        useRefreshFromStore().formKey += 1;
+        useRefreshFromStore().refresh();
         await collectionWrapper.vm.$nextTick();
         expect(collectionTypeField().props("value")).toBe("list");
+        expect(collectionWrapper.emitted("onSetData")).toHaveLength(1);
 
         collectionTypeField().vm.$emit("onChange", "list:paired");
         expect(collectionWrapper.emitted("onSetData")).toHaveLength(2);
         expect(collectionWrapper.emitted("onSetData")[1][1].inputs.collection_type).toBe("list:paired");
+        collectionWrapper.destroy();
     });
 
     it("check initial value and value change", async () => {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -4,7 +4,19 @@ import { mount } from "@vue/test-utils";
 import { PiniaVuePlugin } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useRefreshFromStore } from "@/stores/refreshFromStore";
+
 import FormDefault from "./FormDefault.vue";
+import FormInputCollection from "./FormInputCollection.vue";
+
+function stubComponent(name, props) {
+    return { default: { name, props, render: (h) => h("div") } };
+}
+
+vi.mock("./FormCollectionType.vue", () => stubComponent("FormCollectionType", ["value", "optional"]));
+vi.mock("./FormColumnDefinitions.vue", () => stubComponent("FormColumnDefinitions", ["value", "collectionType"]));
+vi.mock("./FormDatatype.vue", () => stubComponent("FormDatatype", ["id", "value", "datatypes"]));
+vi.mock("./FormRecordFieldDefinitions.vue", () => stubComponent("FormRecordFieldDefinitions", ["value"]));
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
@@ -40,6 +52,43 @@ describe("FormDefault", () => {
                 workflowId: "mock-workflow",
             },
         });
+    });
+
+    it("re-seeds the collection input form from the step on undo and redo", async () => {
+        const collectionStep = {
+            id: 0,
+            content_id: null,
+            annotation: "annotation",
+            label: "label",
+            name: "name",
+            type: "data_collection_input",
+            config_form: { inputs: [] },
+            inputs: [],
+            outputs: [],
+            tool_state: { collection_type: '"list"' },
+        };
+        const collectionWrapper = mount(FormDefault, {
+            propsData: { datatypes: [], step: collectionStep },
+            localVue,
+            pinia: createTestingPinia({ createSpy: vi.fn }),
+            provide: { workflowId: "mock-workflow" },
+        });
+        const collectionTypeField = () =>
+            collectionWrapper.findComponent(FormInputCollection).findComponent({ name: "FormCollectionType" });
+
+        collectionTypeField().vm.$emit("onChange", "paired");
+        await collectionWrapper.vm.$nextTick();
+        expect(collectionTypeField().props("value")).toBe("paired");
+        expect(collectionWrapper.emitted("onSetData")).toHaveLength(1);
+
+        // An undo restores the step in the store and bumps the form key.
+        useRefreshFromStore().formKey += 1;
+        await collectionWrapper.vm.$nextTick();
+        expect(collectionTypeField().props("value")).toBe("list");
+
+        collectionTypeField().vm.$emit("onChange", "list:paired");
+        expect(collectionWrapper.emitted("onSetData")).toHaveLength(2);
+        expect(collectionWrapper.emitted("onSetData")[1][1].inputs.collection_type).toBe("list:paired");
     });
 
     it("check initial value and value change", async () => {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -51,6 +51,7 @@
                 @onChangePostJobActions="onChangePostJobActions" />
             <FormInputCollection
                 v-else-if="type == 'data_collection_input'"
+                :key="formKey"
                 :step="step"
                 :datatypes="datatypes"
                 :inputs="configForm?.inputs"

--- a/client/src/components/Workflow/Editor/Forms/FormInputCollection.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormInputCollection.test.ts
@@ -1,0 +1,90 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount, type Wrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type Vue from "vue";
+
+import FormInputCollection from "./FormInputCollection.vue";
+
+function stubComponent(name: string, props: string[]) {
+    return { default: { name, props, render: (h: (tag: string) => unknown) => h("div") } };
+}
+
+vi.mock("@/components/Form/FormElement.vue", () => stubComponent("FormElement", ["id", "value"]));
+vi.mock("./FormCollectionType.vue", () => stubComponent("FormCollectionType", ["value", "optional"]));
+vi.mock("./FormColumnDefinitions.vue", () => stubComponent("FormColumnDefinitions", ["value", "collectionType"]));
+vi.mock("./FormDatatype.vue", () => stubComponent("FormDatatype", ["id", "value", "datatypes"]));
+vi.mock("./FormRecordFieldDefinitions.vue", () => stubComponent("FormRecordFieldDefinitions", ["value"]));
+
+const localVue = getLocalVue();
+
+const CONDITION_COLUMN = [{ name: "Condition", type: "string", description: "", optional: false }];
+
+function stepWithCollectionType(collectionType: string | null) {
+    return {
+        id: 3,
+        type: "data_collection_input",
+        tool_state: {
+            collection_type: JSON.stringify(collectionType),
+            optional: "false",
+            tag: "null",
+            format: "null",
+            fields: "null",
+            column_definitions: "null",
+        },
+    };
+}
+
+function lastEmittedState(wrapper: Wrapper<Vue>) {
+    const emitted = wrapper.emitted("onChange");
+    return emitted?.[emitted.length - 1]?.[0];
+}
+
+describe("FormInputCollection", () => {
+    let wrapper: Wrapper<Vue>;
+
+    beforeEach(() => {
+        wrapper = mount(FormInputCollection as object, {
+            propsData: {
+                step: stepWithCollectionType("list"),
+                datatypes: [],
+            },
+            localVue,
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("shows the values stored on the step", () => {
+        expect(wrapper.findComponent({ name: "FormCollectionType" }).props("value")).toBe("list");
+    });
+
+    it("sends a later edit together with an earlier one the step has not echoed yet", async () => {
+        vi.useFakeTimers();
+        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet:paired");
+        await wrapper.vm.$nextTick();
+        expect(wrapper.findComponent({ name: "FormColumnDefinitions" }).exists()).toBe(true);
+
+        wrapper.findComponent({ name: "FormColumnDefinitions" }).vm.$emit("onChange", CONDITION_COLUMN);
+        vi.advanceTimersByTime(500);
+        await wrapper.vm.$nextTick();
+
+        const state = lastEmittedState(wrapper);
+        expect(state.collection_type).toBe("sample_sheet:paired");
+        expect(state.column_definitions).toEqual(CONDITION_COLUMN);
+    });
+
+    it("keeps the edited value when the step echoes an older one", async () => {
+        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet");
+        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet:paired");
+        await wrapper.setProps({ step: stepWithCollectionType("sample_sheet") });
+
+        expect(wrapper.findComponent({ name: "FormCollectionType" }).props("value")).toBe("sample_sheet:paired");
+        const optionalField = wrapper
+            .findAllComponents({ name: "FormElement" })
+            .wrappers.find((field) => field.props("id") === "optional");
+        optionalField?.vm.$emit("input", true);
+        expect(lastEmittedState(wrapper).collection_type).toBe("sample_sheet:paired");
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormInputCollection.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormInputCollection.test.ts
@@ -1,19 +1,12 @@
 import { getLocalVue } from "@tests/vitest/helpers";
-import { mount, type Wrapper } from "@vue/test-utils";
+import { shallowMount, type Wrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type Vue from "vue";
 
+import FormCollectionType from "./FormCollectionType.vue";
+import FormColumnDefinitions from "./FormColumnDefinitions.vue";
 import FormInputCollection from "./FormInputCollection.vue";
-
-function stubComponent(name: string, props: string[]) {
-    return { default: { name, props, render: (h: (tag: string) => unknown) => h("div") } };
-}
-
-vi.mock("@/components/Form/FormElement.vue", () => stubComponent("FormElement", ["id", "value"]));
-vi.mock("./FormCollectionType.vue", () => stubComponent("FormCollectionType", ["value", "optional"]));
-vi.mock("./FormColumnDefinitions.vue", () => stubComponent("FormColumnDefinitions", ["value", "collectionType"]));
-vi.mock("./FormDatatype.vue", () => stubComponent("FormDatatype", ["id", "value", "datatypes"]));
-vi.mock("./FormRecordFieldDefinitions.vue", () => stubComponent("FormRecordFieldDefinitions", ["value"]));
+import FormElement from "@/components/Form/FormElement.vue";
 
 const localVue = getLocalVue();
 
@@ -43,7 +36,7 @@ describe("FormInputCollection", () => {
     let wrapper: Wrapper<Vue>;
 
     beforeEach(() => {
-        wrapper = mount(FormInputCollection as object, {
+        wrapper = shallowMount(FormInputCollection as object, {
             propsData: {
                 step: stepWithCollectionType("list"),
                 datatypes: [],
@@ -53,20 +46,21 @@ describe("FormInputCollection", () => {
     });
 
     afterEach(() => {
+        wrapper.destroy();
         vi.useRealTimers();
     });
 
     it("shows the values stored on the step", () => {
-        expect(wrapper.findComponent({ name: "FormCollectionType" }).props("value")).toBe("list");
+        expect(wrapper.findComponent(FormCollectionType).props("value")).toBe("list");
     });
 
     it("sends a later edit together with an earlier one the step has not echoed yet", async () => {
         vi.useFakeTimers();
-        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet:paired");
+        wrapper.findComponent(FormCollectionType).vm.$emit("onChange", "sample_sheet:paired");
         await wrapper.vm.$nextTick();
-        expect(wrapper.findComponent({ name: "FormColumnDefinitions" }).exists()).toBe(true);
+        expect(wrapper.findComponent(FormColumnDefinitions).exists()).toBe(true);
 
-        wrapper.findComponent({ name: "FormColumnDefinitions" }).vm.$emit("onChange", CONDITION_COLUMN);
+        wrapper.findComponent(FormColumnDefinitions).vm.$emit("onChange", CONDITION_COLUMN);
         vi.advanceTimersByTime(500);
         await wrapper.vm.$nextTick();
 
@@ -76,15 +70,21 @@ describe("FormInputCollection", () => {
     });
 
     it("keeps the edited value when the step echoes an older one", async () => {
-        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet");
-        wrapper.findComponent({ name: "FormCollectionType" }).vm.$emit("onChange", "sample_sheet:paired");
+        wrapper.findComponent(FormCollectionType).vm.$emit("onChange", "sample_sheet");
+        wrapper.findComponent(FormCollectionType).vm.$emit("onChange", "sample_sheet:paired");
         await wrapper.setProps({ step: stepWithCollectionType("sample_sheet") });
 
-        expect(wrapper.findComponent({ name: "FormCollectionType" }).props("value")).toBe("sample_sheet:paired");
+        expect(wrapper.findComponent(FormCollectionType).props("value")).toBe("sample_sheet:paired");
         const optionalField = wrapper
-            .findAllComponents({ name: "FormElement" })
+            .findAllComponents(FormElement)
             .wrappers.find((field) => field.props("id") === "optional");
-        optionalField?.vm.$emit("input", true);
-        expect(lastEmittedState(wrapper).collection_type).toBe("sample_sheet:paired");
+        expect(optionalField).toBeDefined();
+        const emittedCount = wrapper.emitted("onChange")!.length;
+        optionalField!.vm.$emit("input", true);
+        expect(wrapper.emitted("onChange")).toHaveLength(emittedCount + 1);
+        expect(lastEmittedState(wrapper)).toMatchObject({
+            collection_type: "sample_sheet:paired",
+            optional: true,
+        });
     });
 });

--- a/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRef } from "vue";
+import { computed, ref, toRef } from "vue";
 
 import type { FieldDict, SampleSheetColumnDefinitions } from "@/api";
 import type { SampleSheetCollectionType } from "@/api/datasetCollections";
@@ -17,7 +17,7 @@ import FormRecordFieldDefinitions from "@/components/Workflow/Editor/Forms/FormR
 interface ToolState {
     collection_type: string | null;
     optional: boolean;
-    format: string | null;
+    format: string | string[] | null;
     tag: string | null;
     fields: FieldDict[] | null;
     column_definitions: SampleSheetColumnDefinitions;
@@ -28,62 +28,64 @@ const props = defineProps<{
     datatypes: DatatypesMapperModel["datatypes"];
 }>();
 
-function asToolState(toolState: unknown) {
-    return toolState as ToolState;
-}
-
 const stepRef = toRef(props, "step");
-const { toolState } = useToolState(stepRef);
+const { toolState: stepToolState } = useToolState(stepRef);
+
+const DEFAULT_TOOL_STATE: Readonly<ToolState> = Object.freeze({
+    collection_type: null,
+    optional: false,
+    tag: null,
+    format: null,
+    fields: null,
+    column_definitions: null,
+});
+
+/**
+ * The form owns its values, like `FormDisplay` does for tool steps. Edits are
+ * sent to the server as a full snapshot and only reach the step store once the
+ * server has echoed them back, so reading the store on every edit would resend
+ * the previous value of a field whose request is still pending. The state is
+ * seeded from the step when the component mounts; `FormDefault` re-keys the
+ * component on undo and redo so it is seeded again from the restored step.
+ */
+const toolState = ref<ToolState>({
+    ...DEFAULT_TOOL_STATE,
+    ...(stepToolState.value as Partial<ToolState>),
+});
 
 function cleanToolState(): ToolState {
-    if (toolState.value) {
-        return asToolState({ ...toolState.value });
-    } else {
-        return {
-            collection_type: null,
-            optional: false,
-            tag: null,
-            format: null,
-            fields: null,
-            column_definitions: null,
-        };
-    }
+    return { ...toolState.value };
 }
 
 const emit = defineEmits(["onChange"]);
 
+function emitChange(edit: Partial<ToolState>) {
+    toolState.value = { ...toolState.value, ...edit };
+    emit("onChange", cleanToolState());
+}
+
 function onDatatype(newDatatype: string[]) {
-    const state = cleanToolState();
-    state.format = newDatatype.join(",");
-    emit("onChange", state);
+    emitChange({ format: newDatatype.join(",") });
 }
 
 function onTags(newTags: string | null) {
-    const state = cleanToolState();
-    state.tag = newTags;
-    emit("onChange", state);
+    emitChange({ tag: newTags });
 }
 
 function onOptional(newOptional: boolean) {
-    const state = cleanToolState();
-    state.optional = newOptional;
-    emit("onChange", state);
+    emitChange({ optional: newOptional });
 }
 
 function onCollectionType(newCollectionType: string | null) {
-    const state = cleanToolState();
-    state.collection_type = newCollectionType;
-    emit("onChange", state);
+    emitChange({ collection_type: newCollectionType });
 }
 
 function onRecordFieldDefinitions(newRecordFieldDefinitions: FieldDict[]) {
-    const state = cleanToolState();
-    state.fields = newRecordFieldDefinitions;
-    emit("onChange", state);
+    emitChange({ fields: newRecordFieldDefinitions });
 }
 
 const isRecordType = computed(() => {
-    const collectionType = asToolState(toolState.value).collection_type;
+    const collectionType = toolState.value.collection_type;
     return collectionType == "record" || collectionType == "list:record" || collectionType == "sample_sheet:record";
 });
 
@@ -97,15 +99,13 @@ function onColumnDefinitions(newColumnDefinitions: SampleSheetColumnDefinitions)
     }
 
     columnDefinitionsTimer = setTimeout(() => {
-        const state = cleanToolState();
-        state.column_definitions = newColumnDefinitions;
-        emit("onChange", state);
+        emitChange({ column_definitions: newColumnDefinitions });
         columnDefinitionsTimer = null;
     }, 500);
 }
 
 const formatsAsList = computed(() => {
-    const formatStr = toolState.value?.format as string | string[] | null;
+    const formatStr = toolState.value.format;
     if (formatStr && typeof formatStr === "string") {
         return formatStr.split(/\s*,\s*/);
     } else if (formatStr) {
@@ -116,7 +116,7 @@ const formatsAsList = computed(() => {
 });
 
 const collectionType = computed(() => {
-    return toolState.value.collection_type as string | undefined;
+    return toolState.value.collection_type ?? undefined;
 });
 
 const isSampleSheetType = computed(() => {
@@ -135,7 +135,7 @@ emit("onChange", cleanToolState());
 <template>
     <div>
         <FormCollectionType :value="collectionType" :optional="true" @onChange="onCollectionType" />
-        <FormElement id="optional" :value="toolState?.optional" title="Optional" type="boolean" @input="onOptional" />
+        <FormElement id="optional" :value="toolState.optional" title="Optional" type="boolean" @input="onOptional" />
         <FormDatatype
             id="format"
             :value="formatsAsList"
@@ -146,7 +146,7 @@ emit("onChange", cleanToolState());
             @onChange="onDatatype" />
         <FormElement
             id="tag"
-            :value="toolState?.tag"
+            :value="toolState.tag"
             title="Tag filter"
             :optional="true"
             type="text"
@@ -155,11 +155,11 @@ emit("onChange", cleanToolState());
         <FormColumnDefinitions
             v-if="isSampleSheetType"
             :collection-type="sampleSheetCollectionType"
-            :value="asToolState(toolState).column_definitions"
+            :value="toolState.column_definitions"
             @onChange="onColumnDefinitions" />
         <FormRecordFieldDefinitions
             v-if="isRecordType"
-            :value="asToolState(toolState).fields || []"
+            :value="toolState.fields || []"
             @onChange="onRecordFieldDefinitions" />
     </div>
 </template>


### PR DESCRIPTION
Fixes the `test_collection_input_sample_sheet_chipseq_example*` Selenium failures that have hit most dev and PR runs since 2026-09-03 (first red dev run: 33791527970; e.g. #23512's run 34613432885). Release branches are not affected.

## What was wrong

All three tests build a workflow input by typing `sample_sheet:paired` into the collection type field of the editor's collection input form and then adding column definitions. On CI the saved type came out as `sample_sheet` (`test_workflow_editor.py::test_collection_input_sample_sheet_chipseq_example` asserts exactly that), and the two `test_workflow_run.py` tests fail downstream of it: a flat sheet with 16 rows instead of 8 pairs, and a collection picker that filters out the `list:paired` collection.

Every edit in that form is sent to `build_module` as a full snapshot through the editor's `LastQueue` (one request per second, newest wins), and the step store is only updated from the response. The form snapshotted the *store* on every edit, so when `build_module` was slow enough for the `sample_sheet` request to be echoed while `sample_sheet:paired` was still queued, the first column-definition edit carried the stale `sample_sheet` and, being the newest request, dropped the `:paired` one. A human on a slow server hits the same thing.

Locally the server answers in ~15 ms and the tests pass; with 700 ms of emulated network latency (`Network.emulateNetworkConditions`) the failure reproduces 2/2 with the exact CI assertion, and passes 2/2 with this change.

## Change

`FormInputCollection` now owns its values like `FormDisplay` does for tool steps: seeded from the step on mount and updated on every edit, so every snapshot carries the latest values. `FormDefault` keys it on the editor's `formKey` (as it already does for `FormDisplay`) so undo and redo remount and re-seed it. That re-keying also fixes a pre-existing problem: `FormDefault` resets its "ignore the initial change" guard on every form key bump, but this form never remounted, so the first edit after an undo was silently dropped.

Follow-ups deliberately not in this PR:
- `FormPickValue` has the same store-snapshot pattern (`cleanToolState()` on every emit) and the same latent race.
- `Index.vue` `onSetData` enqueues without a key, so all steps share one `LastQueue` slot; an edit queued for step A is dropped when step B is edited.
- The inspector shows nothing while a `build_module` request is pending or queued; only the node shows a spinner, and only while the request is in flight.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In the workflow editor add a "Input Dataset Collection" step, throttle the network in devtools (Slow 4G), type `sample_sheet:paired` as collection type and immediately add a column definition.
  2. Save and download the workflow: `collection_type` must be `sample_sheet:paired`. On dev it comes back as `sample_sheet`.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
