### PR TITLE
[26.1] Keep the center GalaxyAI view mounted across its own route changes

### DIFF
--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -47,6 +47,14 @@ const isNoPaddingPath = computed(() => {
     );
 });
 
+/**
+ * Every `/galaxyai` route renders one and the same GalaxyAI instance: it rewrites its own route as a
+ * conversation is created (`/galaxyai` to `/galaxyai/<id>`) or reset (`/galaxyai/new`) and follows
+ * those changes through its `exchangeId` prop, so the live conversation stays in place. All other
+ * routes get a fresh component per path.
+ */
+const routerViewKey = computed(() => (route.path.startsWith("/galaxyai") ? "/galaxyai" : route.fullPath));
+
 const showCenter = ref(false);
 const { showPanels } = usePanels();
 
@@ -86,7 +94,7 @@ onUnmounted(() => {
             <div class="flex-grow-1 overflow-auto" :class="{ 'p-3': !isNoPaddingPath }" style="min-height: 0">
                 <CenterFrame v-show="showCenter" id="galaxy_main" @load="onLoad" />
                 <div v-show="!showCenter" class="h-100">
-                    <router-view :key="$route.fullPath" class="h-100" />
+                    <router-view :key="routerViewKey" class="h-100" />
                 </div>
             </div>
             <ChatPanel v-if="isBottomPanelOpen" />


### PR DESCRIPTION
Fixes `lib/galaxy_test/selenium/test_galaxyai.py::TestGalaxyAI::test_delete_chats_via_selection`, which has failed in every "Playwright tests" run on `dev` since 7472934ff2 (2026-09-12), always with

```
playwright._impl._errors.TimeoutError: Timeout waiting on CSS selector [.system-notice] to become visible.
```

`Analysis.vue` keys the center `router-view` by `$route.fullPath`, so every path change destroys and recreates the center component. `GalaxyAI.vue` rewrites its own route once the first reply lands (`/galaxyai` to `/galaxyai/<id>`), after awaiting a chat history refresh. That navigation remounted the chat: the fresh instance started with no messages and re-fetched the conversation from the server, discarding the live state and never firing the component's `exchangeId` watcher, which already handles self-initiated route changes.

In the Playwright suite this made the test fail whenever the history refresh was slow: the remount landed while `galaxyai_ensure_new_chat` was inspecting the page, it saw zero query cells, skipped the "New Chat" click, and then waited on a welcome notice that the re-fetched conversation never renders. The CI DOM, page URL (`/galaxyai/<id>`) and server log (`GET /api/chat/exchange/<id>/messages` right after the history refresh) all match this sequence, and it reproduces locally by delaying the `/api/chat/history` response by ~1.5 s. It is also a user-visible defect: a second message typed quickly after the first reply was thrown away by the remount.

This gives all `/galaxyai` routes a single `router-view` key so the component follows route changes through its props, as the docked and panel instances already do. Only this test hits the window because it clicks "New Chat" right after the first message of a conversation.

One behaviour changes: browser back from `/galaxyai/<id>` to bare `/galaxyai` used to remount and reload the latest chat. The prop watcher now receives an undefined id and starts a new chat instead. Moving between two ids or to `/galaxyai/new` behaves as before.

Targets `release_26.1` because both the route key and the chat's route sync are on that branch; the resume guard from #23316 that narrows a related variant is on `dev` only.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open GalaxyAI in the center panel, send a message, and start typing a second one immediately: the draft and the conversation stay in place while the URL changes to `/galaxyai/<id>`.
  2. `GALAXY_TEST_DRIVER_BACKEND=playwright ./run_tests.sh -playwright lib/galaxy_test/selenium/test_galaxyai.py` passes (3 of 3 runs locally).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
