### PR TITLE
[25.1] Don't let extended metadata import set the live job's terminal state

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2136,9 +2136,11 @@ class MinimalJobWrapper(HasResourceParameters):
                     user=job.user,
                     tag_handler=self.app.tag_handler.create_tag_handler_session(job.galaxy_session),
                 )
-                import_model_store.perform_import(history=job.history, job=job)
-                if job.state == job.states.ERROR:
-                    final_job_state = job.state
+                object_import_tracker = import_model_store.perform_import(history=job.history, job=job)
+                # The import leaves job.state untouched so nothing polling the job can see it finish before
+                # exec_after_process and the final commit below have run.
+                if object_import_tracker.job_states_by_id.get(job.id) == job.states.ERROR:
+                    final_job_state = job.states.ERROR
             except store.FileTracebackException as e:
                 job.traceback = e.traceback
                 log.exception(f"Problem generating command line for Job {job.id}.\n{job.traceback}")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1288,12 +1288,19 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         # Create each job.
         history_sa_session = get_object_session(history)
         for job_attrs in jobs_attrs:
+            raw_state = job_attrs.get("state")
             if "id" in job_attrs and not self.sessionless:
                 # only thing we allow editing currently is associations for incoming jobs.
                 assert self.import_options.allow_edit
-                job = self.sa_session.get(model.Job, job_attrs["id"])
+                job_id = job_attrs["id"]
+                job = self.sa_session.get(model.Job, job_id)
                 self._connect_job_io(job, job_attrs, _find_hda, _find_hdca, _find_dce)  # type: ignore[attr-defined]
-                self._set_job_attributes(job, job_attrs, force_terminal=False)  # type: ignore[attr-defined]
+                self._set_job_attributes(job, job_attrs)  # type: ignore[attr-defined]
+                if raw_state:
+                    # An existing job is still being finished by its job wrapper, which must not observe
+                    # (or let API clients observe) a terminal state before it has run its post-processing.
+                    # Report the state instead and leave applying it to the caller.
+                    object_import_tracker.job_states_by_id[job_id] = raw_state
                 # Don't edit job
                 continue
 
@@ -1305,7 +1312,11 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             imported_job.imported = True
             imported_job.tool_id = job_attrs["tool_id"]
             imported_job.tool_version = job_attrs["tool_version"]
-            self._set_job_attributes(imported_job, job_attrs, force_terminal=True)  # type: ignore[attr-defined]
+            self._set_job_attributes(imported_job, job_attrs)  # type: ignore[attr-defined]
+            if raw_state:
+                if raw_state not in model.Job.terminal_states:
+                    raw_state = model.Job.states.ERROR
+                imported_job.set_state(raw_state)
 
             restore_times(imported_job, job_attrs)
             self._session_add(imported_job)
@@ -1427,6 +1438,7 @@ class ObjectImportTracker:
     hda_copied_from_sinks: dict[ObjectKeyType, ObjectKeyType]
     hdca_copied_from_sinks: dict[ObjectKeyType, ObjectKeyType]
     jobs_by_key: dict[ObjectKeyType, model.Job]
+    job_states_by_id: dict[int, str]
     requires_hid: list["HistoryItem"]
     copy_hid_for: list[tuple["HistoryItem", "HistoryItem"]]
 
@@ -1442,6 +1454,8 @@ class ObjectImportTracker:
         self.hda_copied_from_sinks = {}
         self.hdca_copied_from_sinks = {}
         self.jobs_by_key = {}
+        # Final states recorded in the store for jobs that already exist and are only edited on import.
+        self.job_states_by_id = {}
         self.invocations_by_key: dict[str, model.WorkflowInvocation] = {}
         self.implicit_collection_jobs_by_key: dict[str, ImplicitCollectionJobs] = {}
         self.workflows_by_key: dict[str, model.Workflow] = {}
@@ -1648,9 +1662,7 @@ class BaseDirectoryImportModelStore(ModelImportStore):
             workflow_key = name[0 : -len(".gxwf.yml")]
             yield workflow_key, os.path.join(workflows_directory, name)
 
-    def _set_job_attributes(
-        self, imported_job: model.Job, job_attrs: dict[str, Any], force_terminal: bool = False
-    ) -> None:
+    def _set_job_attributes(self, imported_job: model.Job, job_attrs: dict[str, Any]) -> None:
         ATTRIBUTES = (
             "info",
             "exit_code",
@@ -1671,11 +1683,6 @@ class BaseDirectoryImportModelStore(ModelImportStore):
         if "stdout" in job_attrs:
             imported_job.tool_stdout = job_attrs.get("stdout")
             imported_job.tool_stderr = job_attrs.get("stderr")
-        raw_state = job_attrs.get("state")
-        if force_terminal and raw_state and raw_state not in model.Job.terminal_states:
-            raw_state = model.Job.states.ERROR
-        if raw_state:
-            imported_job.set_state(raw_state)
 
     def _read_list_if_exists(self, file_name: str, required: bool = False) -> list[dict[str, Any]]:
         file_name = os.path.join(self.archive_dir, file_name)

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -115,6 +115,9 @@ class TestDataManagerIntegration(integration_util.IntegrationTestCase, UsesShed)
                     inputs=inputs,
                     history_id=history_id,
                 )
