### PR TITLE
Merge release_26.1 into dev

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -46,6 +46,7 @@ RUN set -xe; \
         libc-dev \
         bzip2 \
         gcc \
+        zlib1g-dev \
     && pip install --no-cache virtualenv ansible==11.11.0 \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/client/src/components/ScrollList/ScrollList.test.ts
+++ b/client/src/components/ScrollList/ScrollList.test.ts
@@ -141,6 +141,27 @@ describe("ScrollList with local loader and data", () => {
         expect(testLoader).toHaveBeenCalledTimes(Math.ceil(TOTAL_ITEMS / BUFFER_SIZE));
     });
 
+    it("stops auto-retrying on error until the user clicks Load More", async () => {
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(1);
+
+        // Next load fails
+        testLoader.mockRejectedValueOnce(new Error("Boom"));
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(2);
+
+        // Further scrolling must NOT retry automatically
+        await scrollOnce();
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(2);
+
+        // Clicking "Load More" clears the error and retries
+        await wrapper.find(LOAD_MORE_BUTTON).trigger("click");
+        await nextTick();
+        expect(testLoader).toHaveBeenCalledTimes(3);
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(BUFFER_SIZE * 2);
+    });
+
     it("shows item count and total items", async () => {
         await scrollOnce();
         expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE} out of ${TOTAL_ITEMS} ${ITEM_NAME_PLURAL}`);

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -2,15 +2,20 @@
 import { faArrowDown, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
-import { BAlert, BListGroup } from "bootstrap-vue";
+import { BListGroup } from "bootstrap-vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
+import { useToast } from "@/composables/toast";
+import { errorMessageAsString } from "@/utils/simple-error";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ScrollToTopButton from "@/components/ToolsList/ScrollToTopButton.vue";
+
+const CLICK_TO_RETRY_MSG = "Click on the button at the bottom of the list to retry." as const;
 
 interface LoaderResult<T> {
     items: T[];
@@ -70,6 +75,8 @@ const emit = defineEmits<{
     (e: "update:prop-scroll-top", value: number): void;
 }>();
 
+const Toast = useToast();
+
 const scrollableDiv = ref<HTMLElement | null>(null);
 
 // TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
@@ -124,8 +131,14 @@ const listEndText = computed<string>(() => {
 
 const allLoaded = computed(() => totalItemCount.value !== undefined && totalItemCount.value <= items.value.length);
 
-async function loadItems() {
-    if (!busy.value && !allLoaded.value && !props.loadDisabled) {
+async function loadItems(clearError = false) {
+    let msgCleared = false;
+    if (clearError) {
+        errorMessage.value = "";
+        msgCleared = true;
+    }
+
+    if (!busy.value && !allLoaded.value && !props.loadDisabled && !errorMessage.value) {
         try {
             if (props.loader === undefined && props.propItems === undefined) {
                 throw new Error("No loader function or propItems provided");
@@ -144,7 +157,12 @@ async function loadItems() {
             localTotalItemCount.value = total;
             errorMessage.value = "";
         } catch (e) {
-            errorMessage.value = `Failed to load items: ${e}`;
+            errorMessage.value = errorMessageAsString(e);
+            if (items.value.length > 0 || msgCleared) {
+                const errMsg = errorMessage.value;
+                const toastedMsg = `${errMsg}${errMsg.endsWith(".") ? "" : ". "}${CLICK_TO_RETRY_MSG}`;
+                Toast.error(toastedMsg, `Failed to load ${props.namePlural}`);
+            }
         } finally {
             localBusy.value = false;
         }
@@ -214,39 +232,42 @@ watch(
                     toolMenuContainer: inPanel,
                 }"
                 role="list">
-                <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
-                <template v-else>
-                    <slot v-if="items.length === 0" name="loading">
-                        <BAlert v-if="busy" variant="info" show>
+                <template v-if="items.length === 0">
+                    <GAlert v-if="errorMessage" variant="danger">
+                        <p>{{ errorMessage }}</p>
+                        <strong>{{ CLICK_TO_RETRY_MSG }}</strong>
+                    </GAlert>
+                    <slot name="loading">
+                        <GAlert v-if="busy" variant="info">
                             <LoadingSpan :message="`Loading ${props.namePlural}`" />
-                        </BAlert>
+                        </GAlert>
                     </slot>
-                    <component
-                        :is="props.gridView ? 'div' : BListGroup"
-                        class="pt-1"
-                        :class="{ 'card-list d-flex flex-wrap': props.gridView }">
-                        <!-- Use component wrapper with v-for to provide proper keying while avoiding layout interference -->
-                        <component
-                            :is="'div'"
-                            v-for="(item, index) in items"
-                            :key="itemKey(item)"
-                            style="display: contents">
-                            <slot name="item" :item="item" :index="index" />
-                        </component>
-
-                        <template v-if="!busy">
-                            <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
-                                <div class="list-end" data-description="no items found footer">
-                                    - No {{ props.namePlural }} found -
-                                </div>
-                            </slot>
-
-                            <slot v-else-if="allLoaded" name="all-loaded-footer">
-                                <div class="list-end">- {{ listEndText }} -</div>
-                            </slot>
-                        </template>
-                    </component>
                 </template>
+                <component
+                    :is="props.gridView ? 'div' : BListGroup"
+                    class="pt-1"
+                    :class="{ 'card-list d-flex flex-wrap': props.gridView }">
+                    <!-- Use component wrapper with v-for to provide proper keying while avoiding layout interference -->
+                    <component
+                        :is="'div'"
+                        v-for="(item, index) in items"
+                        :key="itemKey(item)"
+                        style="display: contents">
+                        <slot name="item" :item="item" :index="index" />
+                    </component>
+
+                    <template v-if="!busy">
+                        <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
+                            <div class="list-end" data-description="no items found footer">
+                                - No {{ props.namePlural }} found -
+                            </div>
+                        </slot>
+
+                        <slot v-else-if="allLoaded" name="all-loaded-footer">
+                            <div class="list-end">- {{ listEndText }} -</div>
+                        </slot>
+                    </template>
+                </component>
             </div>
             <ScrollToTopButton :offset="scrollTop" @click="scrollToTop" />
         </div>
@@ -264,7 +285,7 @@ watch(
                     :disabled="busy"
                     title="Load More"
                     transparent
-                    @click="loadItems()">
+                    @click="loadItems(true)">
                     <FontAwesomeIcon :icon="busy ? faSpinner : faArrowDown" :spin="busy" />
                 </GButton>
             </div>

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -276,7 +276,11 @@ watch(
                 v-if="!allLoaded"
                 class="mr-auto d-flex justify-content-center align-items-center"
                 :class="inPanel && 'mt-1'">
-                <i class="mr-1">Loaded {{ items.length }} out of {{ totalItemCount }} {{ props.namePlural }}</i>
+                <i class="mr-1">
+                    Loaded {{ items.length }}
+                    <span v-if="totalItemCount !== undefined">out of {{ totalItemCount }}</span>
+                    {{ props.namePlural }}
+                </i>
                 <GButton
                     v-if="!props.loadDisabled"
                     data-description="load more items button"

--- a/client/src/components/Tool/ToolSourceDisplay.vue
+++ b/client/src/components/Tool/ToolSourceDisplay.vue
@@ -62,6 +62,7 @@ export default {
 <style scoped>
 .editor-container {
     width: 100%;
-    height: 600px;
+    flex: 1 1 0;
+    min-height: 0;
 }
 </style>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -131,10 +131,8 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             :show.sync="showPreview"
             size="large"
             title="Workflow Preview"
-            hide-header
             fixed-height
-            class="workflow-card-preview-modal"
-            centered>
+            class="workflow-card-preview-modal">
             <template v-slot:header>
                 <WorkflowPublishedButtons
                     v-if="workflowPublished?.workflowInfo"
@@ -156,10 +154,6 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
 <style lang="scss">
 .workflow-card-preview-modal {
     max-width: min(1400px, calc(100% - 200px));
-
-    .modal-content {
-        height: min(800px, calc(100vh - 80px));
-    }
 }
 </style>
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -119,7 +119,7 @@ defineExpose({
     <div id="columns" class="workflow-published">
         <ActivityBar v-if="!props.embed && !props.quickView" />
 
-        <div id="center" class="container-root" :class="{ 'm-3': !props.quickView }">
+        <div id="center" class="container-root" :class="{ 'p-3': !props.quickView }">
             <div v-if="loading">
                 <Heading h1 separator size="lg">
                     <FontAwesomeIcon :icon="faSpinner" spin />

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -68,6 +68,8 @@ const initialPosition = computed(() => ({
 /** Workflow steps force typed as `Steps` from the `workflowStepStore` */
 const workflowSteps = computed(() => (workflow.value?.steps as unknown as Steps) ?? []);
 
+const showHeader = computed(() => props.showHeading || props.showButtons);
+
 async function load() {
     errorMessage.value = "";
 
@@ -131,8 +133,8 @@ defineExpose({
                     {{ errorMessage }}
                 </BAlert>
             </div>
-            <div v-else-if="workflowInfo" class="published-workflow">
-                <div v-if="props.showHeading || props.showButtons" class="workflow-header">
+            <div v-else-if="workflowInfo" class="published-workflow" :class="{ 'has-header': showHeader }">
+                <div v-if="showHeader" class="workflow-header">
                     <Heading v-if="props.showHeading" h1 separator inline size="lg" class="flex-grow-1 mb-0">
                         <span v-if="props.showAbout"> Workflow Preview </span>
                         <span v-else> {{ workflowInfo.name }} </span>
@@ -186,10 +188,14 @@ defineExpose({
         display: grid;
         gap: 0.5rem 1rem;
         grid-template-columns: minmax(0, 1fr) minmax(18rem, 30%);
-        grid-template-rows: auto minmax(0, 1fr);
+        grid-template-rows: minmax(0, 1fr);
 
         height: 100%;
         min-height: 0;
+
+        &.has-header {
+            grid-template-rows: auto minmax(0, 1fr);
+        }
 
         .workflow-header {
             grid-column: 1 / -1;

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -47,6 +47,14 @@ const isNoPaddingPath = computed(() => {
     );
 });
 
+/**
+ * Every `/galaxyai` route renders one and the same GalaxyAI instance: it rewrites its own route as a
+ * conversation is created (`/galaxyai` to `/galaxyai/<id>`) or reset (`/galaxyai/new`) and follows
+ * those changes through its `exchangeId` prop, so the live conversation stays in place. All other
+ * routes get a fresh component per path.
+ */
+const routerViewKey = computed(() => (route.path.startsWith("/galaxyai") ? "/galaxyai" : route.fullPath));
+
 const showCenter = ref(false);
 const { showPanels } = usePanels();
 
@@ -86,7 +94,7 @@ onUnmounted(() => {
             <div class="flex-grow-1 overflow-auto" :class="{ 'p-3': !isNoPaddingPath }" style="min-height: 0">
                 <CenterFrame v-show="showCenter" id="galaxy_main" @load="onLoad" />
                 <div v-show="!showCenter" class="h-100">
-                    <router-view :key="$route.fullPath" class="h-100" />
+                    <router-view :key="routerViewKey" class="h-100" />
                 </div>
             </div>
             <ChatPanel v-if="isBottomPanelOpen" />

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -40,6 +40,13 @@ MAIN_TASK_MODULE = "galaxy.celery.tasks"
 DEFAULT_TASK_QUEUE = "galaxy.internal"
 TASKS_MODULES = [MAIN_TASK_MODULE]
 PYDANTIC_AWARE_SERIALIZER_NAME = "pydantic-aware-json"
+# task_serializer also serializes control (pidbox) replies, which echo task arguments.
+CELERY_APP_DEFAULTS: dict[str, Any] = {
+    "task_default_queue": DEFAULT_TASK_QUEUE,
+    "task_create_missing_queues": True,
+    "task_serializer": PYDANTIC_AWARE_SERIALIZER_NAME,
+    "timezone": "UTC",
+}
 
 APP_LOCAL = local()
 
@@ -200,13 +207,7 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
 
 
 def init_celery_app():
-    celery_app_kwd: dict[str, Any] = {
-        "include": TASKS_MODULES,
-        "task_default_queue": DEFAULT_TASK_QUEUE,
-        "task_create_missing_queues": True,
-        "timezone": "UTC",
-    }
-    celery_app = GalaxyCelery("galaxy", **celery_app_kwd)
+    celery_app = GalaxyCelery("galaxy", include=TASKS_MODULES, **CELERY_APP_DEFAULTS)
     celery_app.set_default()
     config = get_config()
     config_celery_app(config, celery_app)

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,11 +1,13 @@
 import logging
 import os
 import shutil
+import tempfile
 from contextlib import contextmanager
 from datetime import datetime
 from typing import (
     Any,
     Dict,
+    Iterator,
     Optional,
 )
 
@@ -121,8 +123,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         file_ok = self._download(rel_path)
         if file_ok:
             fix_permissions(self.config, self._get_cache_path(rel_path_dir))
-        else:
-            unlink(self._get_cache_path(rel_path), ignore_errors=True)
         return file_ok
 
     def _get_data(self, obj, start=0, count=-1, **kwargs):
@@ -397,26 +397,26 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         raise NotImplementedError()
 
     @contextmanager
-    def _atomic_download(self, cache_path):
-        """Download to a temp file then atomically rename to prevent serving partial files.
-
-        Usage::
-
-            with self._atomic_download(local_destination) as tmp_path:
-                do_download(tmp_path)
-        """
-        tmp_path = cache_path + ".tmp"
+    def _atomic_download(self, cache_path: str, expected_size: Optional[int] = None) -> Iterator[str]:
+        """Yield a unique temporary path and publish it atomically after optional size validation."""
+        fd, tmp_path = tempfile.mkstemp(
+            dir=os.path.dirname(cache_path),
+            prefix=f".{os.path.basename(cache_path)}.",
+            suffix=".tmp",
+        )
+        os.close(fd)
+        os.unlink(tmp_path)
         try:
             yield tmp_path
-            os.rename(tmp_path, cache_path)
-        except BaseException:
-            # Catch BaseException (not just Exception) so that KeyboardInterrupt
-            # and SystemExit also trigger cleanup — we re-raise immediately, so
-            # propagation is not blocked. Without this, interrupted downloads
-            # leave .tmp files that poison the cache on next startup.
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            raise
+            downloaded_size = os.path.getsize(tmp_path)
+            if expected_size is not None and expected_size >= 0 and downloaded_size != expected_size:
+                raise OSError(
+                    f"downloaded object size does not match remote size for {cache_path}: "
+                    f"expected {expected_size}, got {downloaded_size}"
+                )
+            os.replace(tmp_path, cache_path)
+        finally:
+            unlink(tmp_path, ignore_errors=True)
 
     def _download(self, rel_path: str) -> bool:
         raise NotImplementedError()

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -34,22 +34,6 @@ log = logging.getLogger(__name__)
 logging.getLogger("boto").setLevel(logging.INFO)  # Otherwise boto is quite noisy
 
 
-def download_directory(bucket, remote_folder, local_path):
-    objects = bucket.list(prefix=remote_folder)
-    for obj in objects:
-        remote_file_path = obj.key
-        local_file_path = os.path.join(local_path, os.path.relpath(remote_file_path, remote_folder))
-        os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-        tmp_file_path = local_file_path + ".tmp"
-        try:
-            obj.get_contents_to_filename(tmp_file_path)
-            os.rename(tmp_file_path, local_file_path)
-        except Exception:
-            if os.path.exists(tmp_file_path):
-                os.remove(tmp_file_path)
-            raise
-
-
 def parse_config_xml(config_xml):
     try:
         a_xml = config_xml.findall("auth")[0]
@@ -317,11 +301,14 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)
                 url = key.generate_url(7200)
-                return self._axel_download(url, local_destination)
+                with self._atomic_download(local_destination, remote_size) as tmp:
+                    if not self._axel_download(url, tmp):
+                        raise OSError(f"Failed to download key '{rel_path}' with axel")
+                return True
             else:
                 log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
                 self.transfer_progress = 0  # Reset transfer progress counter
-                with self._atomic_download(local_destination) as tmp:
+                with self._atomic_download(local_destination, remote_size) as tmp:
                     key.get_contents_to_filename(tmp, cb=self._transfer_cb, num_cb=10)
                 return True
         except S3ResponseError:
@@ -406,7 +393,11 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             return False
 
     def _download_directory_into_cache(self, rel_path, cache_path):
-        download_directory(self._bucket, rel_path, cache_path)
+        for obj in self._bucket.list(prefix=rel_path):
+            local_file_path = os.path.join(cache_path, os.path.relpath(obj.key, rel_path))
+            os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
+            with self._atomic_download(local_file_path, obj.size) as tmp:
+                obj.get_contents_to_filename(tmp)
 
     def _get_object_url(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -327,10 +327,11 @@ class S3ObjectStore(CachingConcreteObjectStore):
         local_destination = self._get_cache_path(rel_path)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path):
+            remote_size = self._get_remote_size(rel_path)
+            if not self._caching_allowed(rel_path, remote_size):
                 return False
             config = self._transfer_config("download")
-            with self._atomic_download(local_destination) as tmp:
+            with self._atomic_download(local_destination, remote_size) as tmp:
                 self._client.download_file(self.bucket, rel_path, tmp, Config=config)
             return True
         except ClientError:
@@ -380,11 +381,18 @@ class S3ObjectStore(CachingConcreteObjectStore):
             for content in page.get("Contents", ()):
                 yield content["Key"]
 
+    def _keys_with_sizes(self, prefix: str):
+        s3_paginator = self._client.get_paginator("list_objects_v2")
+        prefix = prefix.lstrip("/")
+        for page in s3_paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for content in page.get("Contents", ()):
+                yield content["Key"], content["Size"]
+
     def _download_directory_into_cache(self, rel_path, cache_path):
-        for key in self._keys(rel_path):
+        for key, size in self._keys_with_sizes(rel_path):
             local_file_path = os.path.join(cache_path, os.path.relpath(key, rel_path))
             os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-            with self._atomic_download(local_file_path) as tmp:
+            with self._atomic_download(local_file_path, size) as tmp:
                 self._client.download_file(self.bucket, key, tmp)
 
     def _get_object_url(self, obj, **kwargs):

--- a/lib/galaxy_test/api/conftest.py
+++ b/lib/galaxy_test/api/conftest.py
@@ -10,6 +10,7 @@ from typing import (
 
 import pytest
 
+from galaxy.celery import CELERY_APP_DEFAULTS
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.api import (
     AnonymousGalaxyInteractor,
@@ -107,10 +108,7 @@ def celery_worker_parameters():
 
 @pytest.fixture(scope="session")
 def celery_parameters():
-    return {
-        "task_create_missing_queues": True,
-        "task_default_queue": "galaxy.internal",
-    }
+    return CELERY_APP_DEFAULTS
 
 
 @pytest.fixture

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 from typing_extensions import Protocol
 
+from galaxy.celery import CELERY_APP_DEFAULTS
 from galaxy.util.properties import get_from_env
 from .api_asserts import (
     assert_error_code_is,
@@ -78,10 +79,7 @@ class UsesCeleryTasks:
 
     @pytest.fixture(scope="session")
     def celery_parameters(self):
-        return {
-            "task_create_missing_queues": True,
-            "task_default_queue": "galaxy.internal",
-        }
+        return CELERY_APP_DEFAULTS
 
 
 class HasAnonymousGalaxyInteractor(Protocol):

--- a/test/integration/test_celery_inspect_pydantic_args.py
+++ b/test/integration/test_celery_inspect_pydantic_args.py
@@ -1,0 +1,32 @@
+from celery import current_app
+
+from galaxy.celery import galaxy_task
+from galaxy.schema.tasks import PurgeDatasetsTaskRequest
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+@galaxy_task
+def echo_pydantic_request(request: PurgeDatasetsTaskRequest):
+    return request.dataset_ids
+
+
+class TestCeleryInspectPydanticArgsIntegration(IntegrationTestCase):
+    """Worker replies to inspect() commands must be able to encode pydantic task arguments.
+
+    Uses scheduled() rather than active(): the test worker's solo pool cannot answer
+    control commands while a task runs. Both replies carry the same Request.info() payload.
+    """
+
+    def test_inspect_scheduled_with_pydantic_task_args(self):
+        inspect = current_app.control.inspect(timeout=3)
+        assert inspect.ping(), "worker does not answer control commands at all"
+        request = PurgeDatasetsTaskRequest(dataset_ids=[1, 2])
+        result = echo_pydantic_request.apply_async(kwargs={"request": request}, countdown=15)
+        scheduled_response = inspect.scheduled()
+        assert scheduled_response, "worker did not answer the scheduled() control command"
+        scheduled_requests = {
+            entry["request"]["id"]: entry["request"] for entries in scheduled_response.values() for entry in entries
+        }
+        assert result.id in scheduled_requests, f"task {result.id} missing from {scheduled_response}"
+        assert scheduled_requests[result.id]["kwargs"]["request"] == request
+        assert result.get(timeout=60) == [1, 2]

--- a/test/unit/app/test_celery.py
+++ b/test/unit/app/test_celery.py
@@ -2,6 +2,7 @@ from galaxy.celery import (
     celery_app,
     DEFAULT_TASK_QUEUE,
     GalaxyCelery,
+    PYDANTIC_AWARE_SERIALIZER_NAME,
     TASKS_MODULES,
 )
 from galaxy.config import GalaxyAppConfiguration
@@ -15,6 +16,7 @@ def test_default_configuration():
     assert conf.include == TASKS_MODULES
     assert conf.task_create_missing_queues is True
     assert conf.timezone == "UTC"
+    assert conf.task_serializer == PYDANTIC_AWARE_SERIALIZER_NAME
     assert conf.broker_url == galaxy_conf.amqp_internal_connection
     assert conf.task_routes["galaxy.fetch_data"] == "galaxy.external"
     assert conf.task_routes["galaxy.set_job_metadata"] == "galaxy.external"

--- a/test/unit/objectstore/test_s3_cache_download.py
+++ b/test/unit/objectstore/test_s3_cache_download.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from galaxy.objectstore.examples import get_example
+from galaxy.objectstore.s3 import S3ObjectStore
+from galaxy.objectstore.s3_boto3 import S3ObjectStore as Boto3ObjectStore
+from galaxy.objectstore.unittest_utils import Config as StoreConfig
+
+REMOTE_CONTENT = b"remote object content"
+BOTO3_CONFIG = """
+type: boto3
+auth:
+  access_key: access_moo
+  secret_key: secret_cow
+bucket:
+  name: unique_bucket_name_all_lowercase
+"""
+
+
+class UninitializedS3ObjectStore(S3ObjectStore):
+    def _initialize(self):
+        pass
+
+
+class UninitializedBoto3ObjectStore(Boto3ObjectStore):
+    def _initialize(self):
+        pass
+
+
+class FailedDownloadBoto3ObjectStore(UninitializedBoto3ObjectStore):
+    def _download(self, rel_path: str) -> bool:
+        return False
+
+
+@pytest.fixture
+def legacy_store():
+    pytest.importorskip("boto")
+    with StoreConfig(get_example("s3_global_cache.yml"), clazz=UninitializedS3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        store.use_axel = False
+        store._bucket = MagicMock()
+        yield store
+
+
+@pytest.fixture
+def boto3_store():
+    with StoreConfig(BOTO3_CONFIG, clazz=UninitializedBoto3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        store._client = MagicMock()
+        yield store
+
+
+def _serve_legacy_object(store, downloaded_content):
+    key = store._bucket.get_key.return_value
+    key.size = len(REMOTE_CONTENT)
+    key.get_contents_to_filename.side_effect = lambda filename, **_: Path(filename).write_bytes(downloaded_content)
+
+
+def _serve_boto3_object(store, downloaded_content, remote_size=len(REMOTE_CONTENT)):
+    store._client.head_object.return_value = {"ContentLength": remote_size}
+    store._client.download_file.side_effect = lambda _bucket, _key, filename, **_: Path(filename).write_bytes(
+        downloaded_content
+    )
+
+
+def _cache(store) -> Path:
+    return Path(store.staging_path)
+
+
+def _assert_nothing_published(store, rel_path="object"):
+    assert not (_cache(store) / rel_path).exists()
+    assert not list(_cache(store).rglob("*.tmp"))
+
+
+def test_legacy_s3_does_not_publish_truncated_download(legacy_store):
+    _serve_legacy_object(legacy_store, REMOTE_CONTENT[:5])
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        legacy_store._download("object")
+
+    _assert_nothing_published(legacy_store)
+
+
+def test_boto3_does_not_publish_empty_download_for_nonempty_object(boto3_store):
+    _serve_boto3_object(boto3_store, b"")
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        boto3_store._download("object")
+
+    _assert_nothing_published(boto3_store)
+
+
+def test_boto3_preserves_legitimate_empty_remote_object(boto3_store):
+    _serve_boto3_object(boto3_store, b"", remote_size=0)
+
+    assert boto3_store._download("object")
+    assert (_cache(boto3_store) / "object").read_bytes() == b""
+
+
+def test_legacy_s3_axel_download_is_size_checked(legacy_store, monkeypatch):
+    legacy_store.use_axel = True
+    legacy_store._bucket.get_key.return_value.size = len(REMOTE_CONTENT)
+    legacy_store._bucket.get_key.return_value.generate_url.return_value = "https://example.org/object"
+
+    def axel_download_that_writes_nothing(_url, path):
+        Path(path).write_bytes(b"")
+        return True
+
+    monkeypatch.setattr(legacy_store, "_axel_download", axel_download_that_writes_nothing)
+
+    with pytest.raises(OSError, match="downloaded object size"):
+        legacy_store._download("object")
+
+    _assert_nothing_published(legacy_store)
+
+
+def test_interrupted_download_cleans_temporary_file(boto3_store):
+    cache_path = str(_cache(boto3_store) / "object")
+
+    with pytest.raises(KeyboardInterrupt):
+        with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as tmp:
+            Path(tmp).write_bytes(REMOTE_CONTENT[:5])
+            raise KeyboardInterrupt()
+
+    _assert_nothing_published(boto3_store)
+
+
+def test_failed_download_does_not_remove_concurrently_published_file():
+    with StoreConfig(BOTO3_CONFIG, clazz=FailedDownloadBoto3ObjectStore) as (_, store):
+        store._ensure_staging_path_writable()
+        (_cache(store) / "object").write_bytes(REMOTE_CONTENT)
+
+        assert not store._pull_into_cache("object")
+        assert (_cache(store) / "object").read_bytes() == REMOTE_CONTENT
+
+
+def test_concurrent_downloads_use_distinct_temp_files_and_failure_cannot_replace_success(boto3_store):
+    cache_path = str(_cache(boto3_store) / "object")
+
+    with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as first_tmp:
+        with pytest.raises(OSError, match="downloaded object size"):
+            with boto3_store._atomic_download(cache_path, len(REMOTE_CONTENT)) as second_tmp:
+                assert second_tmp != first_tmp
+                Path(second_tmp).write_bytes(REMOTE_CONTENT[:5])
+        Path(first_tmp).write_bytes(REMOTE_CONTENT)
+
+    assert (_cache(boto3_store) / "object").read_bytes() == REMOTE_CONTENT
+    assert not list(_cache(boto3_store).rglob("*.tmp"))
+
+
+def test_boto3_directory_download_uses_listed_sizes_without_head_requests(boto3_store):
+    contents = {"dataset_1_files/a.txt": REMOTE_CONTENT, "dataset_1_files/sub/b.txt": b""}
+    boto3_store._client.get_paginator.return_value.paginate.return_value = [
+        {"Contents": [{"Key": key, "Size": len(content)} for key, content in contents.items()]}
+    ]
+    boto3_store._client.download_file.side_effect = lambda _bucket, key, filename, **_: Path(filename).write_bytes(
+        contents[key]
+    )
+    cache_dir = _cache(boto3_store) / "dataset_1_files"
+
+    boto3_store._download_directory_into_cache("dataset_1_files", str(cache_dir))
+
+    boto3_store._client.head_object.assert_not_called()
+    assert (cache_dir / "a.txt").read_bytes() == REMOTE_CONTENT
+    assert (cache_dir / "sub" / "b.txt").read_bytes() == b""
+    assert not list(_cache(boto3_store).rglob("*.tmp"))


### PR DESCRIPTION
Merge `release_26.1` into `dev` to bring in the S3 cache download, Celery control serialization, ScrollList retry, GalaxyAI route persistence, and workflow/tool-source modal fixes.

The S3 conflict resolution preserves dev's cache-shard routing, unique temporary files, and streaming cleanup while adding remote-size validation and protecting concurrently published cache files. The incoming S3 regression tests now use dev's object-ID-aware cache API.

## How to test the changes?
- [x] Includes automated regression tests.
- `tox -e lint,format,mypy`: passed against a clean snapshot of the staged merge, excluding unrelated local scratch files.
- Object-store and Celery unit tests: 127 passed, 14 skipped (optional remote-service tests and unavailable legacy boto).
- ScrollList and GalaxyAI route-sync client tests: 8 passed.
- Reviewed incoming commit messages and merge changes; no remaining conflict markers or whitespace errors.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
