### PR TITLE
[25.1] Use pydantic-aware serializer for celery control replies

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -40,6 +40,13 @@ MAIN_TASK_MODULE = "galaxy.celery.tasks"
 DEFAULT_TASK_QUEUE = "galaxy.internal"
 TASKS_MODULES = [MAIN_TASK_MODULE]
 PYDANTIC_AWARE_SERIALIZER_NAME = "pydantic-aware-json"
+# task_serializer also serializes control (pidbox) replies, which echo task arguments.
+CELERY_APP_DEFAULTS: dict[str, Any] = {
+    "task_default_queue": DEFAULT_TASK_QUEUE,
+    "task_create_missing_queues": True,
+    "task_serializer": PYDANTIC_AWARE_SERIALIZER_NAME,
+    "timezone": "UTC",
+}
 
 APP_LOCAL = local()
 
@@ -200,13 +207,7 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
 
 
 def init_celery_app():
-    celery_app_kwd: dict[str, Any] = {
-        "include": TASKS_MODULES,
-        "task_default_queue": DEFAULT_TASK_QUEUE,
-        "task_create_missing_queues": True,
-        "timezone": "UTC",
-    }
-    celery_app = GalaxyCelery("galaxy", **celery_app_kwd)
+    celery_app = GalaxyCelery("galaxy", include=TASKS_MODULES, **CELERY_APP_DEFAULTS)
     celery_app.set_default()
     config = get_config()
     config_celery_app(config, celery_app)

--- a/lib/galaxy_test/api/conftest.py
+++ b/lib/galaxy_test/api/conftest.py
@@ -10,6 +10,7 @@ from typing import (
 
 import pytest
 
+from galaxy.celery import CELERY_APP_DEFAULTS
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.api import (
     AnonymousGalaxyInteractor,
@@ -107,10 +108,7 @@ def celery_worker_parameters():
 
 @pytest.fixture(scope="session")
 def celery_parameters():
-    return {
-        "task_create_missing_queues": True,
-        "task_default_queue": "galaxy.internal",
-    }
+    return CELERY_APP_DEFAULTS
 
 
 @pytest.fixture

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 from typing_extensions import Protocol
 
+from galaxy.celery import CELERY_APP_DEFAULTS
 from galaxy.util.properties import get_from_env
 from .api_asserts import (
     assert_error_code_is,
@@ -78,10 +79,7 @@ class UsesCeleryTasks:
 
     @pytest.fixture(scope="session")
     def celery_parameters(self):
-        return {
-            "task_create_missing_queues": True,
-            "task_default_queue": "galaxy.internal",
-        }
+        return CELERY_APP_DEFAULTS
 
 
 class HasAnonymousGalaxyInteractor(Protocol):

--- a/test/integration/test_celery_inspect_pydantic_args.py
+++ b/test/integration/test_celery_inspect_pydantic_args.py
@@ -1,0 +1,32 @@
+from celery import current_app
+
+from galaxy.celery import galaxy_task
+from galaxy.schema.tasks import PurgeDatasetsTaskRequest
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+@galaxy_task
+def echo_pydantic_request(request: PurgeDatasetsTaskRequest):
+    return request.dataset_ids
+
+
+class TestCeleryInspectPydanticArgsIntegration(IntegrationTestCase):
+    """Worker replies to inspect() commands must be able to encode pydantic task arguments.
+
+    Uses scheduled() rather than active(): the test worker's solo pool cannot answer
+    control commands while a task runs. Both replies carry the same Request.info() payload.
+    """
+
+    def test_inspect_scheduled_with_pydantic_task_args(self):
+        inspect = current_app.control.inspect(timeout=3)
+        assert inspect.ping(), "worker does not answer control commands at all"
+        request = PurgeDatasetsTaskRequest(dataset_ids=[1, 2])
+        result = echo_pydantic_request.apply_async(kwargs={"request": request}, countdown=15)
+        scheduled_response = inspect.scheduled()
+        assert scheduled_response, "worker did not answer the scheduled() control command"
+        scheduled_requests = {
+            entry["request"]["id"]: entry["request"] for entries in scheduled_response.values() for entry in entries
+        }
+        assert result.id in scheduled_requests, f"task {result.id} missing from {scheduled_response}"
+        assert scheduled_requests[result.id]["kwargs"]["request"] == request
+        assert result.get(timeout=60) == [1, 2]

--- a/test/unit/app/test_celery.py
+++ b/test/unit/app/test_celery.py
@@ -2,6 +2,7 @@ from galaxy.celery import (
     celery_app,
     DEFAULT_TASK_QUEUE,
     GalaxyCelery,
+    PYDANTIC_AWARE_SERIALIZER_NAME,
     TASKS_MODULES,
 )
 from galaxy.config import GalaxyAppConfiguration
@@ -15,6 +16,7 @@ def test_default_configuration():
     assert conf.include == TASKS_MODULES
     assert conf.task_create_missing_queues is True
     assert conf.timezone == "UTC"
+    assert conf.task_serializer == PYDANTIC_AWARE_SERIALIZER_NAME
     assert conf.broker_url == galaxy_conf.amqp_internal_connection
     assert conf.task_routes["galaxy.fetch_data"] == "galaxy.external"
     assert conf.task_routes["galaxy.set_job_metadata"] == "galaxy.external"


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/23440
Fixes GALAXY-MAIN-4KSCZZZ00192B

A production worker logged

```
Control command error: EncodeError(TypeError('Object of type PurgeHistoryDatasetsTaskRequest is not JSON serializable'))
```

from `celery.worker.pidbox` while answering an `inspect active` control command. The worker had deserialized the task's pydantic argument with Galaxy's pydantic-aware serializer, but the control mailbox that carries inspect replies uses `task_serializer`, which was still the default `json`. Replies to `active` and `scheduled` include the deserialized arguments, so encoding them failed and the reply was never sent. The client only sees a timeout and an empty result, which anything that asks workers what is running (the celery CLI, Flower, or Galaxy's own stale-task cleanup in newer releases) misreads as "nothing is running".

This defaults `task_serializer` to the pydantic-aware serializer so control replies can carry the same payloads as task messages, and shares the app defaults with the test harness's session app so the embedded worker behaves the same way.

The integration test reproduces via `scheduled` with a countdown task, because the test worker's solo pool cannot answer control commands while a task executes. With the fix reverted the test fails and the worker logs the same `EncodeError` as in the Sentry event.

Targets release_25.1 as the oldest supported release with pydantic task arguments.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