+                job = self.dataset_populator.check_run(run_response)
+                job_state = self.dataset_populator.wait_for_job(job["id"], timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
+                assert job_state == "error"
                 with pytest.raises(AssertionError):
                     self.dataset_populator.wait_for_tool_run(
                         history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -991,6 +991,21 @@ def test_import_job_with_output_copy():
     assert copy.extension == "txt"
 
 
+def test_import_existing_job_reports_state_without_applying_it():
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": True})
+    job = h.active_datasets[-1].creating_job
+    assert job
+    job.state = model.Job.states.RUNNING
+    app.commit()
+    import_model_store = store.get_import_model_store_for_directory(
+        temp_directory, import_options=store.ImportOptions(allow_dataset_object_edit=True, allow_edit=True), app=app
+    )
+    object_import_tracker = import_model_store.perform_import()
+    assert job.state == model.Job.states.RUNNING
+    assert app.model.session.scalar(select(model.Job.state).where(model.Job.id == job.id)) == model.Job.states.RUNNING
+    assert object_import_tracker.job_states_by_id == {job.id: model.Job.states.OK}
+
+
 def test_import_datasets_with_ids_fails_if_not_editing_models():
     app, h, temp_directory, import_history = _setup_simple_export({"for_edit": True})
     u = h.user


### PR DESCRIPTION
Fixes the flaky `test/integration/test_data_manager.py::TestDataManagerIntegration::test_data_manager_hook_can_fail` ("Failed: DID NOT RAISE AssertionError"). The flakiness is a server bug, not test timing.

## Problem

With `metadata_strategy: extended` the job script serializes the job with its final state (`set_metadata.py`) and `JobWrapper.finish` imports that store with `allow_edit=True`. `_import_jobs` applied the serialized state to the *existing* job and `perform_import` committed it, so the job was visible to the API as `ok` before `exec_after_process` had run. If that hook raised (here: `DataManagerTool.exec_after_process` refusing a duplicate `all_fasta` entry), `fail()` flipped the job to `error` afterwards, and anything polling the job in between saw it finish successfully.

The comment in `finish` states the intended invariant ("*don't* set job.state until after dataset discovery"); the non-extended path honours it, the extended path broke it through the store import. Consumers affected: any API poller, the workflow scheduler, `wait_for_job`.

Timeline from CI job 101186811726 (job 4 is the second data manager run):

```
22:32:25,165  execution finished: .../000/4/galaxy_4.sh
              GET /api/jobs/f3f73e481f432006?full=True 200   <- terminal state returned
22:32:25,228  ERROR exec_after_process hook failed for job 4
22:32:25,237  Collecting metrics for Job 4                   <- JobWrapper.fail()
```

## Fix

- `_import_jobs` no longer applies the store's state to an existing job. It records it on the `ObjectImportTracker` (`job_states_by_id`) instead. Newly imported jobs (history import, sessionless metadata import) are still forced to a terminal state as before; the `force_terminal` flag on `_set_job_attributes` went away because state handling now sits next to the new-vs-existing decision.
- `finish` reads the tracker and folds an imported `error` into `final_job_state` exactly as it did before. The persisted job state now only becomes terminal in `set_final_state` at the end of `finish`, like on the non-extended path.
- Unit test: an existing job in `running` is imported from a store carrying `ok`; the job stays `running` (in memory and in the DB) and the tracker reports `ok`. Fails on unpatched code with `assert 'ok' == running`.
- Integration test: polls the second job to a terminal state and asserts it is `error` before the existing `pytest.raises(AssertionError)` check.

## Left as is, deliberately

- HDA states are still committed as `ok` during the import: the job script serializes dataset state itself, so `dataset_state_serialized` is true and HDA state never derived from the job state here. The job stays `running`, so pollers keep waiting, but the history panel can briefly show green datasets for a job that then fails. Deferring HDA state too would need `_finish_dataset` / discovery changes; out of scope for this fix.
- `Job.set_state` still allows `ok -> error`. A guard there would have hidden this bug rather than fixed it.

Same code on release_26.0, release_26.1 and dev.

## How to test the changes?

- [x] Unit test `test_import_existing_job_reports_state_without_applying_it` fails without the fix, passes with it
- [x] `test/integration/test_data_manager.py::TestDataManagerIntegration::test_data_manager_hook_can_fail` passes locally
- [x] `test/integration/test_extended_metadata.py`: 41 passed locally (the deferred BAM test does not run on this machine)
- [x] `tox -e lint,format,mypy`

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
