### PR TITLE
Update RMSX Flipbook to 0.0.4 with multi-chain Analysis and image export

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -113,7 +113,7 @@ rerunio:
     version: 0.0.0
 rmsxflipbook:
     package: "@galaxyproject/rmsxflipbook"
-    version: 0.0.2
+    version: 0.0.4
 seqviz:
     package: "@galaxyproject/seqviz"
     version: 0.0.2

--- a/test/unit/data/datatypes/test_datatypes_registry.py
+++ b/test/unit/data/datatypes/test_datatypes_registry.py
@@ -1,5 +1,6 @@
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import example_datatype_registry_for_sample
+from galaxy.datatypes.text import Json
 
 
 def test_matches_any():
@@ -114,3 +115,14 @@ def test_sniff_compressed_dynamic_datatypes_default_off():
     assert "fastq" not in sniff.guess_ext(fname, sniff_order)
     fname = sniff.get_test_fname("1.fastqsanger.bz2")
     assert "fastq" not in sniff.guess_ext(fname, sniff_order)
+
+
+def test_rmsx_manifest_visualization_registration():
+    registry = example_datatype_registry_for_sample()
+    datatype = registry.get_datatype_by_extension("rmsx.json")
+    assert registry.datatypes_by_extension["rmsx.json"] is datatype
+    assert isinstance(datatype, Json)
+    assert datatype.is_subclass
+    assert registry.mimetypes_by_extension["rmsx.json"] == "application/json"
+    assert "rmsx.json" in registry.upload_file_formats
+    assert registry.get_all_visualization_mappings()["rmsx.json"]["visualization"] == "rmsxflipbook"


### PR DESCRIPTION
Update `@galaxyproject/rmsxflipbook` from 0.0.2 to published 0.0.4. This includes synchronized multi-chain Analysis, centered molecular rotation, downward-facing ubiquitin unfolding, click-away clearing of plot guides, and PNG image export from galaxyproject/galaxy-visualizations#178 and #188. Structures remains the default. Existing `rmsx.json` datasets and legacy `flipbook-molstar-viewer/v1` manifests remain compatible.

Add a registry regression covering the JSON subclass, MIME type, upload availability, and `rmsxflipbook` visualization mapping.

Validation:
- All four datatype-registry tests passed on dev base `7472934ff219200feee11437517ad07971b12393`.
- All five container-backed wrapper tests executed and passed on this candidate; zero skips or failures.
- npm 0.0.4 tarball SHA-512 integrity verified. Published assets passed protease, ubiquitin, and legacy-manifest smoke checks, plus all four plot-clearing/image-export browser tests with zero skips or retries.
- A local Galaxy 26.1 instance using the companion backport ran the real two-chain protease PDB/XTC successfully. Its generated manifest opened through the native Visualize menu and displayed two chain lanes plus one assembly lane, with nine slices per lane. PNG export passed. Galaxy-served JavaScript and CSS matched the published npm package byte-for-byte.

The wrapper remains under review in galaxycomputationalchemistry/galaxy-tools-compchem#187. Its upstream CI approval, Tool Shed publication, clean Tool Shed installation, and Europe/Main deployment remain pending. Local validation does not establish public-server acceptance.
