### PR TITLE
[26.1] Backport RMSX datatype registration and viewer 0.0.4 to Galaxy 26.1

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -105,6 +105,9 @@ plyr:
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0
+rmsxflipbook:
+    package: "@galaxyproject/rmsxflipbook"
+    version: 0.0.4
 tabulator:
     package: "@galaxyproject/tabulator"
     version: 0.0.11

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -1230,6 +1230,9 @@
     <datatype extension="safetensors" type="galaxy.datatypes.binary:Safetensors" mimetype="application/octet-stream" display_in_upload="true" description="A simple format for storing tensors safely (as opposed to pickle) and that is still fast (zero-copy)" description_url="https://huggingface.co/docs/safetensors/index"/>
     <datatype extension="mlmodel" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" display_in_upload="true" description="A Protocol Buffers-based (Protobuf) format developed by Apple for storing machine learning models" description_url="https://apple.github.io/coremltools/mlmodel/index.html"/>
     <datatype extension="deacon.idx" type="galaxy.datatypes.binary:Binary" subclass="true" mimetype="application/octet-stream" display_in_upload="true" description="Binary index format which is compatible with Deacon."/>
+    <datatype extension="rmsx.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true" description="RMSX Molstar viewer manifest containing per-slice structures and residue-level RMSX values.">
+      <visualization plugin="rmsxflipbook" />
+    </datatype>
   </registration>
 
   <sniffers>

--- a/test/unit/data/datatypes/test_datatypes_registry.py
+++ b/test/unit/data/datatypes/test_datatypes_registry.py
@@ -1,5 +1,6 @@
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import example_datatype_registry_for_sample
+from galaxy.datatypes.text import Json
 
 
 def test_matches_any():
@@ -114,3 +115,14 @@ def test_sniff_compressed_dynamic_datatypes_default_off():
     assert "fastq" not in sniff.guess_ext(fname, sniff_order)
     fname = sniff.get_test_fname("1.fastqsanger.bz2")
     assert "fastq" not in sniff.guess_ext(fname, sniff_order)
+
+
+def test_rmsx_manifest_visualization_registration():
+    registry = example_datatype_registry_for_sample()
+    datatype = registry.get_datatype_by_extension("rmsx.json")
+    assert registry.datatypes_by_extension["rmsx.json"] is datatype
+    assert isinstance(datatype, Json)
+    assert datatype.is_subclass
+    assert registry.mimetypes_by_extension["rmsx.json"] == "application/json"
+    assert "rmsx.json" in registry.upload_file_formats
+    assert registry.get_all_visualization_mappings()["rmsx.json"]["visualization"] == "rmsxflipbook"


### PR DESCRIPTION
Make the complete RMSX Flipbook viewer available on Galaxy 26.1 by backporting the `rmsx.json` registration and visualization mapping from #23009, adding the published `@galaxyproject/rmsxflipbook` 0.0.4 pin, and adding a registry regression. The change is limited to three configuration/test files; no dataset migration or manifest changes are required.

Viewer 0.0.4 provides synchronized multi-chain Analysis, centered rotation, downward-facing ubiquitin unfolding, click-away plot-guide clearing, and PNG export. It was merged and published through galaxyproject/galaxy-visualizations#188.

Validation:
- All four registry tests passed on `release_26.1` base `c8cbb2ade4557b7d418fc8b6eaf55756b7371e0e`.
- The published npm tarball integrity was verified, and the local Galaxy instance served its JavaScript and CSS byte-for-byte without viewer asset edits.
- Uploaded the real protease PDB/XTC with explicit datatypes and completed an all-chain analysis job on this candidate. Opened the generated manifest through Visualize → RMSX Flipbook, verified two chain lanes and one combined assembly lane with nine slices each, and downloaded the Analysis PNG.
- The published viewer also passed protease, ubiquitin, legacy-manifest, and plot-clearing/export browser checks. All five wrapper tool tests passed on the companion dev candidate; that five-test suite was not repeated on this backport.

This coordinates with the dev viewer pin and galaxycomputationalchemistry/galaxy-tools-compchem#187. Tool Shed publication and public-server deployment are still pending. If this feature backport is unsuitable for 26.1, each deployment will wait for a compatible server upgrade. A reported server version alone does not establish compatibility.
