### PR TITLE
[25.1] Backport: Replace minio in integration tests with seaweedfs

### DIFF
--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -20,10 +20,10 @@ OBJECT_STORE_CONFIG = string.Template(
     """
 <object_store type="hierarchical" id="primary">
     <backends>
-        <object_store id="swifty" type="generic_s3" weight="1" order="0">
+        <object_store id="swifty" type="boto3" weight="1" order="0">
             <auth access_key="${access_key}" secret_key="${secret_key}" />
-            <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
-            <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>
+            <bucket name="galaxy" />
+            <connection endpoint_url="http://${host}:${port}" region="us-east-1" />
             <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
             <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
@@ -361,6 +361,37 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
+    # Wait for SeaweedFS S3 API to be ready
+    import socket
+    max_attempts = 30
+    for attempt in range(max_attempts):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect(("127.0.0.1", OBJECT_STORE_PORT))
+            sock.close()
+            time.sleep(5)  # Give it more time for S3 API to be fully ready
+            break
+        except (socket.error, ConnectionRefusedError):
+            if attempt == max_attempts - 1:
+                raise TimeoutError(f"SeaweedFS did not start within {max_attempts} seconds")
+            time.sleep(1)
+
+    # Create the galaxy bucket
+    try:
+        import boto3
+        from botocore.client import Config
+        s3 = boto3.client(
+            's3',
+            endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+            aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
+            aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
+            region_name='us-east-1',
+            config=Config(signature_version='s3v4')
+        )
+        s3.create_bucket(Bucket='galaxy')
+    except Exception:
+        pass  # Bucket may already exist
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -8,9 +8,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 OBJECT_STORE_HOST = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_HOST", "127.0.0.1")
-OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 9000))
-OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "minioadmin")
-OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "minioadmin")
+OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 8333))
+OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "admin")
+OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "admin")
 OBJECT_STORE_RUCIO_ACCOUNT = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_ACCOUNT", "root")
 OBJECT_STORE_RUCIO_USERNAME = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_USERNAME", "rucio")
 OBJECT_STORE_RUCIO_RSE_NAME = "TEST"
@@ -162,7 +162,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
     @classmethod
     def setUpClass(cls):
         cls.container_name = f"{cls.__name__}_container"
-        start_minio(cls.container_name)
+        start_seaweedfs(cls.container_name)
         super().setUpClass()
 
     @classmethod
@@ -358,9 +358,9 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
         return True
 
 
-def start_minio(container_name):
-    ports = [(OBJECT_STORE_PORT, 9000)]
-    docker_run("minio/minio:latest", container_name, "server", "/data", ports=ports)
+def start_seaweedfs(container_name):
+    ports = [(OBJECT_STORE_PORT, 8333)]
+    docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -6,6 +6,10 @@ import time
 
 import boto3
 from botocore.client import Config
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+)
 
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -364,29 +368,40 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
+    wait_seaweedfs_ready()
+
+
+def wait_seaweedfs_ready(bucket: str = "galaxy", timeout: float = 60) -> None:
+    """Block until the SeaweedFS S3 gateway accepts requests and ``bucket`` exists.
+
+    The gateway comes up a few seconds after the container does, and the object store
+    initialization in Galaxy does not retry, so wait for the whole master -> volume -> filer -> s3
+    chain to be up by creating the bucket through it.
+    """
     s3 = boto3.client(
         "s3",
-        endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+        endpoint_url=f"http://{OBJECT_STORE_HOST}:{OBJECT_STORE_PORT}",
         aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
         aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
         region_name="us-east-1",
-        config=Config(signature_version="s3v4"),
+        config=Config(signature_version="s3v4", retries={"max_attempts": 1}, connect_timeout=2, read_timeout=5),
     )
-
-    # Retry bucket creation with exponential backoff
-    for attempt in range(5):
+    deadline = time.monotonic() + timeout
+    while True:
         try:
-            s3.head_bucket(Bucket="galaxy")
-            break  # Bucket exists
-        except Exception:
-            try:
-                s3.create_bucket(Bucket="galaxy")
-                break  # Bucket created
-            except Exception as e:
-                if attempt < 4:
-                    time.sleep(2**attempt)  # Exponential backoff: 1, 2, 4, 8 seconds
-                else:
-                    raise TimeoutError(f"Failed to create SeaweedFS bucket after {attempt + 1} attempts: {e}")
+            s3.create_bucket(Bucket=bucket)
+            return
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                return
+            if e.response["ResponseMetadata"]["HTTPStatusCode"] < 500:
+                raise
+            last_error: Exception = e
+        except BotoCoreError as e:
+            last_error = e
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"SeaweedFS S3 gateway not ready after {timeout}s: {last_error}") from last_error
+        time.sleep(0.5)
 
 
 def start_onezone(oz_container_name):


### PR DESCRIPTION
Backport of #21524 to release_25.1.

The `minio/minio` image is no longer available on Docker Hub, so the object store integration tests that spin up an S3 container can no longer start. This switches them to SeaweedFS (`chrislusf/seaweedfs`), moves the `swifty` backend of the hierarchical test object store from `generic_s3` to `boto3`, and waits for the SeaweedFS S3 gateway to accept requests before starting Galaxy.

The commit that adapted the tee streaming and direct download tests is not included because those tests do not exist on this branch.

## Additional commit: wait for the upload hash task in `TestCacheOperation`

The last commit is not part of #21524. It fixes a flaky test that showed up on the first dev Integration run after #21524 merged ([run 34740921761](https://github.com/galaxyproject/galaxy/actions/runs/34740921761/job/103680390371)):

```
test/integration/objectstore/test_remote_objectstore_cache_operations.py::TestCacheOperation::test_cache_repopulated
    assert files_count(self.object_store_cache_path) == 1
E   AssertionError: assert 2 == 1
```

The extra file belonged to the previous test's dataset. Every upload in this class fires an asynchronous `compute_dataset_hash` celery task from `JobWrapper.finish` (`calculate_dataset_hash` defaults to `upload`). That task runs on the worker after the job is already visible as terminal, and it reads the dataset file, so if the test's `tearDown` has emptied the shared cache directory in the meantime it pulls the object back in. The next test then counts a stray file. In the failing run the hash task for the previous test's dataset started about 250 ms after its job finished, well after the cache had been wiped.

The fix uploads through a new `upload_dataset_and_wait_for_hash` helper on the object store test base that also waits for the dataset hashes to appear, so the hash is computed while the file is still cached and nothing is left pending when the cache is wiped. This class was previously never reached on dev because the MinIO container failed to start, so there is no history of it with MinIO, but the race is independent of the S3 backend and the same code is on release_25.1. The same fix goes to dev separately.

Verified by delaying the hash task locally: without the fix four of the five tests in the class fail with the CI assertion, with the fix all pass.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
