### PR TITLE
[26.1] Report datasets left shared when making a history private

### DIFF
--- a/client/src/components/History/HistoryMakePrivate.vue
+++ b/client/src/components/History/HistoryMakePrivate.vue
@@ -27,14 +27,22 @@ async function makeHistoryPrivate() {
         if (!history.value) {
             throw new Error("History not found");
         }
-        const { sharingStatusChanged } = await historyStore.secureHistory(history.value);
+        const { sharingStatusChanged, skippedDatasets } = await historyStore.secureHistory(history.value);
         Toast.success(
             localize(
-                "Existing data in this history is now private, as well as any new data created in this history. \
+                "Your data in this history is now private, as well as any new data created in this history. \
                 Your sharing preferences have also been reset.",
             ),
             localize("Successfully made history private."),
         );
+        if (skippedDatasets > 0) {
+            Toast.warning(
+                `${skippedDatasets} ${localize(
+                    "dataset(s) in this history belong to another user and remain accessible to others.",
+                )}`,
+                localize("Some datasets were not made private."),
+            );
+        }
         emit("history-made-private", sharingStatusChanged);
     } catch (error) {
         Toast.error(errorMessageAsString(error), localize("An error occurred while making the history private."));
@@ -51,9 +59,10 @@ async function makeHistoryPrivate() {
         </template>
 
         <p v-localize>
-            This will make all the data in this history private (excluding library datasets), and will set permissions
-            such that all new data is created as private. Any datasets within that are currently shared will need to be
-            re-shared or published. Are you sure you want to do this?
+            This will make the datasets you own in this history private (excluding library datasets), and will set
+            permissions such that all new data is created as private. Datasets that belong to another user, for example
+            those in a history you imported, stay as they are. Any datasets within that are currently shared will need
+            to be re-shared or published. Are you sure you want to do this?
         </p>
 
         <AsyncButton

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -533,11 +533,14 @@ export const useHistoryStore = defineStore("historyStore", () => {
         }
     }
 
-    async function secureHistory(history: HistorySummary): Promise<{ sharingStatusChanged: boolean }> {
-        const { securedHistory, sharingStatusChanged } = await secureHistoryOnServer(history);
+    async function secureHistory(
+        history: HistorySummary,
+    ): Promise<{ sharingStatusChanged: boolean; skippedDatasets: number }> {
+        const { securedHistory, sharingStatusChanged, skippedDatasets } = await secureHistoryOnServer(history);
         setHistory(securedHistory);
         return {
             sharingStatusChanged,
+            skippedDatasets,
         };
     }
 

--- a/client/src/stores/services/history.services.ts
+++ b/client/src/stores/services/history.services.ts
@@ -135,6 +135,7 @@ export async function secureHistoryOnServer(history: AnyHistory) {
         securedHistory: result.data,
         message: response.data.message as string,
         sharingStatusChanged: response.data.sharing_status_changed as boolean,
+        skippedDatasets: response.data.skipped_datasets as number,
     };
 }
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -521,6 +521,44 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
                 else:
                     log.warning(f"User without permissions tried to make dataset with id: {dataset.id} public")
 
+    def make_private(self, trans: ProvidesUserContext, histories: list[model.History]) -> int:
+        """Make the datasets in ``histories`` private and set private default permissions.
+
+        Permissions live on the dataset, not on the history association, so a
+        dataset that the user cannot manage (typically one shared from another
+        user's history through an import) is left untouched. Returns the number
+        of such datasets that stayed shared.
+        """
+        user = trans.user
+        assert user
+        security_agent = self.app.security_agent
+        private_role = security_agent.get_private_user_role(user)
+        private_permissions = {
+            security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS: [private_role],
+            security_agent.permitted_actions.DATASET_ACCESS: [private_role],
+        }
+        user_roles = user.all_roles()
+        seen_datasets: set[int] = set()
+        skipped_datasets: set[int] = set()
+
+        for history in histories:
+            security_agent.history_set_default_permissions(history, private_permissions)
+            for hda in history.datasets:
+                dataset = hda.dataset
+                assert dataset
+                if dataset.id in seen_datasets:
+                    continue
+                seen_datasets.add(dataset.id)
+                if dataset.library_associations or security_agent.dataset_is_private_to_user(trans, dataset):
+                    continue
+                if not security_agent.can_manage_dataset(user_roles, dataset):
+                    skipped_datasets.add(dataset.id)
+                    continue
+                security_agent.set_all_dataset_permissions(dataset, private_permissions, flush=False)
+
+        self.session().commit()
+        return len(skipped_datasets)
+
     def archive_history(self, history: model.History, archive_export_id: Optional[int]):
         """Marks the history with the given id as archived and optionally associates it with the given archive export record.
 

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -197,30 +197,16 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                 histories.append(history)
         if not histories:
             raise exceptions.RequestParameterMissingException("No history or histories specified.")
-        private_role = trans.app.security_agent.get_private_user_role(trans.user)
-        user_roles = trans.user.all_roles()
-        private_permissions = {
-            trans.app.security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS: [private_role],
-            trans.app.security_agent.permitted_actions.DATASET_ACCESS: [private_role],
-        }
+        skipped_datasets = self.history_manager.make_private(trans, histories)
+        sharing_status_changed = False
         for history in histories:
-            # Set default role for history to private
-            trans.app.security_agent.history_set_default_permissions(history, private_permissions)
-            # Set private role for all datasets
-            for hda in history.datasets:
-                if (
-                    not hda.dataset.library_associations
-                    and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
-                    and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)
-                ):
-                    # If it's not private to me, and I can manage it, set fixed private permissions.
-                    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
-
             importable = history.importable
             link_access = self.service.shareable_service.disable_link_access(trans, history.id)
+            sharing_status_changed = sharing_status_changed or importable != link_access.importable
         return {
             "message": f"Success, requested permissions have been changed in {'all histories' if all_histories else history.name}.",
-            "sharing_status_changed": importable != link_access.importable,
+            "sharing_status_changed": sharing_status_changed,
+            "skipped_datasets": skipped_datasets,
         }
 
     # ......................................................................... actions/orig. async

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -1,3 +1,4 @@
+import re
 import time
 from typing import ClassVar
 from unittest import SkipTest
@@ -8,6 +9,7 @@ import pytest
 from requests import (
     post,
     put,
+    Session,
 )
 
 from galaxy.model.unittest_utils.store_fixtures import (
@@ -18,11 +20,13 @@ from galaxy_test.api.sharable import SharingApiTests
 from galaxy_test.base.api_asserts import assert_has_keys
 from galaxy_test.base.decorators import (
     requires_admin,
+    requires_new_library,
     requires_new_user,
 )
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
+    LibraryPopulator,
     skip_without_tool,
 )
 from ._framework import ApiTestCase
@@ -1024,6 +1028,7 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
 
     @requires_new_user
     def test_sharing_with_private_datasets(self):
@@ -1145,6 +1150,73 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
             self._assert_status_code_is(show_response, 200)
             hda = show_response.json()
             assert hda["id"] == hda_id
+
+    @requires_new_library
+    @requires_new_user
+    def test_make_private_imported_history(self):
+        source_history_id = self.dataset_populator.new_history()
+        source_hdas = [
+            self.dataset_populator.new_dataset(source_history_id, content=content, wait=True)
+            for content in ("source dataset one", "source dataset two")
+        ]
+        library_dataset = self.library_populator.new_library_dataset("source library dataset")
+        library_copy_response = self._post(
+            f"histories/{source_history_id}/contents",
+            data={"content": library_dataset["id"], "source": "library", "type": "dataset"},
+            json=True,
+        )
+        library_copy_response.raise_for_status()
+        source_library_hda = library_copy_response.json()
+        self.dataset_populator.make_dataset_public_raw(source_history_id, source_library_hda["id"]).raise_for_status()
+        self.dataset_populator.make_public(source_history_id)
+
+        with self._different_user():
+            importer_email = self._get("users/current").json()["email"]
+            copied_history_response = self.dataset_populator.copy_history(source_history_id)
+            copied_history_response.raise_for_status()
+            copied_history_id = copied_history_response.json()["id"]
+            imported_hdas = self.dataset_populator.get_history_contents(copied_history_id)
+            importer_hda = self.dataset_populator.new_dataset(copied_history_id, content="importer dataset", wait=True)
+
+            make_private_response = self._make_history_private_as_browser(importer_email, copied_history_id)
+            # the two imported datasets belong to the source user, the library dataset is not counted
+            assert make_private_response["skipped_datasets"] == len(source_hdas)
+
+            for imported_hda, source_hda in zip(imported_hdas, source_hdas):
+                imported_details = self._get(f"datasets/{imported_hda['id']}")
+                self._assert_status_code_is(imported_details, 200)
+                assert imported_details.json()["dataset_id"] == source_hda["dataset_id"]
+            self._assert_status_code_is(self._get(f"datasets/{importer_hda['id']}"), 200)
+
+            with self._different_user("unrelated-user@test.galaxyproject.org"):
+                for hda in imported_hdas:
+                    self._assert_status_code_is(self._get(f"datasets/{hda['id']}"), 200)
+                self._assert_status_code_is(self._get(f"datasets/{importer_hda['id']}"), 403)
+
+        source_history = self._show(source_history_id)
+        assert source_history["published"] is True
+        with self._different_user("unrelated-user@test.galaxyproject.org"):
+            for hda in [*source_hdas, source_library_hda]:
+                self._assert_status_code_is(self._get(f"datasets/{hda['id']}"), 200)
+
+    def _make_history_private_as_browser(self, email: str, history_id: str) -> dict:
+        # history/make_private is a legacy controller route outside /api, so it
+        # only accepts a browser session, not an API key.
+        with Session() as session:
+            login_page = session.get(urljoin(self.url, "login/start"))
+            self._assert_status_code_is(login_page, 200)
+            csrf_token_match = re.search(r'session_csrf_token = "(.*)"', login_page.text)
+            assert csrf_token_match
+            login_response = session.post(
+                urljoin(self.url, "user/login"),
+                data={"login": email, "password": "testpass", "session_csrf_token": csrf_token_match.group(1)},
+            )
+            self._assert_status_code_is(login_response, 200)
+            make_private_response = session.post(
+                urljoin(self.url, "history/make_private"), data={"history_id": history_id}
+            )
+            self._assert_status_code_is(make_private_response, 200)
+            return make_private_response.json()
 
     def _share_history_with_payload(self, history_id, payload):
         sharing_response = self._put(f"histories/{history_id}/share_with_users", data=payload, json=True)

--- a/test/unit/webapps/test_make_histories_private.py
+++ b/test/unit/webapps/test_make_histories_private.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
+from galaxy.managers.histories import HistoryManager
 from galaxy.managers.users import UserManager
 from galaxy.util.unittest import TestCase
 from galaxy.webapps.galaxy.controllers.history import HistoryController
@@ -33,6 +34,7 @@ class TestMakeHistoriesPrivateController(TestCase):
         self.app.model.session.commit()
 
         controller = HistoryController(self.app)
+        controller.history_manager = self.app[HistoryManager]
         mock_link_access = MagicMock()
         mock_link_access.importable = False
         controller.service = MagicMock()
@@ -41,6 +43,13 @@ class TestMakeHistoriesPrivateController(TestCase):
         result = json.loads(controller.make_private(self.trans, all_histories=True))
 
         assert "all histories" in result["message"]
+        private_role = self.app.security_agent.get_private_user_role(self.user)
+        for history in (history1, history2):
+            assert {permission.role for permission in history.default_permissions} == {private_role}
+            assert {permission.action for permission in history.default_permissions} == {
+                model.Dataset.permitted_actions.DATASET_ACCESS.action,
+                model.Dataset.permitted_actions.DATASET_MANAGE_PERMISSIONS.action,
+            }
 
         calls = controller.service.shareable_service.disable_link_access.call_args_list
         called_ids = [call.args[1] for call in calls]


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19644

Permissions live on the dataset, not on the history association. When a user imports a public history the copied HDAs point at the original owner's Dataset rows, so "Make private" on the imported history cannot touch them without also revoking the owner's access to their own data. Those datasets were silently skipped while the confirmation dialog promised that all data in the history would become private, which is the confusion reported in the issue.

This PR says what actually happens instead:

- The dialog states that only the datasets you own become private and that datasets belonging to another user stay as they are.
- The endpoint counts the datasets it had to skip and returns that as `skipped_datasets`. The history panel shows a warning with the count after the action, so the user can see why some data is still accessible.
- The permission logic moves from the legacy `HistoryController` into `HistoryManager.make_private`. Each dataset is processed once even when several HDAs point at it, and permissions are committed once at the end instead of per dataset.
- `sharing_status_changed` now reflects all histories in the all-histories path instead of the last one iterated.

An earlier iteration of this branch copied the shared datasets into new private Dataset rows instead. That delivered what the old dialog promised, but doubled storage for every imported dataset and ran the copies synchronously in the request, so it was dropped in favour of honest messaging.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. As user A, create a history with a couple of datasets and publish it.
  2. As user B, import the history, add a dataset of your own, then open the history's sharing panel and use "Make History Private".
  3. The dialog text says only datasets you own become private. After confirming, a warning toast reports that two datasets belong to another user and remain accessible. User B's own dataset is private, the imported ones are still accessible, and user A's history is unchanged.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
